### PR TITLE
First implementation of userspace arch

### DIFF
--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -369,6 +369,7 @@ impl Architecture for MetalArch {
             out("x30") _,
         );
     }
+
     unsafe fn sfence_vma() {
         asm!("sfence.vma")
     }

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -3,9 +3,17 @@
 //! This implementation is useful for running Miralis on the host (potentially non-riscv)
 //! architecutre, such as when running unit tests.
 
-use super::Architecture;
+use core::marker::PhantomData;
+use core::{ptr, usize};
+
+use spin::Mutex;
+
+use super::{mie, mstatus, Architecture, Csr, MCause, Mode};
 use crate::arch::{HardwareCapability, PmpGroup};
 use crate::main;
+use crate::virt::VirtContext;
+
+static HOST_CTX: Mutex<VirtContext> = Mutex::new(VirtContext::new(0, 16));
 
 /// User space mock, running on the host architecture.
 pub struct HostArch {}
@@ -19,39 +27,187 @@ impl Architecture for HostArch {
     }
 
     fn wfi() {
-        todo!()
+        log::debug!("Userspace wfi");
     }
 
-    unsafe fn set_mpp(mode: super::Mode) {
-        let _ = mode.to_bits();
-        todo!()
+    unsafe fn set_mpp(mode: Mode) {
+        let value = mode.to_bits() << mstatus::MPP_OFFSET;
+        let mstatus = Self::read_csr(Csr::Mstatus);
+        Self::write_csr(Csr::Mstatus, (mstatus & !mstatus::MPP_FILTER) | value);
     }
 
-    unsafe fn write_pmp(_pmp: &PmpGroup) {
-        todo!()
+    unsafe fn write_pmp(pmp: &PmpGroup) {
+        let pmpaddr = pmp.pmpaddr();
+        let pmpcfg = pmp.pmpcfg();
+        let nb_pmp = pmp.nb_pmp as usize;
+
+        assert!(
+            nb_pmp as usize <= pmpaddr.len() && nb_pmp as usize <= pmpcfg.len() * 8,
+            "Invalid number of PMP registers"
+        );
+
+        for idx in 0..nb_pmp {
+            HOST_CTX.lock().csr.pmpaddr[idx] = pmpaddr[idx];
+        }
+        for idx in 0..(nb_pmp / 8) {
+            let cfg = pmpcfg[idx];
+            HOST_CTX.lock().csr.pmpcfg[idx * 2] = cfg;
+        }
     }
 
     unsafe fn run_vcpu(_ctx: &mut crate::virt::VirtContext) {
         todo!()
     }
 
-    unsafe fn get_raw_faulting_instr(_trap_info: &super::TrapInfo) -> usize {
-        todo!()
+    unsafe fn get_raw_faulting_instr(trap_info: &super::TrapInfo) -> usize {
+        if trap_info.mcause == MCause::IllegalInstr as usize {
+            // First, try mtval and check if it contains an instruction
+            if trap_info.mtval != 0 {
+                return trap_info.mtval;
+            }
+        }
+
+        let instr_ptr = trap_info.mepc as *const u32;
+
+        // With compressed instruction extention ("C") instructions can be misaligned.
+        // TODO: add support for 16 bits instructions
+        let instr = ptr::read_unaligned(instr_ptr);
+        instr as usize
     }
 
     unsafe fn sfence_vma() {
-        todo!()
+        log::debug!("Userspace sfence.vma");
     }
 
     unsafe fn detect_hardware() -> HardwareCapability {
-        todo!()
+        HardwareCapability {
+            interrupts: usize::MAX,
+            hart: 0,
+            _marker: PhantomData,
+            available_reg: super::RegistersCapability {
+                menvcfg: true,
+                senvcfg: true,
+                nb_pmp: 16,
+            },
+        }
     }
 
-    fn read_csr(_csr: super::Csr) -> usize {
-        todo!()
+    fn read_csr(csr: Csr) -> usize {
+        let ctx = HOST_CTX.lock();
+        match csr {
+            Csr::Mhartid => ctx.csr.marchid,
+            Csr::Mstatus => ctx.csr.mstatus,
+            Csr::Misa => ctx.csr.misa,
+            Csr::Mie => ctx.csr.mie,
+            Csr::Mtvec => ctx.csr.mtvec,
+            Csr::Mscratch => ctx.csr.mscratch,
+            Csr::Mip => ctx.csr.mip,
+            Csr::Mvendorid => ctx.csr.mvendorid,
+            Csr::Marchid => ctx.csr.marchid,
+            Csr::Mimpid => ctx.csr.mimpid,
+            Csr::Pmpcfg(index) => ctx.csr.pmpcfg[index],
+            Csr::Pmpaddr(index) => ctx.csr.pmpaddr[index],
+            Csr::Mcycle => ctx.csr.mcycle,
+            Csr::Minstret => ctx.csr.minstret,
+            Csr::Mhpmcounter(index) => ctx.csr.mhpmcounter[index],
+            Csr::Mcountinhibit => ctx.csr.mcountinhibit,
+            Csr::Mhpmevent(index) => ctx.csr.mhpmevent[index],
+            Csr::Mcounteren => ctx.csr.mcounteren,
+            Csr::Menvcfg => ctx.csr.menvcfg,
+            Csr::Mseccfg => ctx.csr.mseccfg,
+            Csr::Mconfigptr => ctx.csr.mconfigptr,
+            Csr::Medeleg => ctx.csr.medeleg,
+            Csr::Mideleg => ctx.csr.mideleg,
+            Csr::Mtinst => ctx.csr.mtinst,
+            Csr::Mtval2 => todo!(),
+            Csr::Tselect => todo!(),
+            Csr::Tdata1 => todo!(),
+            Csr::Tdata2 => todo!(),
+            Csr::Tdata3 => todo!(),
+            Csr::Mcontext => todo!(),
+            Csr::Dcsr => todo!(),
+            Csr::Dpc => todo!(),
+            Csr::Dscratch0 => todo!(),
+            Csr::Dscratch1 => todo!(),
+            Csr::Mepc => ctx.csr.mepc,
+            Csr::Mcause => ctx.csr.mcause,
+            Csr::Mtval => ctx.csr.mtval,
+            Csr::Sstatus => ctx.csr.mstatus & mstatus::SSTATUS_FILTER,
+            Csr::Sie => ctx.csr.mie & mie::SIE_FILTER,
+            Csr::Stvec => ctx.csr.stvec,
+            Csr::Scounteren => ctx.csr.scounteren,
+            Csr::Senvcfg => ctx.csr.senvcfg,
+            Csr::Sscratch => ctx.csr.sscratch,
+            Csr::Sepc => ctx.csr.sepc,
+            Csr::Scause => ctx.csr.scause,
+            Csr::Stval => ctx.csr.stval,
+            Csr::Sip => ctx.csr.mip & mie::SIE_FILTER,
+            Csr::Satp => ctx.csr.satp,
+            Csr::Scontext => ctx.csr.scontext,
+            Csr::Unknown => panic!("Unkown csr!"),
+        }
     }
 
-    unsafe fn write_csr(_csr: super::Csr, _value: usize) -> usize {
-        todo!()
+    unsafe fn write_csr(csr: Csr, value: usize) -> usize {
+        let prev_val = Self::read_csr(csr);
+        let mut ctx = HOST_CTX.lock();
+
+        log::debug!("Write {:?} with value 0x{:x}", csr, value);
+        match csr {
+            Csr::Mhartid => ctx.csr.marchid = value,
+            Csr::Mstatus => ctx.csr.mstatus = value,
+            Csr::Misa => ctx.csr.misa = value,
+            Csr::Mie => ctx.csr.mie = value,
+            Csr::Mtvec => ctx.csr.mtvec = value,
+            Csr::Mscratch => ctx.csr.mscratch = value,
+            Csr::Mip => ctx.csr.mip = value, // TODO : add write filter
+            Csr::Mvendorid => ctx.csr.mvendorid = value,
+            Csr::Marchid => ctx.csr.marchid = value,
+            Csr::Mimpid => ctx.csr.mimpid = value,
+            Csr::Pmpcfg(index) => ctx.csr.pmpcfg[index] = value,
+            Csr::Pmpaddr(index) => ctx.csr.pmpaddr[index] = value,
+            Csr::Mcycle => ctx.csr.mcycle = value,
+            Csr::Minstret => ctx.csr.minstret = value,
+            Csr::Mhpmcounter(index) => ctx.csr.mhpmcounter[index] = value,
+            Csr::Mcountinhibit => ctx.csr.mcountinhibit = value,
+            Csr::Mhpmevent(index) => ctx.csr.mhpmevent[index] = value,
+            Csr::Mcounteren => ctx.csr.mcounteren = value,
+            Csr::Menvcfg => ctx.csr.menvcfg = value,
+            Csr::Mseccfg => ctx.csr.mseccfg = value,
+            Csr::Mconfigptr => ctx.csr.mconfigptr = value,
+            Csr::Medeleg => ctx.csr.medeleg = value,
+            Csr::Mideleg => ctx.csr.mideleg = value,
+            Csr::Mtinst => ctx.csr.mtinst = value,
+            Csr::Mtval2 => todo!(),
+            Csr::Tselect => todo!(),
+            Csr::Tdata1 => todo!(),
+            Csr::Tdata2 => todo!(),
+            Csr::Tdata3 => todo!(),
+            Csr::Mcontext => todo!(),
+            Csr::Dcsr => todo!(),
+            Csr::Dpc => todo!(),
+            Csr::Dscratch0 => todo!(),
+            Csr::Dscratch1 => todo!(),
+            Csr::Mepc => ctx.csr.mepc = value,
+            Csr::Mcause => ctx.csr.mcause = value,
+            Csr::Mtval => ctx.csr.mtval = value,
+            Csr::Sstatus => {
+                ctx.csr.mstatus =
+                    (ctx.csr.mstatus & !mstatus::SSTATUS_FILTER) | (value & mstatus::SSTATUS_FILTER)
+            }
+            Csr::Sie => ctx.csr.mie = (ctx.csr.mie & !mie::SIE_FILTER) & (value & mie::SIE_FILTER),
+            Csr::Stvec => ctx.csr.stvec = value,
+            Csr::Scounteren => ctx.csr.scounteren = value,
+            Csr::Senvcfg => ctx.csr.senvcfg = value,
+            Csr::Sscratch => ctx.csr.sscratch = value,
+            Csr::Sepc => ctx.csr.sepc = value,
+            Csr::Scause => ctx.csr.scause = value,
+            Csr::Stval => ctx.csr.stval = value,
+            Csr::Sip => ctx.csr.mip = ctx.csr.mip & !mie::SIE_FILTER | value & mie::SIE_FILTER,
+            Csr::Satp => ctx.csr.satp = value,
+            Csr::Scontext => ctx.csr.scontext = value,
+            Csr::Unknown => panic!("Unkown csr!"),
+        }
+        prev_val
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,14 @@ use crate::virt::traits::*;
 use crate::virt::{ExecutionMode, VirtContext};
 
 // Defined in the linker script
+#[cfg(not(feature = "userspace"))]
 extern "C" {
     pub(crate) static _stack_start: u8;
 }
+
+#[cfg(feature = "userspace")]
+#[allow(non_upper_case_globals)]
+pub(crate) static _stack_start: u8 = 0;
 
 pub(crate) extern "C" fn main(hart_id: usize, device_tree_blob_addr: usize) -> ! {
     // For now we simply park all the harts other than the boot one
@@ -280,4 +285,67 @@ fn log_ctx(ctx: &VirtContext) {
         ctx.get(Csr::Mie),
         ctx.get(Csr::Mip)
     );
+}
+
+// ————————————————————————————————— Tests —————————————————————————————————— //
+
+/// We test some properties after handling a trap from firmware.
+/// We simulate a trap by creating a dummy trap state for the context of the machine.
+///
+/// Mideleg must be 0: don't allow nested interrupts when running Miralis.
+/// ctx.pc must be set to the handler start address.
+/// Mie, vMie, vMideleg must not change.
+/// vMepc and vMstatus.MIE must be set to corresponding values in ctx.trap_info.
+/// vMip must be updated to the value of Mip.
+/// In case of an interrupt, Mip must be cleared: avoid Miralis to trap again.
+#[cfg(test)]
+mod tests {
+
+    use crate::arch::{mstatus, Arch, Architecture, Csr, MCause, Mode};
+    use crate::handle_trap;
+    use crate::host::MiralisContext;
+    use crate::virt::VirtContext;
+
+    #[test]
+    fn handle_trap_state() {
+        let hw = unsafe { Arch::detect_hardware() };
+        let mut mctx = MiralisContext::new(hw);
+        let mut ctx = VirtContext::new(0, mctx.hw.available_reg.nb_pmp);
+
+        // Firmware is running
+        ctx.mode = Mode::M;
+
+        ctx.csr.mstatus = 0;
+        ctx.csr.mie = 0b1;
+        ctx.csr.mideleg = 0;
+        ctx.csr.mtvec = 0x80200024; // Dummy mtvec
+
+        // Simulating a trap
+        ctx.trap_info.mepc = 0x80200042; // Dummy address
+        ctx.trap_info.mstatus = 0b1000;
+        ctx.trap_info.mcause = MCause::Breakpoint as usize; // TODO : use a real int.
+        ctx.trap_info.mip = 0b1;
+        ctx.trap_info.mtval = 0;
+
+        unsafe {
+            Arch::write_csr(Csr::Mie, 0b1);
+            Arch::write_csr(Csr::Mip, 0b1);
+            Arch::write_csr(Csr::Mideleg, 0);
+        };
+        handle_trap(&mut ctx, &mut mctx);
+
+        assert_eq!(Arch::read_csr(Csr::Mideleg), 0, "mideleg must be 0");
+        assert_eq!(Arch::read_csr(Csr::Mie), 0b1, "mie must be 1");
+        // assert_eq!(Arch::read_csr(Csr::Mip), 0, "mip must be 0"); // TODO : uncomment if using a real int.
+        assert_eq!(ctx.pc, 0x80200024, "pc must be at handler start");
+        assert_eq!(ctx.csr.mip, 0b1, "mip must to be updated");
+        assert_eq!(ctx.csr.mie, 1, "mie must not change");
+        assert_eq!(ctx.csr.mideleg, 0, "mideleg must not change");
+        assert_eq!(ctx.csr.mepc, 0x80200042);
+        assert_eq!(
+            (ctx.csr.mstatus & mstatus::MIE_FILTER) >> mstatus::MIE_OFFSET,
+            0b1,
+            "mstatus.MIE must be set to trap_info.mstatus.MIE"
+        );
+    }
 }

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -48,16 +48,58 @@ pub struct VirtContext {
 }
 
 impl VirtContext {
-    pub fn new(hart_id: usize, nb_pmp: usize) -> Self {
+    pub const fn new(hart_id: usize, nb_pmp: usize) -> Self {
         assert!(nb_pmp <= 64, "Too many PMP registers");
 
         VirtContext {
             host_stack: 0,
-            regs: Default::default(),
-            csr: Default::default(),
+            regs: [0; 32],
+            csr: VirtCsr {
+                misa: 0,
+                mie: 0,
+                mip: 0,
+                mtvec: 0,
+                mscratch: 0,
+                mvendorid: 0,
+                marchid: 0,
+                mimpid: 0,
+                mcycle: 0,
+                minstret: 0,
+                mcountinhibit: 0,
+                mcounteren: 0,
+                menvcfg: 0,
+                mseccfg: 0,
+                mcause: 0,
+                mepc: 0,
+                mtval: 0,
+                mstatus: 0,
+                mtinst: 0,
+                mconfigptr: 0,
+                stvec: 0,
+                scounteren: 0,
+                senvcfg: 0,
+                sscratch: 0,
+                sepc: 0,
+                scause: 0,
+                stval: 0,
+                satp: 0,
+                scontext: 0,
+                medeleg: 0,
+                mideleg: 0,
+                pmpcfg: [0; 8],
+                pmpaddr: [0; 64],
+                mhpmcounter: [0; 29],
+                mhpmevent: [0; 29],
+            },
             pc: 0,
             mode: Mode::M,
-            trap_info: Default::default(),
+            trap_info: TrapInfo {
+                mepc: 0,
+                mstatus: 0,
+                mcause: 0,
+                mip: 0,
+                mtval: 0,
+            },
             nb_exits: 0,
             hart_id,
             nb_pmp,
@@ -104,48 +146,6 @@ pub struct VirtCsr {
     pub pmpaddr: [usize; 64],
     pub mhpmcounter: [usize; 29],
     pub mhpmevent: [usize; 29],
-}
-
-impl Default for VirtCsr {
-    fn default() -> VirtCsr {
-        VirtCsr {
-            misa: 0,
-            mie: 0,
-            mip: 0,
-            mtvec: 0,
-            mscratch: 0,
-            mvendorid: 0,
-            marchid: 0,
-            mimpid: 0,
-            mcycle: 0,
-            minstret: 0,
-            mcountinhibit: 0,
-            mcounteren: 0,
-            menvcfg: 0,
-            mseccfg: 0,
-            mcause: 0,
-            mepc: 0,
-            mtval: 0,
-            mstatus: 0,
-            mtinst: 0,
-            mconfigptr: 0,
-            stvec: 0,
-            scounteren: 0,
-            senvcfg: 0,
-            sscratch: 0,
-            sepc: 0,
-            scause: 0,
-            stval: 0,
-            satp: 0,
-            scontext: 0,
-            medeleg: 0,
-            mideleg: 0,
-            pmpcfg: [0; 8],
-            pmpaddr: [0; 64],
-            mhpmcounter: [0; 29],
-            mhpmevent: [0; 29],
-        }
-    }
 }
 
 impl VirtCsr {
@@ -992,5 +992,81 @@ where
     #[inline]
     fn set_csr(&mut self, register: &'a R, value: usize, hw: &HardwareCapability) {
         self.set_csr(*register, value, hw)
+    }
+}
+
+// ————————————————————————————————— Tests —————————————————————————————————— //
+
+#[cfg(test)]
+mod tests {
+    use core::usize;
+
+    use crate::arch::{mstatus, Arch, Architecture, Csr, Mode};
+    use crate::host::MiralisContext;
+    use crate::virt::VirtContext;
+
+    /// We test value of mstatus.MPP.
+    /// When switching from firmware to payload,
+    /// virtual mstatus.MPP must to be S (because we are jumping to payload)
+    /// and mstatus.MPP must be M (coming from Miralis).
+    ///
+    /// When switching from payload to firmware,
+    /// virtual mstatus.MPP must to be S (coming from payload)
+    /// and mstatus.MPP must be U (going to firmware).
+    #[test]
+    fn switch_context_mpp() {
+        let hw = unsafe { Arch::detect_hardware() };
+        let mut mctx = MiralisContext::new(hw);
+        let mut ctx = VirtContext::new(0, mctx.hw.available_reg.nb_pmp);
+
+        ctx.csr.mstatus |= Mode::S.to_bits() << mstatus::MPP_OFFSET;
+
+        unsafe { ctx.switch_from_firmware_to_payload(&mut mctx) }
+
+        assert_eq!(
+            ctx.csr.mstatus & mstatus::MPP_FILTER,
+            Mode::S.to_bits() << mstatus::MPP_OFFSET,
+            "VirtContext Mstatus.MPP must be set to S mode (going to payload)"
+        );
+
+        assert_eq!(
+            Arch::read_csr(Csr::Mstatus) & mstatus::MPP_FILTER,
+            Mode::M.to_bits() << mstatus::MPP_OFFSET,
+            "Mstatus.MPP must be set to M mode (coming from Miralis)"
+        );
+
+        // Simulate a trap
+        unsafe { Arch::write_csr(Csr::Mstatus, Mode::S.to_bits() << mstatus::MPP_OFFSET) };
+
+        unsafe { ctx.switch_from_payload_to_firmware(&mut mctx) }
+
+        // VirtContext Mstatus.MPP has been set to M mode
+        assert_eq!(
+            ctx.csr.mstatus & mstatus::MPP_FILTER,
+            Mode::S.to_bits() << mstatus::MPP_OFFSET,
+            "VirtContext Mstatus.MPP has been set to S mode (coming from payload)"
+        );
+
+        // Mstatus.MPP has been set to U mode
+        assert_eq!(
+            Arch::read_csr(Csr::Mstatus) & mstatus::MPP_FILTER,
+            Mode::U.to_bits() << mstatus::MPP_OFFSET,
+            "Mstatus.MPP has been set to U mode (going to firmware)"
+        );
+    }
+
+    /// We test value of mideleg when switching from payload to firmware.
+    /// Mideleg must always be 0 when executing the firware.
+    #[test]
+    fn switch_to_firmware_mideleg() {
+        let hw = unsafe { Arch::detect_hardware() };
+        let mut mctx = MiralisContext::new(hw);
+        let mut ctx = VirtContext::new(0, mctx.hw.available_reg.nb_pmp);
+
+        unsafe { Arch::write_csr(Csr::Mideleg, usize::MAX) };
+
+        unsafe { ctx.switch_from_payload_to_firmware(&mut mctx) }
+
+        assert_eq!(Arch::read_csr(Csr::Mideleg), 0, "Mideleg must be 0");
     }
 }


### PR DESCRIPTION
Close #112 

Support for running Miralis in user-space in order to allow unit testing of some of the Miralis logic configuring the CPU state. We expect that this will help enforcing invariants regarding interrupt configuration to prevent breaking them in the future.

Basic userspace architecture function. Simple tests for main.rs and virt.rs. Trap.rs refactoring.