### PR TITLE
feat: add riscv64-unknown-linux-gnu-gdb to gdb list

### DIFF
--- a/runner/src/gdb.rs
+++ b/runner/src/gdb.rs
@@ -12,7 +12,11 @@ use crate::GdbArgs;
 // ——————————————————————————————— Constants ———————————————————————————————— //
 
 /// A list of GDB executables that support RISC-V 64
-static GDB_EXECUTABLES: &[&'static str] = &["gdb-multiarch", "riscv64-elf-gdb"];
+static GDB_EXECUTABLES: &[&'static str] = &[
+    "gdb-multiarch",
+    "riscv64-elf-gdb",
+    "riscv64-unknown-linux-gnu-gdb",
+];
 
 // —————————————————————————————————— GDB ——————————————————————————————————— //
 


### PR DESCRIPTION
Add `riscv64-unknown-linux-gnu-gdb` as a valid option to gdb list. 