### PR TITLE
Automatically detect the available number of PMP registers

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -93,6 +93,8 @@ pub struct RegistersCapability {
     pub menvcfg: bool,
     /// Boolean value indicating if Supervisor environment configuration register is present
     pub senvcfg: bool,
+    /// The number of implemented and non-zero PMP registers
+    pub nb_pmp: usize,
 }
 
 // ———————————————————————————— Privilege Modes ————————————————————————————— //

--- a/src/host.rs
+++ b/src/host.rs
@@ -21,9 +21,9 @@ pub struct MiralisContext {
 
 impl MiralisContext {
     /// Creates a new Miralis context with default values.
-    pub fn new(nb_pmp: usize, hw: HardwareCapability) -> Self {
+    pub fn new(hw: HardwareCapability) -> Self {
         Self {
-            pmp: PmpGroup::new(nb_pmp),
+            pmp: PmpGroup::new(hw.available_reg.nb_pmp),
             virt_pmp_offset: 0,
             hw,
             devices: [Plat::create_clint_device()],

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -30,9 +30,6 @@ pub trait Platform {
     /// Load the firmware (virtual M-mode software) and return its address.
     fn load_firmware() -> usize;
 
-    /// Return the number of PMPs of the platform.
-    fn get_nb_pmp() -> usize;
-
     /// Returns the start and size of Miralis's own memory.
     fn get_miralis_memory_start_and_size() -> (usize, usize);
 

--- a/src/platform/virt.rs
+++ b/src/platform/virt.rs
@@ -17,7 +17,6 @@ const TEST_MMIO_ADDRESS: usize = 0x100000;
 const MIRALIS_START_ADDR: usize = 0x80000000;
 const FIRMWARE_START_ADDR: usize = 0x80200000;
 const CLINT_BASE: usize = 0x2000000;
-const PMP_NUMBER: usize = 16;
 
 // ———————————————————————————— Platform Devices ———————————————————————————— //
 
@@ -71,10 +70,6 @@ impl Platform for VirtPlatform {
     fn load_firmware() -> usize {
         // We directly load the firmware from QEMU, nothing to do here.
         FIRMWARE_START_ADDR
-    }
-
-    fn get_nb_pmp() -> usize {
-        PMP_NUMBER
     }
 
     fn get_miralis_memory_start_and_size() -> (usize, usize) {

--- a/src/platform/visionfive2.rs
+++ b/src/platform/visionfive2.rs
@@ -17,7 +17,6 @@ const SERIAL_PORT_BASE_ADDRESS: usize = 0x10000000;
 const MIRALIS_START_ADDR: usize = 0x80000000;
 const FIRMWARE_START_ADDR: usize = 0x80200000;
 const CLINT_BASE: usize = 0x2000000;
-const PMP_NUMBER: usize = 8;
 
 // ———————————————————————————— Platform Devices ———————————————————————————— //
 
@@ -76,10 +75,6 @@ impl Platform for VisionFive2Platform {
 
     fn load_firmware() -> usize {
         FIRMWARE_START_ADDR
-    }
-
-    fn get_nb_pmp() -> usize {
-        PMP_NUMBER
     }
 
     fn get_miralis_memory_start_and_size() -> (usize, usize) {


### PR DESCRIPTION
Before this patch we had to specify the number of PMPs manually for each platform, which is fine but makes it harder to port Miralis to other environments (for instance running Miralis on Miralis). With this patch Miralis detects automatically the number of available PMP registers, removing the need for hard-coding such number for each platform.

Note that because each PMP register needs to be written with a different assembly instruction the code for poking at the 64 PMP registers is quite verbose and macro heavy, but I am not sure how to do better without going too far onto the macro path.