### PR TITLE
Centralize configuration constants in the config.rs file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,9 @@
-//! Configuration helpers
+//! Configuration constants
+//!
+//! The constants in this files are parsed from the Mirage configuration file (passed through
+//! environment variables by the runner during Mirage build).
+
+// ———————————————————————————————— Helpers ————————————————————————————————— //
 
 /// Helper macro to check is boolean choice is enabled by the configuration, defaulting to yes.
 ///
@@ -16,4 +21,13 @@ macro_rules! is_enabled {
     };
 }
 
-pub(crate) use is_enabled;
+// ———————————————————————— Configuration Parameters ———————————————————————— //
+
+/// Weather the platform supports S mode.
+pub const HAS_S_MODE: bool = is_enabled!("MIRAGE_PLATFORM_S_MODE");
+
+/// The desired log level.
+pub const LOG_LEVEL: Option<&'static str> = option_env!("MIRAGE_LOG_LEVEL");
+
+/// The maximum number of payload exits before quitting.
+pub const MAX_PAYLOAD_EXIT: Option<&'static str> = option_env!("MIRAGE_DEBUG_MAX_PAYLOAD_EXITS");

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,6 +1,6 @@
 //! Debug utils for Mirage
 
-use crate::{_stack_bottom, _stack_top};
+use crate::{_stack_bottom, _stack_top, config};
 
 // ——————————————————————————— Max Payload Exits ———————————————————————————— //
 
@@ -12,7 +12,7 @@ use crate::{_stack_bottom, _stack_top};
 /// https://github.com/rust-lang/rust/pull/99322 gets merged we can convert this function to a
 /// constant.
 pub fn get_max_payload_exits() -> Option<usize> {
-    match option_env!("MIRAGE_DEBUG_MAX_PAYLOAD_EXITS") {
+    match config::MAX_PAYLOAD_EXIT {
         Some(env_var) => usize::from_str_radix(env_var, 10).ok(),
         None => None,
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,10 +1,10 @@
 //! Structured logging implementation
 
-use core::option_env;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use log::{Level, LevelFilter, Metadata, Record};
 
+use crate::config;
 use crate::platform::{Plat, Platform};
 
 // ————————————————————————————————— Logger ————————————————————————————————— //
@@ -37,7 +37,7 @@ impl Logger {
     const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Info;
 
     const fn new_from_env() -> Self {
-        let log_level = match option_env!("MIRAGE_LOG_LEVEL") {
+        let log_level = match config::LOG_LEVEL {
             Some(s) => match s.as_bytes() {
                 b"trace" => LevelFilter::Trace,
                 b"debug" => LevelFilter::Debug,

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -4,8 +4,7 @@ use core::fmt;
 
 // Re-export virt platform by default for now
 use crate::arch::{Arch, Architecture};
-use crate::config::is_enabled;
-use crate::logger;
+use crate::{config, logger};
 
 /// Export the current platform.
 /// For now, only QEMU's Virt board is supported
@@ -26,7 +25,7 @@ pub trait Platform {
     /// Return maximum valid address
     fn get_max_valid_address() -> usize;
 
-    const HAS_S_MODE: bool = is_enabled!("MIRAGE_PLATFORM_S_MODE");
+    const HAS_S_MODE: bool = config::HAS_S_MODE;
 }
 
 pub fn init() {


### PR DESCRIPTION
As I am thinking about adding more constants, I realized that we are parsing the configuration variables all over the place. This commit regroups all configuration parsing in a single file to make it easier for a reader to see all our configuration variables at a glance.