### PR TITLE
registers senvcfg and menvcfg store and restore

### DIFF
--- a/firmware/csr_ops/src/perf_counters.rs
+++ b/firmware/csr_ops/src/perf_counters.rs
@@ -49,14 +49,14 @@ fn test_simple_regs() {
     // Test mcounteren
     unsafe {
         asm!(
-            "li {0}, 0x42",
+            "li {0}, 0xffff",
             "csrw mcounteren, {0}",
             "csrr {1}, mcounteren",
             out(reg) _,
             out(reg) res,
         );
     }
-    assert_eq!(res, 0);
+    assert_eq!(res, 0b111);
 }
 
 fn test_some_counters_events() {

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -287,11 +287,24 @@ impl Architecture for MetalArch {
             options(nomem)
         );
 
-        // TODO: add support for senvcfg
-        if false {
+        asm!(
+            "csrw mcounteren, {mcounteren}",
+            mcounteren = in(reg) ctx.csr.mcounteren,
+            options(nomem)
+        );
+
+        if mctx.hw.available_reg.senvcfg {
             asm!(
                 "csrw senvcfg, {senvcfg}",
                 senvcfg = in(reg) ctx.csr.senvcfg,
+                options(nomem)
+            );
+        }
+
+        if mctx.hw.available_reg.menvcfg {
+            asm!(
+                "csrw menvcfg, {menvcfg}",
+                menvcfg = in(reg) ctx.csr.menvcfg,
                 options(nomem)
             );
         }
@@ -341,6 +354,8 @@ impl Architecture for MetalArch {
         let scause: usize;
         let stval: usize;
         let satp: usize;
+        let menvcfg: usize;
+        let mcounteren: usize;
 
         asm!(
             "csrrw {stvec}, stvec, x0",
@@ -375,8 +390,7 @@ impl Architecture for MetalArch {
         );
         ctx.csr.stval = stval;
 
-        // TODO: add support for senvcfg
-        if false {
+        if mctx.hw.available_reg.senvcfg {
             asm!(
                 "csrrw {senvcfg}, senvcfg, x0",
                 senvcfg = out(reg) senvcfg,
@@ -384,6 +398,22 @@ impl Architecture for MetalArch {
             );
             ctx.csr.senvcfg = senvcfg;
         }
+
+        if mctx.hw.available_reg.menvcfg {
+            asm!(
+                "csrrw {menvcfg}, menvcfg, x0",
+                menvcfg = out(reg) menvcfg,
+                options(nomem)
+            );
+            ctx.csr.menvcfg = menvcfg;
+        }
+
+        asm!(
+            "csrrw {mcounteren}, mcounteren, x0",
+            mcounteren = out(reg) mcounteren,
+            options(nomem)
+        );
+        ctx.csr.mcounteren = mcounteren;
 
         // Now save M-mode registers which are (partially) exposed as S-mode registers.
         // For mstatus we read the current value and clear the two MPP bits to jump into U-mode

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -706,12 +706,12 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
                 }
                 self.csr.pmpaddr[pmp_addr_idx] = Csr::PMP_ADDR_LEGAL_MASK & value;
             }
-            Csr::Mcycle => (),                    // Read-only 0
-            Csr::Minstret => (),                  // Read-only 0
-            Csr::Mhpmcounter(_counter_idx) => (), // Read-only 0
-            Csr::Mcountinhibit => (),             // Read-only 0
-            Csr::Mhpmevent(_event_idx) => (),     // Read-only 0
-            Csr::Mcounteren => (),                // Read-only 0
+            Csr::Mcycle => (),                                      // Read-only 0
+            Csr::Minstret => (),                                    // Read-only 0
+            Csr::Mhpmcounter(_counter_idx) => (),                   // Read-only 0
+            Csr::Mcountinhibit => (),                               // Read-only 0
+            Csr::Mhpmevent(_event_idx) => (),                       // Read-only 0
+            Csr::Mcounteren => self.csr.mcounteren = value & 0b111, // Only show IR, TM and CY (for cycle, time and instret counters)
             Csr::Menvcgf => self.csr.menvcfg = value,
             Csr::Mseccfg => self.csr.mseccfg = value,
             Csr::Mconfigptr => (), // Read-only


### PR DESCRIPTION
When swithcing from payload to firware (and opposite) the registers senvcfg and menvcfg need to be stored and restored by mirage if they are availables.

This PR also allow opensbi to set the last three bits of mcounteren in order to give the kernel the rights to read associated counter to IR, TM and CY fields.

This is related to #78.