### PR TITLE
hart_id is getting reassigned so that firmware won't be confused

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,9 @@ pub(crate) extern "C" fn main(hart_id: usize, device_tree_blob_addr: usize) -> !
             core::hint::spin_loop();
         }
     }
+    // On the VisionFive2 board there is an issue with a hart_id
+    // Identification, so we have to reassign it for now
+    let hart_id = Arch::read_csr(Csr::Mhartid);
 
     init();
     log::info!("Hello, world!");


### PR DESCRIPTION
On the VisionFive2 board `hart_id` somehow was turned out to be 4 while `Mhartid` was 1 for the same thread. It's unclear what causes this issue (Refs #122), but as a temporary workaround we can reassign the value after the parking loop.