### PR TITLE
Add architecture section in the documentation

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -4,6 +4,49 @@ This folder contains documentation that is primarily intended for people working
 This documentation is intended to be living thing!
 It will and should evolve along with the project.
 
+## Architecture
+
+The purpose of Mirage is to virtualize firmware.
+In a standard RISC-V deployment, the firmware runs in M-mode, below the OS:
+
+```
+        ┌──────────────┐
+U-mode  │   User App   │
+        ├──────────────┤
+S-mode  │      OS      │
+        ├──────────────┤
+M-mode  │   Firmware   │
+        └──────────────┘
+```
+
+Because M-mode is all-powerful, it has absolute control over the OS, including reading and modifying its data.
+The traditional purpose of the firmware is the manage the SoC, that is initializing and configuring all devices, manage power, monitor temperature and device health, etc...
+In addition, the firmware is increasingly used for security-critical features, such as enforcing isolation.
+For instance, on Arm the firmware (EL3 on that architecture) is responsible for enforcing the security guarantees of confidential VMs (see Arm CCA extension).
+
+We end-up in a situation where the firmware has two roles: to manage the physical board, and to enforce security policies.
+Unfortunately those two roles are in tension: hardware manufacturers tend to ship opaque firmware blob to manage proprietary hardware, while security require measured and open-source software to allow scrutiny.
+
+The purpose of Mirage is decouple those two functions: on one hand it can support opaque firmware for managing the board, and on the other it can enforce security by isolating the OS.
+The way Mirage achieve this is through firmware virtualization.
+At a high level, a deployment on top of Mirage looks like this:
+
+```
+        ┌──────────────┐ ┌────────────┐
+U-mode  │   User App   │ │  Firmware  │
+        ├──────────────┤ └────────────┘
+S-mode  │      OS      │               
+        ├──────────────┴──────────────┐
+M-mode  │            Mirage           │
+        └─────────────────────────────┘
+```
+
+Mirage itself runs in M-mode in the place where one would usually find the firmware.
+But because the hardware still requires a firmware to function properly, Mirage actually runs the firmware in U-mode and virtualizes all privileged operations, such as interacting with M-mode registers.
+At the same time, Mirage allows running a standard OS like it usually would, in S-mode.
+The OS can call into the firmware, and mirage will take care of forwarding those calls appropriately.
+That way, Mirage manages to keep all the firmware functionalities, but can enforce strong security guarantees, such as ensuring that the firmware can never access the  OS memory.
+
 ## Contributing
 
 The development of Mirage is done through pull requests against the `main` branch.


### PR DESCRIPTION
This commit briefly describes Mirage's architecture, that should help people to get an idea of what is Mirage and how it works.