### PR TITLE
Refactor benchmark code and add more counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecall_benchmark"
+version = "0.1.0"
+dependencies = [
+ "miralis_abi",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +242,13 @@ dependencies = [
 
 [[package]]
 name = "os_ctx_switch"
+version = "0.1.0"
+dependencies = [
+ "miralis_abi",
+]
+
+[[package]]
+name = "os_ecall"
 version = "0.1.0"
 dependencies = [
  "miralis_abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ members = [
     "firmware/os_ctx_switch",
     "firmware/sandbox",
     "firmware/interrupt",
+    "firmware/ecall_benchmark",
+    "firmware/os_ecall",
 
     # Crates
     "crates/abi",

--- a/benchmark-analyzer/src/tools.rs
+++ b/benchmark-analyzer/src/tools.rs
@@ -48,7 +48,7 @@ pub fn compute_statistics(map_type_tag_values: HashMap<String, HashMap<String, V
         println!("Benchmark for {}:", key);
         println!("--------------------");
 
-        if key == "nb_exits" {
+        if key == "counters" {
             for (tag, values) in map {
                 println!("{:.<24} count: {:>12}", tag, values.iter().max().unwrap());
                 println!();

--- a/config/example.config.toml
+++ b/config/example.config.toml
@@ -66,3 +66,9 @@ instruction = false
 
 # Count number of total exits
 nb_exits = false
+
+# Count number of firmware exits
+nb_firmware_exits = false
+
+# Count number of world switches
+world_switches = false

--- a/config/test/qemu-virt-benchmark.toml
+++ b/config/test/qemu-virt-benchmark.toml
@@ -19,3 +19,5 @@ enable = true
 time = true
 instruction = true
 nb_exits = true
+nb_firmware_exits = true
+world_switches = true

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,6 +22,8 @@ pub mod abi {
     pub const MIRALIS_SUCCESS_FID: usize = 1;
     /// Logging interface.
     pub const MIRALIS_LOG_FID: usize = 2;
+    /// Benchmark prints and exit.
+    pub const MIRALIS_BENCHMARK_FID: usize = 3;
 
     /// Log level constants, with the same semantic as the `log` crate.
     pub mod log {

--- a/firmware/ecall_benchmark/Cargo.toml
+++ b/firmware/ecall_benchmark/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ecall_benchmark"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "ecall_benchmark"
+path = "main.rs"
+
+[dependencies]
+miralis_abi = { path = "../../crates/abi" }

--- a/firmware/ecall_benchmark/main.rs
+++ b/firmware/ecall_benchmark/main.rs
@@ -1,0 +1,22 @@
+#![no_std]
+#![no_main]
+
+use core::arch::global_asm;
+
+use miralis_abi::firmware_panic;
+
+// This ecall Miralis with benchmark ecall number that results in exits.
+global_asm!(
+    r#"
+.text
+.align 4
+.global _start
+_start:
+    csrw mie, 0x1      // Dummy instruction to exit firmware
+    li a6, 3           // Miralis ABI FID: benchmark
+    li a7, 0x08475bcd  // Miralis ABI EID
+    ecall
+"#,
+);
+
+firmware_panic!();

--- a/firmware/os_ecall/Cargo.toml
+++ b/firmware/os_ecall/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "os_ecall"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "os_ecall"
+path = "main.rs"
+
+[dependencies]
+miralis_abi = { path = "../../crates/abi" }

--- a/firmware/os_ecall/main.rs
+++ b/firmware/os_ecall/main.rs
@@ -1,0 +1,70 @@
+#![no_std]
+#![no_main]
+
+use core::arch::{asm, global_asm};
+
+use miralis_abi::{failure, setup_firmware};
+
+setup_firmware!(main);
+
+fn main() -> ! {
+    // Setup some values                : firmware
+    // Jump into OS function with mret  : firmware -> OS
+    // Ecall from S-Mode                : OS -> Miralis
+    // ecall intercepted by Miralis     : exit
+
+    let os: usize = _raw_os as usize;
+    let trap: usize = _raw_trap_handler as usize;
+    let mpp: i32 = 0b1 << 11; // MPP = S-mode
+
+    unsafe {
+        asm!(
+            "li t4, 0xfffffffff",
+            "csrw pmpcfg0, 0xf",   // XRW TOR
+            "csrw pmpaddr0, t4",   // All memory
+            "auipc t4, 0",
+            "addi t4, t4, 24",
+            "csrw mtvec, {mtvec}", // Write mtvec with trap handler
+            "csrw mstatus, {mpp}", // Write MPP of mstatus to S-mode
+            "csrw mepc, {os}",     // Write MEPC
+
+            "mret",                // Jump to OS
+
+            os = in(reg) os,
+            mtvec = in(reg) trap,
+            mpp = in(reg) mpp,
+        );
+    }
+    failure()
+}
+
+// —————————————————————————————— Trap Handler —————————————————————————————— //
+
+global_asm!(
+    r#"
+.text
+.align 4
+.global _raw_trap_handler
+_raw_trap_handler:
+    jr t4
+"#,
+);
+
+// ———————————————————————————————— Guest OS ———————————————————————————————— //
+
+global_asm!(
+    r#"
+.text
+.align 4
+.global _raw_os
+_raw_os:
+    li a6, 3           // Miralis ABI FID: benchmark
+    li a7, 0x08475bcd  // Miralis ABI EID
+    ecall
+"#,
+);
+
+extern "C" {
+    fn _raw_trap_handler();
+    fn _raw_os();
+}

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 default          := "default"
+benchmark        := "ecall_benchmark"
 qemu_virt        := "./config/test/qemu-virt.toml"
 qemu_virt_2harts := "./config/test/qemu-virt.toml"
 qemu_virt_benchmark := "./config/test/qemu-virt-benchmark.toml"
@@ -37,13 +38,15 @@ test:
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware os_ctx_switch
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware sandbox
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware interrupt
+	cargo run --package runner -- run --config {{qemu_virt_benchmark}} --firmware ecall_benchmark
+	cargo run --package runner -- run --config {{qemu_virt}} --firmware os_ecall
 
 	# Testing with external projects
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware opensbi
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware zephyr --max-exits 1000000
 
 	# Test benchmark code
-	cargo run --package runner -- run --config {{qemu_virt_benchmark}} --firmware default --benchmark
+	cargo run --package runner -- run --config {{qemu_virt_benchmark}} --firmware ecall_benchmark --benchmark
 
 # Run unit tests
 unit-test:
@@ -76,7 +79,7 @@ install-toolchain:
 # The following line gives highlighting on vim
 # vim: set ft=make :
 
-benchmark firmware=default:
+benchmark firmware=benchmark:
 	cargo run --package runner -- run -v --firmware {{firmware}} --benchmark
 
 analyze-benchmark input_path:

--- a/runner/src/config.rs
+++ b/runner/src/config.rs
@@ -79,6 +79,8 @@ pub struct Benchmark {
     pub time: Option<bool>,
     pub instruction: Option<bool>,
     pub nb_exits: Option<bool>,
+    pub nb_firmware_exits: Option<bool>,
+    pub world_switches: Option<bool>,
 }
 
 // ————————————————————————— Environment Variables —————————————————————————— //
@@ -206,6 +208,18 @@ impl Benchmark {
             envs.insert(
                 String::from("MIRALIS_BENCHMARK_NB_EXISTS"),
                 format!("{}", nb_exits),
+            );
+        }
+        if let Some(nb_firmware_exits) = self.nb_firmware_exits {
+            envs.insert(
+                String::from("MIRALIS_BENCHMARK_NB_FIRMWARE_EXITS"),
+                format!("{}", nb_firmware_exits),
+            );
+        }
+        if let Some(world_switches) = self.world_switches {
+            envs.insert(
+                String::from("MIRALIS_BENCHMARK_WORLD_SWITCHES"),
+                format!("{}", world_switches),
             );
         }
         envs

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -131,7 +131,7 @@ impl Architecture for MetalArch {
             Csr::Pmpcfg(_) => todo!(),
             Csr::Pmpaddr(_) => todo!(),
             Csr::Mcycle => asm_read_csr!("mcycle"),
-            Csr::Minstret => asm_read_csr!("instret"),
+            Csr::Minstret => asm_read_csr!("minstret"),
             Csr::Mhpmcounter(_) => todo!(),
             Csr::Mcountinhibit => asm_read_csr!("mcountinhibit"),
             Csr::Mhpmevent(_) => todo!(),

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -216,7 +216,6 @@ impl Benchmark {
     }
 
     /// Log counter value. Tag allows to link different recordings together for analysis.
-    #[allow(dead_code)]
     pub fn record_counter(counter: Counter, tag: &str) {
         if !config::BENCHMARK {
             return;

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -3,7 +3,7 @@
 //! This is useful for creating different benchmark on time of execution or
 //! the number of instruction for example.
 
-use core::arch::asm;
+use spin::Mutex;
 
 use crate::arch::{Arch, Architecture, Csr};
 use crate::config;
@@ -22,73 +22,229 @@ macro_rules! benchmark_print {
     ($($arg:tt)*) => (if config::BENCHMARK { $crate::_benchmark_print!("{}\r\n", core::format_args!($($arg)*))})
 }
 
+pub static BENCH: Mutex<Benchmark> = Mutex::new(Benchmark::new());
+
+const NB_COUNTER: usize = 3;
+
+/// Benchmark counters.
+/// This kind of counter aims to be incremented to count occurences of an event.
+#[derive(PartialEq, Eq)]
+pub enum Counter {
+    TotalExits = 0,
+    FirmwareExits = 1,
+    WorldSwitches = 2,
+}
+
+const NB_INTERVAL_COUNTER: usize = 2;
+
+/// Benchmark interval counters.
+/// This kind of counter aims to measure difference beetween two events.
+#[derive(PartialEq, Eq)]
+pub enum IntervalCounter {
+    ExecutionTime = 0,
+    InstructionRet = 1,
+}
+
+enum Either {
+    IntervalCounter(IntervalCounter),
+    Counter(Counter),
+}
+
+/// Either enum represent either classic counters or interval counters.
+/// The purpose of this is to unify common functionnalities.
+impl Either {
+    /// Whether the config enabled the counter.
+    fn is_enabled(&self) -> bool {
+        match self {
+            Either::Counter(c) => match c {
+                Counter::TotalExits => config::BENCHMARK_NB_EXITS,
+                Counter::FirmwareExits => config::BENCHMARK_NB_FIRMWARE_EXITS,
+                Counter::WorldSwitches => config::BENCHMARK_WORLD_SWITCHES,
+            },
+            Either::IntervalCounter(c) => match c {
+                IntervalCounter::ExecutionTime => config::BENCHMARK_TIME,
+                IntervalCounter::InstructionRet => config::BENCHMARK_INSTRUCTION,
+            },
+        }
+    }
+
+    /// Default value of the counter: Usually zero for occurence counters and current
+    /// value for interval counters.
+    fn reset_value(&self) -> usize {
+        match self {
+            Either::Counter(_) => 0,
+            Either::IntervalCounter(c) => match c {
+                IntervalCounter::ExecutionTime => Plat::get_clint().lock().read_mtime(),
+                IntervalCounter::InstructionRet => Arch::read_csr(Csr::Minstret),
+            },
+        }
+    }
+
+    /// The name of the counter. Name are intended to be used to regroup measures.
+    fn name(&self) -> &'static str {
+        match self {
+            Either::Counter(_) => "counters",
+            Either::IntervalCounter(c) => match c {
+                IntervalCounter::ExecutionTime => "time",
+                IntervalCounter::InstructionRet => "instruction ret",
+            },
+        }
+    }
+}
+
 pub struct Benchmark {
-    // Does the benchmark started.
-    pub is_running: bool,
-
     // Temporary value to store previous state (e.g. state when the benchmark started to compare).
-    pub previous_instr_count: usize,
+    interval_counters: [usize; NB_INTERVAL_COUNTER],
 
-    pub previous_timer: usize,
+    // Counters that could be incremented and reset to 0.
+    counters: [usize; NB_COUNTER],
 }
 
 impl Benchmark {
-    pub fn new() -> Benchmark {
+    pub const fn new() -> Benchmark {
         Benchmark {
-            is_running: false,
-            previous_instr_count: 0,
-            previous_timer: 0,
+            interval_counters: [0; NB_INTERVAL_COUNTER],
+            counters: [0; NB_COUNTER],
         }
     }
 
-    /// Start benchmarking.
-    pub fn start(&mut self) {
-        if self.is_running {
-            log::error!("already counting instr");
-        } else {
-            self.is_running = true;
+    /// Reset counter value to default and return previous one.
+    fn reset(&mut self, counter: Either) -> usize {
+        let value = counter.reset_value();
+        self.set(counter, value)
+    }
 
-            // instruction
-            if config::BENCHMARK_INSTRUCTION {
-                self.previous_instr_count = Arch::read_csr(Csr::Minstret);
+    /// Increment counter by one. Mainly useful for occurence counters.
+    fn increment(&mut self, counter: Either) {
+        match counter {
+            Either::Counter(c) => self.counters[c as usize] += 1,
+            Either::IntervalCounter(c) => self.interval_counters[c as usize] += 1,
+        }
+    }
+
+    /// Set value of a counter and return previous value.
+    fn set(&mut self, counter: Either, value: usize) -> usize {
+        match counter {
+            Either::Counter(c) => {
+                let index = c as usize;
+                let previous = self.counters[index];
+                self.counters[index] = value;
+                previous
             }
-
-            // time
-            if config::BENCHMARK_TIME {
-                unsafe {
-                    asm!(
-                        "rdtime {value}",
-                        value = out(reg) self.previous_timer
-                    );
-                }
+            Either::IntervalCounter(c) => {
+                let index = c as usize;
+                let previous = self.interval_counters[index];
+                self.interval_counters[index] = value;
+                previous
             }
         }
     }
 
-    /// Stop benchmarking.
-    pub fn stop(&mut self, tag: &str) {
-        self.is_running = false;
+    /// Read value of a counter.
+    fn read(&self, counter: Either) -> usize {
+        match counter {
+            Either::Counter(c) => self.counters[c as usize],
+            Either::IntervalCounter(c) => self.interval_counters[c as usize],
+        }
+    }
 
-        // instruction
-        if config::BENCHMARK_INSTRUCTION {
-            let stop_value = Arch::read_csr(Csr::Minstret);
-            Self::record_entry("instr", tag, stop_value - self.previous_instr_count);
+    /// Reset interval counters.
+    pub fn start_interval_counters() {
+        if !config::BENCHMARK {
+            return;
         }
 
-        // time
-        if config::BENCHMARK_TIME {
-            let stop_time: usize;
-            unsafe {
-                asm!(
-                    "rdtime {value}", 
-                    value = out(reg) stop_time);
+        for counter in [
+            IntervalCounter::ExecutionTime,
+            IntervalCounter::InstructionRet,
+        ]
+        .map(Either::IntervalCounter)
+        {
+            if !counter.is_enabled() {
+                return;
             }
-            Self::record_entry("time", tag, stop_time - self.previous_timer);
+
+            BENCH.lock().reset(counter);
         }
+    }
+
+    /// Stop and record interval counter.
+    pub fn stop_interval_counters(tag: &str) {
+        if !config::BENCHMARK {
+            return;
+        }
+
+        for counter in [
+            IntervalCounter::ExecutionTime,
+            IntervalCounter::InstructionRet,
+        ]
+        .map(Either::IntervalCounter)
+        {
+            if !counter.is_enabled() {
+                return;
+            }
+
+            let bench = counter.name();
+            let value = counter.reset_value() - BENCH.lock().reset(counter);
+
+            Self::record_entry(bench, tag, value);
+        }
+    }
+
+    /// Increment counter's value.
+    pub fn increment_counter(counter: Counter) {
+        if !config::BENCHMARK {
+            return;
+        }
+
+        let wrapped_counter = Either::Counter(counter);
+
+        if !wrapped_counter.is_enabled() {
+            return;
+        }
+
+        BENCH.lock().increment(wrapped_counter)
+    }
+
+    #[allow(dead_code)] // TODO: remove this when eventually used
+    pub fn reset_counter(counter: Counter) {
+        if !config::BENCHMARK {
+            return;
+        }
+
+        BENCH.lock().reset(Either::Counter(counter));
+    }
+
+    /// Log counter value. Tag allows to link different recordings together for analysis.
+    #[allow(dead_code)]
+    pub fn record_counter(counter: Counter, tag: &str) {
+        if !config::BENCHMARK {
+            return;
+        }
+        let wrapped_counter = Either::Counter(counter);
+
+        if !wrapped_counter.is_enabled() {
+            return;
+        }
+        Benchmark::record_entry(
+            wrapped_counter.name(),
+            tag,
+            BENCH.lock().read(wrapped_counter),
+        )
     }
 
     /// Print formated string with value of the entry and a tag for identification.
+    /// "benchmark" section allows to filter lines of benchmarking in the output.
+    ///
+    /// bench: what kind of benchmark it is
+    /// (e.g. execution time, instruction count, number of exits...)
+    ///
+    /// tag: unique identifier of a measure that can be used to add more context
+    /// (e.g. time when we measured, in which part of the code...)
     pub fn record_entry(bench: &str, tag: &str, entry: usize) {
+        if !config::BENCHMARK {
+            return;
+        }
         benchmark_print!("benchmark || {:>15} || {:25} || {}", bench, tag, entry);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -223,3 +223,9 @@ pub const BENCHMARK_INSTRUCTION: bool = is_enabled!("MIRALIS_BENCHMARK_INSTRUCTI
 
 /// Whether count or not total number of exits
 pub const BENCHMARK_NB_EXITS: bool = is_enabled!("MIRALIS_BENCHMARK_NB_EXISTS");
+
+/// Whether count or not number of firmware exits
+pub const BENCHMARK_NB_FIRMWARE_EXITS: bool = is_enabled!("MIRALIS_BENCHMARK_NB_FIRMWARE_EXITS");
+
+/// Whether count or not number of world switches
+pub const BENCHMARK_WORLD_SWITCHES: bool = is_enabled!("MIRALIS_BENCHMARK_WORLD_SWITCHES");

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,7 @@ fn handle_trap(ctx: &mut VirtContext, mctx: &mut MiralisContext) {
     ctx.nb_exits += 1;
     match exec_mode {
         ExecutionMode::Firmware => ctx.handle_firmware_trap(&mctx),
-        ExecutionMode::Payload => ctx.emulate_jump_trap_handler(),
+        ExecutionMode::Payload => ctx.handle_payload_trap(),
     }
 
     if exec_mode == ExecutionMode::Firmware {


### PR DESCRIPTION
Code is refactored to make it easier to add a counter. Two type of counters: first one is basic counters yith purpose of counting occurences of events. The second one aims to measure difference beetween two events.
The counters shares many properties that are grouped under the Either enum.

Other properties are recorded like number of world switches or firmware exits.

Related to #125. 