### PR TITLE
Bugfix: properly exit with an error when config is invalid

### DIFF
--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ test:
 
 	# Checking configs...
 	cargo run -q --package runner -- check-config ./config/example.config.toml
-	cargo run -q --package runner -- check-config ./config/qemu_virt.toml
+	cargo run -q --package runner -- check-config ./config/qemu-virt.toml
 	cargo run -q --package runner -- check-config ./config/visionfive2.toml
 
 	# Running integration tests...

--- a/runner/src/config.rs
+++ b/runner/src/config.rs
@@ -209,7 +209,7 @@ pub fn check_config(args: &CheckConfigArgs) {
         Ok(config) => config,
         Err(error) => {
             println!("Could not read config: {}", error);
-            return;
+            std::process::exit(1);
         }
     };
 


### PR DESCRIPTION
Our runner has a new `check-config` command, but it turns out the command was only printing the error, not exiting with a non-zero code. Because of that our CI was passing despite a type in the name of one of the config file. This patch makes the CI report error properly if one of the config is broken.