### PR TITLE
Add zephyr to CI

### DIFF
--- a/justfile
+++ b/justfile
@@ -37,6 +37,7 @@ test:
 
 	# Testing with external projects
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware opensbi
+	cargo run --package runner -- run --config {{qemu_virt}} --firmware zephyr --max-exits 1000000
 
 # Run unit tests
 unit-test:

--- a/misc/artifacts.toml
+++ b/misc/artifacts.toml
@@ -4,4 +4,4 @@
 opensbi = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.1.7/opensbi.bin"
 linux = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.0/opensbi-linux-kernel-exit.bin"
 linux-shell = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.0/opensbi-linux-kernel-shell.bin"
-zephyr = "https://github.com/CharlyCst/miralis-artifact-zephyr/releases/download/v0.0.6/zephyr.bin"
+zephyr = "https://github.com/CharlyCst/miralis-artifact-zephyr/releases/download/v0.1.1/zephyr.bin"


### PR DESCRIPTION
Simple Zephyr firmware that summons two threads, logging in round-robin before exiting. This sample requires a lot of exits as it's not using the cpu a lot.