### PR TITLE
Improve git sanity checks in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,18 @@ jobs:
           false
         fi
 
-        # We run tests for all commits in the PR
+        # List the biggest git objects
+        echo "Biggest git objects:"
+        git ls-tree --format="%(objectsize:padded)  %(path)" -r HEAD | sort --key 1 --reverse | head -n 5
+
+        # And here we check that no object is too big
+        biggest="$(git ls-tree --format="%(objectsize:padded)" -r HEAD | sort --reverse | head -n 1)"
+        if [ $biggest -gt "200000" ]; then
+          echo "It seems a big object was committed. Please remove any executable or binary blob."
+          echo "Object size: $biggest bytes"
+        fi
+
+        # Finally we run the tests for all commits in the PR
         revisions=$(git rev-list origin/main..HEAD)
         for commit in $revisions; do
           echo ""


### PR DESCRIPTION
This PR adds two new git checks to the CI:
- First that no merge commits are present in a PR, as it turns out the "enforce linear history" option of github only prevent from merging with a merge commit.
- And second that no big object (usually executable or binary blobs) have been committed. For now the limit is 200Kb, which should be big enough for all test objects and should catch most other things.