### PR TITLE
Add support for visionfive2 platform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ miralis_core = { path = "crates/core" }
 # When running on host architecture as a userspace application, such as when
 # running unit tests.
 userspace = []
+platform_visionfive2 = []
 
 [profile.dev]
 panic = "abort"

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@
 
 // ———————————————————————————————— Helpers ————————————————————————————————— //
 
+use crate::platform::{Plat, Platform};
+
 /// Helper macro to check is boolean choice is enabled by the configuration, defaulting to yes.
 ///
 /// The current implementation works around the limitation of const functions in rust at the
@@ -197,7 +199,14 @@ pub const LOG_TRACE: &[&str; str_list_len(option_env!("MIRALIS_LOG_TRACE"))] =
     &parse_str_list(option_env!("MIRALIS_LOG_TRACE"));
 
 /// The expected number of harts.
-pub const PLATFORM_NB_HARTS: usize = parse_usize_or(option_env!("MIRALIS_PLATFORM_NB_HARTS"), 1);
+pub const PLATFORM_NB_HARTS: usize = {
+    const MAX_NB_HARTS: usize = parse_usize_or(option_env!("MIRALIS_PLATFORM_NB_HARTS"), 1);
+    if MAX_NB_HARTS < Plat::NB_HARTS {
+        MAX_NB_HARTS
+    } else {
+        Plat::NB_HARTS
+    }
+};
 
 /// The stack size for each Miralis thread (one per hart).
 pub const PLATFORM_STACK_SIZE: usize =

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ pub(crate) extern "C" fn main(hart_id: usize, device_tree_blob_addr: usize) -> !
 
     init();
     log::info!("Hello, world!");
+    log::info!("Platform name: {}", Plat::name());
     log::info!("Hart ID: {}", hart_id);
     log::info!("misa:    0x{:x}", Arch::read_misa());
     log::info!("vmisa:   0x{:x}", Arch::read_misa() & !misa::DISABLED);

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,4 +1,5 @@
 pub mod virt;
+pub mod visionfive2;
 
 use core::fmt;
 
@@ -11,9 +12,14 @@ use crate::{config, device, logger};
 
 /// Export the current platform.
 /// For now, only QEMU's Virt board is supported
+#[cfg(not(feature = "platform_visionfive2"))]
 pub type Plat = virt::VirtPlatform;
 
+#[cfg(feature = "platform_visionfive2")]
+pub type Plat = visionfive2::VisionFive2Platform;
+
 pub trait Platform {
+    fn name() -> &'static str;
     fn init();
     fn debug_print(args: fmt::Arguments);
     fn exit_success() -> !;
@@ -34,6 +40,7 @@ pub trait Platform {
     fn get_max_valid_address() -> usize;
 
     const HAS_S_MODE: bool = config::VCPU_S_MODE;
+    const NB_HARTS: usize;
 }
 
 pub fn init() {


### PR DESCRIPTION
Add platform implementation for VisionFive2 board and a way to select the platform in the Cargo.toml file.

Closes #104 