### PR TITLE
Bugfix: set MPP to 0 after MRET

### DIFF
--- a/firmware/mret/src/main.rs
+++ b/firmware/mret/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> ! {
     let mpie = (mstatus >> 7) & 0b1;
     let mprv = (mstatus >> 17) & 0b1;
 
-    assert_eq!(mpp, 3, "Invalid MPP: {}, expected 3", mpp);
+    assert_eq!(mpp, 0, "Invalid MPP: {}, expected 0", mpp);
     assert_eq!(mpie, 1, "Invalid MPIE: {}, expected 1", mpie);
     assert_eq!(mprv, 0, "Invalid MPRV: {}, expected 0", mprv);
     assert_eq!(

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -294,6 +294,12 @@ impl VirtContext {
                     mstatus::MIE_FILTER,
                     mpie,
                 );
+                VirtCsr::set_csr_field(
+                    &mut self.csr.mstatus,
+                    mstatus::MPP_OFFSET,
+                    mstatus::MPP_FILTER,
+                    0,
+                );
 
                 // Jump back to firmware
                 self.pc = self.csr.mepc;


### PR DESCRIPTION
The spec mandates that MPP is reset to the lowest available privilege mode when executing MRET. For systems without U-mode this corresponds to M-mode, otherwise U-mode is always the least privileged mode (and we assume M-mode with Mirage).
The previous implementation was not resetting MPP appropriately, this patch implements the correct behaviour.

This bug was found using formal methods to compare the Mirage instruction emulator with the Sail RISC-V model (i.e. the executable specification).