### PR TITLE
Change firmware address for fixing Linux alignment with opensbi

### DIFF
--- a/misc/linker-script-firmware.x
+++ b/misc/linker-script-firmware.x
@@ -3,7 +3,7 @@ STACK_SIZE = 0x8000;
 SECTIONS
 {
   /* Start address */
-  . = 0x80100000;
+  . = 0x80200000;
 
   /* Output a text section, starting with the entry point */
   .text : ALIGN(0x4) {

--- a/misc/setup.gdb
+++ b/misc/setup.gdb
@@ -8,7 +8,7 @@ set print asm-demangle
 # Define an helper function to load firmware symbols.
 # The symbols are not loaded by default to prevent collisions with Mirage's own symbols
 define firmware
-    add-symbol-file target/riscv-unknown-firmware/debug/default 0x80100000
+    add-symbol-file target/riscv-unknown-firmware/debug/default 0x80200000
 end
 
 # Helper function to print the next instructions

--- a/runner/src/run.rs
+++ b/runner/src/run.rs
@@ -23,7 +23,7 @@ const QEMU_ARGS: &[&str] = &[
 ];
 
 /// Address at which the firmware is loaded in memory.
-const FIRMWARE_ADDR: u64 = 0x80100000;
+const FIRMWARE_ADDR: u64 = 0x80200000;
 
 // —————————————————————————————————— Run ——————————————————————————————————— //
 

--- a/src/platform/virt.rs
+++ b/src/platform/virt.rs
@@ -13,7 +13,7 @@ use super::Platform;
 const SERIAL_PORT_BASE_ADDRESS: usize = 0x10000000;
 const TEST_MMIO_ADDRESS: usize = 0x100000;
 const MIRAGE_START_ADDR: usize = 0x80000000;
-const FIRMWARE_START_ADDR: usize = 0x80100000;
+const FIRMWARE_START_ADDR: usize = 0x80200000;
 
 static SERIAL_PORT: Mutex<Option<MmioSerialPort>> = Mutex::new(None);
 


### PR DESCRIPTION
Linux need to have 21 bits alignment. Currently, opensbi loaded Linux as a payload with the proper alignment, but loading opensbi at 0x80100000 misaligned the kernel, resulting in an error when booting. A solution is to load the firmware while preserving the alignment of the kernel at 0x80200000 instead.