### PR TITLE
Add Zephyr artifact

### DIFF
--- a/misc/artifacts.toml
+++ b/misc/artifacts.toml
@@ -2,3 +2,4 @@
 
 [bin]
 opensbi = "https://github.com/CharlyCst/mirage-artifact-opensbi/releases/download/v0.1.6/opensbi.bin"
+zephyr = "https://github.com/CharlyCst/mirage-artifact-zephyr/releases/download/v0.0.4/zephyr.bin"

--- a/runner/src/artifacts.rs
+++ b/runner/src/artifacts.rs
@@ -59,6 +59,7 @@ struct ArtifactManifest {
 #[serde(deny_unknown_fields)]
 struct Bin {
     opensbi: Option<String>,
+    zephyr: Option<String>,
 }
 
 fn read_artifact_manifest() -> ArtifactManifest {
@@ -101,6 +102,7 @@ pub fn get_external_artifacts() -> HashMap<String, Artifact> {
     let mut map = HashMap::new();
 
     append_artifact("opensbi", &manifest.bin.opensbi, &mut map);
+    append_artifact("zephyr", &manifest.bin.zephyr, &mut map);
     map
 }
 


### PR DESCRIPTION
This commit adds a Zephyr artifact, using the artifact built from a new repository that we operate:
https://github.com/CharlyCst/mirage-artifact-zephyr The build instructions are inspired from #73 and adapter to run on the CI.

For now the artifact is not tested as part of the CI, because we don't have support for running Zephyr yet. It is still useful to have access to the Zephyr artifacts though, as it makes it simple to track progress toward running Zephyr.