### PR TITLE
Bump artifacts version in response to start address change

### DIFF
--- a/misc/artifacts.toml
+++ b/misc/artifacts.toml
@@ -1,5 +1,5 @@
 # Artifact manifest
 
 [bin]
-opensbi = "https://github.com/CharlyCst/mirage-artifact-opensbi/releases/download/v0.1.6/opensbi.bin"
-zephyr = "https://github.com/CharlyCst/mirage-artifact-zephyr/releases/download/v0.0.4/zephyr.bin"
+opensbi = "https://github.com/CharlyCst/mirage-artifact-opensbi/releases/download/v0.1.7/opensbi.bin"
+zephyr = "https://github.com/CharlyCst/mirage-artifact-zephyr/releases/download/v0.0.6/zephyr.bin"


### PR DESCRIPTION
In #91 we changed the start address of the firmware to accommodate alignment requirements. This PR bumps the version number of the OpenSBI and Zephyr artifact to use newer version with the updated start address.