### PR TITLE
Add timer interrupt integration test

### DIFF
--- a/firmware/interrupt/src/main.rs
+++ b/firmware/interrupt/src/main.rs
@@ -1,9 +1,9 @@
 #![no_std]
 #![no_main]
 
-use core::arch::asm;
+use core::arch::{asm, global_asm};
 
-use miralis_abi::{setup_firmware, success};
+use miralis_abi::{failure, setup_firmware, success};
 
 setup_firmware!(main);
 
@@ -14,8 +14,8 @@ fn main() -> ! {
     test_sie();
     log::debug!("Testing sie by mie register");
     test_sie_by_mie();
-    log::debug!("Done!");
-    success();
+    log::debug!("Testing CLINT");
+    test_timer_interrupts();
 }
 
 // —————————————————————————————— mie and sie ——————————————————————————————— //
@@ -76,4 +76,104 @@ fn test_sie_by_mie() {
     }
 
     assert_eq!(res, masked_value);
+}
+
+// ———————————————————————————— Timer Interrupt ————————————————————————————— //
+
+const CLINT_BASE: usize = 0x2000000;
+const MTIME_OFFSET: usize = 0xBFF8;
+const MTIMECMP_OFFSET: usize = 0x4000;
+
+// Get the current mtime value
+fn get_current_mtime() -> usize {
+    let mtime_ptr = (CLINT_BASE + MTIME_OFFSET) as *const usize;
+    unsafe { mtime_ptr.read_volatile() }
+}
+
+// Set mtimecmp value in the future
+fn set_mtimecmp_future_value() {
+    let current_mtime = get_current_mtime();
+    let future_time = current_mtime + 10000;
+
+    let mtimecmp_ptr = (CLINT_BASE + MTIMECMP_OFFSET) as *mut usize; // TODO: add support for different harts
+    unsafe {
+        mtimecmp_ptr.write_volatile(future_time);
+    }
+
+    // Read back the value to verify
+    let read_back = unsafe { mtimecmp_ptr.read_volatile() };
+    assert_eq!(read_back, future_time, "mtimecmp set correctly");
+}
+
+#[allow(unreachable_code)]
+fn test_timer_interrupts() -> ! {
+    // Configure trap handler and enable interrupts
+    unsafe {
+        asm!(
+            "csrw mtvec, {handler}",       // Setup trap handler
+            "csrs mstatus, {mstatus_mie}", // Enable interrupts (MIE)
+            "csrs mie, {mtie}",            // Enable machine timer interrupt (MTIE)
+            handler = in(reg) _raw_interrupt_trap_handler as usize,
+            mstatus_mie = in(reg) 0x8,
+            mtie = in(reg) 0x80,
+        );
+    }
+
+    // Setup a timer deadline
+    set_mtimecmp_future_value();
+
+    // Wait for an interrupt
+    loop {
+        unsafe { asm!("wfi") };
+    }
+
+    // The trap handler should exit, if we reach that point the handler did not do its job
+    failure();
+}
+
+/// This function should be called from the raw trap handler
+extern "C" fn trap_handler() {
+    // Check the interrupt cause
+    let expected_mcause: usize = 0x8000000000000007;
+    let mut mcause: usize;
+    unsafe {
+        asm!(
+            "csrr {0}, mcause",
+            out(reg) mcause,
+        );
+    }
+    assert_eq!(
+        mcause, expected_mcause,
+        "Expected to receive a timer interrupt, got something else"
+    );
+
+    // TODO: we do not have MIP emulation yet, enable this test once we support it
+    // let mip: usize;
+    // unsafe {
+    //     asm!(
+    //         "csrr {0}, mip",
+    //         out(reg) mip,
+    //     );
+    // }
+    // assert!(mip & 0x80 != 0, "MTIP flag set");
+
+    log::debug!("Done!");
+    success();
+}
+
+// —————————————————————————————— Trap Handler —————————————————————————————— //
+
+global_asm!(
+    r#"
+.text
+.align 4
+.global _raw_interrupt_trap_handler
+_raw_interrupt_trap_handler:
+    j {trap_handler} // Jump immediately into the Rust trap handler
+"#,
+    trap_handler = sym trap_handler,
+);
+
+extern "C" {
+    fn _raw_interrupt_trap_handler();
 }

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -329,32 +329,28 @@ impl VirtContext {
                     }
                 }
             }
+            Instr::Sd { rs1, rs2, imm } => {
+                let address = utils::calculate_addr(self.get(rs1), *imm);
+                let offset = address - device.start_addr;
+                match device.device_interface.write_device(offset, self.get(rs2)) {
+                    Ok(()) => self.pc += 4,
+                    Err(err) => panic!("Error writing {}: {}", device.name, err),
+                }
+            }
             Instr::CSd { rs1, rs2, imm } => {
                 let address = self.get(rs1) + imm * 8;
                 let offset = address - device.start_addr;
-                let data = self.get(rs2);
-                match device.device_interface.write_device(offset, data) {
-                    Ok(()) => {
-                        self.set(rs1, data);
-                        self.pc += 2;
-                    }
-                    Err(err) => {
-                        panic!("Error writing {}: {}", device.name, err);
-                    }
+                match device.device_interface.write_device(offset, self.get(rs2)) {
+                    Ok(()) => self.pc += 2,
+                    Err(err) => panic!("Error writing {}: {}", device.name, err),
                 }
             }
             Instr::CSw { rs1, rs2, imm } => {
                 let address = self.get(rs1) + imm * 4;
                 let offset = address - device.start_addr;
-                let data = self.get(rs2);
-                match device.device_interface.write_device(offset, data) {
-                    Ok(()) => {
-                        self.set(rs1, data);
-                        self.pc += 2;
-                    }
-                    Err(err) => {
-                        panic!("Error writing {}: {}", device.name, err);
-                    }
+                match device.device_interface.write_device(offset, self.get(rs2)) {
+                    Ok(()) => self.pc += 2,
+                    Err(err) => panic!("Error writing {}: {}", device.name, err),
                 }
             }
             _ => todo!("Instruction not yet implemented: {:?}", instr),


### PR DESCRIPTION
This patch extend the interrupt integration test to cover timer interrupts. The test simply read the current time, configure a timer with a deadline, enable interrupts and wait until the interrupt happens. With this test we now exercise the virtual CLINT device and interrupt logic of Miralis.