### PR TITLE
Fix manual save of register in run_vcpu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ platform_visionfive2 = []
 
 [profile.dev]
 panic = "abort"
-opt-level = 0
+opt-level = 3
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ platform_visionfive2 = []
 
 [profile.dev]
 panic = "abort"
+opt-level = 0
 
 [profile.release]
 panic = "abort"

--- a/firmware/pmp/main.rs
+++ b/firmware/pmp/main.rs
@@ -15,7 +15,6 @@ fn main() -> ! {
     // Test normal write to config
     unsafe {
         asm!(
-            "li {0}, 0b00000111",
             "csrw pmpcfg0, {0}",
             "csrr {1}, pmpcfg0",
             in(reg) secret_cfg,
@@ -27,10 +26,9 @@ fn main() -> ! {
     // Test invalid write to config
     unsafe {
         asm!(
-            "li {0}, 0b01100111",
             "csrw pmpcfg0, {0}",
             "csrr {1}, pmpcfg0",
-            in(reg) secret_cfg,
+            in(reg) 0b01100111,
             out(reg) res,
         );
     }
@@ -39,10 +37,9 @@ fn main() -> ! {
     // Test out of range write to config (with 8 PMP)
     unsafe {
         asm!(
-            "li {0}, 0b01100111",
             "csrw pmpcfg4, {0}",
             "csrr {1}, pmpcfg4",
-            in(reg) secret_cfg,
+            in(reg) 0b01100111,
             out(reg) res,
         );
     }
@@ -51,10 +48,9 @@ fn main() -> ! {
     // Test normal write to address
     unsafe {
         asm!(
-            "li {0}, 0x42",
             "csrw pmpaddr0, {0}",
             "csrr {1}, pmpaddr0",
-            in(reg) secret_cfg,
+            in(reg) 0x42,
             out(reg) res,
         );
     }
@@ -75,10 +71,9 @@ fn main() -> ! {
     // Test out of range write to address : for 16 pmp
     unsafe {
         asm!(
-            "li {0}, 0x42",
             "csrw pmpaddr17, {0}",
             "csrr {1}, pmpaddr9",
-            in(reg) secret_cfg,
+            in(reg) 0x42,
             out(reg) res,
         );
     }

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -326,17 +326,19 @@ impl Architecture for MetalArch {
 
         asm!(
             // We need to save some registers manually, the compiler can't handle those
-            "sd x3, (8*1)(sp)",
-            "sd x4, (8*2)(sp)",
-            "sd x8, (8*3)(sp)",
-            "sd x9, (8*4)(sp)",
+            "add sp, sp, -32",
+            "sd x3, (8*0)(sp)",
+            "sd x4, (8*1)(sp)",
+            "sd x8, (8*2)(sp)",
+            "sd x9, (8*3)(sp)",
             // Jump into context switch code
             "jal x30, _run_vcpu",
             // Restore registers
-            "ld x3, (8*1)(sp)",
-            "ld x4, (8*2)(sp)",
-            "ld x8, (8*3)(sp)",
-            "ld x9, (8*4)(sp)",
+            "ld x3, (8*0)(sp)",
+            "ld x4, (8*1)(sp)",
+            "ld x8, (8*2)(sp)",
+            "ld x9, (8*3)(sp)",
+            "add sp, sp, 32",
             // Clobber all other registers, so that the compiler automatically
             // saves and restores the ones it needs
             inout("x31") ctx => _,

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,14 +118,14 @@ pub(crate) extern "C" fn main(hart_id: usize, device_tree_blob_addr: usize) -> !
         ctx.pc = firmware_addr;
     }
 
-    main_loop(ctx, mctx);
+    main_loop(&mut ctx, &mut mctx);
 }
 
-fn main_loop(mut ctx: VirtContext, mut mctx: MiralisContext) -> ! {
+fn main_loop(ctx: &mut VirtContext, mctx: &mut MiralisContext) -> ! {
     loop {
         unsafe {
-            Arch::run_vcpu(&mut ctx);
-            handle_trap(&mut ctx, &mut mctx);
+            Arch::run_vcpu(ctx);
+            handle_trap(ctx, mctx);
         }
     }
 }


### PR DESCRIPTION
Closes #115 

Stack pointer wasn't updated correctly, resulting in wrong save/restoration of manually save registers under full rust compiler optimization.
Add optimization for development.
Slight changes for performance.