### PR TITLE
Add linux driver release

### DIFF
--- a/benchmark-analyzer/src/tools.rs
+++ b/benchmark-analyzer/src/tools.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 
 /// Parse a benchmark file in order to get a map from tags to list of usize values.
-pub fn parse_content(content: Vec<String>) -> HashMap<String, HashMap<String, Vec<usize>>> {
-    let mut map_type_tag_values: HashMap<String, HashMap<String, Vec<usize>>> = HashMap::new();
-
+pub fn parse_content(
+    content: Vec<String>,
+    map_type_tag_values: &mut HashMap<String, HashMap<String, Vec<usize>>>,
+) {
     // keep only benchark logs
     content
         .iter()
@@ -33,12 +34,13 @@ pub fn parse_content(content: Vec<String>) -> HashMap<String, HashMap<String, Ve
                 .entry(tag)
                 .or_insert(Vec::new())
                 .push(value.unwrap())
-        });
-
-    map_type_tag_values
+        })
 }
 
-pub fn compute_statistics(map_type_tag_values: HashMap<String, HashMap<String, Vec<usize>>>) {
+pub fn compute_statistics(
+    map_type_tag_values: &HashMap<String, HashMap<String, Vec<usize>>>,
+    iteration: usize,
+) {
     if map_type_tag_values.is_empty() {
         println!("Nothing has been benchmarked !")
     } else {
@@ -48,16 +50,21 @@ pub fn compute_statistics(map_type_tag_values: HashMap<String, HashMap<String, V
         println!("Benchmark for {}:", key);
         println!("--------------------");
 
-        if key == "counters" {
-            for (tag, values) in map {
-                println!("{:.<24} count: {:>12}", tag, values.iter().max().unwrap());
-                println!();
-            }
-        } else {
-            for (tag, values) in map {
+        for (tag, values) in map {
+            if values.len() == 1 {
+                println!("{:.<25}     : {:>12}", tag, values.iter().max().unwrap());
+            } else {
                 println!("{:.<25}  Min: {:>12}", tag, values.iter().min().unwrap());
                 println!("{:.<25}  Max: {:>12}", tag, values.iter().max().unwrap());
-                println!("{:.<25}  Sum: {:>12}", tag, values.iter().sum::<usize>());
+                if iteration == 1 {
+                    println!("{:.<25}  Sum: {:>12}", tag, values.iter().sum::<usize>());
+                } else {
+                    println!(
+                        "{:.<21} Avg. sum: {:>12}",
+                        tag,
+                        values.iter().sum::<usize>() / iteration
+                    );
+                }
                 println!(
                     "{:.<25} Mean: {:12}",
                     tag,
@@ -66,5 +73,7 @@ pub fn compute_statistics(map_type_tag_values: HashMap<String, HashMap<String, V
                 println!();
             }
         }
+
+        println!();
     }
 }

--- a/justfile
+++ b/justfile
@@ -4,6 +4,8 @@ qemu_virt        := "./config/test/qemu-virt.toml"
 qemu_virt_2harts := "./config/test/qemu-virt.toml"
 qemu_virt_benchmark := "./config/test/qemu-virt-benchmark.toml"
 benchmark_folder := "./benchmark-out"
+default_iterations := "1"
+
 
 # Print the list of commands
 help:
@@ -79,8 +81,8 @@ install-toolchain:
 # The following line gives highlighting on vim
 # vim: set ft=make :
 
-benchmark firmware=benchmark:
-	cargo run --package runner -- run -v --firmware {{firmware}} --benchmark
+benchmark firmware=benchmark iterations=default_iterations:
+	cargo run --package runner -- run -v --firmware {{firmware}} --benchmark --benchmark-iterations {{iterations}}
 
 analyze-benchmark input_path:
 	cargo run --package benchmark-analyzer -- {{input_path}}

--- a/misc/artifacts.toml
+++ b/misc/artifacts.toml
@@ -2,6 +2,7 @@
 
 [bin]
 opensbi = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.1.7/opensbi.bin"
-linux = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.0/opensbi-linux-kernel-exit.bin"
-linux-shell = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.0/opensbi-linux-kernel-shell.bin"
+linux = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.1/opensbi-linux-kernel-exit.bin"
+linux-shell = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.1/opensbi-linux-kernel-shell.bin"
+linux-driver = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.1/opensbi-linux-kernel-driver.bin"
 zephyr = "https://github.com/CharlyCst/miralis-artifact-zephyr/releases/download/v0.1.1/zephyr.bin"

--- a/misc/artifacts.toml
+++ b/misc/artifacts.toml
@@ -4,5 +4,5 @@
 opensbi = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.1.7/opensbi.bin"
 linux = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.1/opensbi-linux-kernel-exit.bin"
 linux-shell = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.1/opensbi-linux-kernel-shell.bin"
-linux-driver = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.1/opensbi-linux-kernel-driver.bin"
+linux-boot-benchmark = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.1/opensbi-linux-kernel-driver.bin"
 zephyr = "https://github.com/CharlyCst/miralis-artifact-zephyr/releases/download/v0.1.1/zephyr.bin"

--- a/runner/src/artifacts.rs
+++ b/runner/src/artifacts.rs
@@ -63,8 +63,8 @@ struct Bin {
     linux: Option<String>,
     #[serde(rename = "linux-shell")]
     linux_shell: Option<String>,
-    #[serde(rename = "linux-driver")]
-    linux_driver: Option<String>,
+    #[serde(rename = "linux-boot-benchmark")]
+    linux_boot_benchmark: Option<String>,
 }
 
 fn read_artifact_manifest() -> ArtifactManifest {
@@ -110,7 +110,11 @@ pub fn get_external_artifacts() -> HashMap<String, Artifact> {
     append_artifact("zephyr", &manifest.bin.zephyr, &mut map);
     append_artifact("linux", &manifest.bin.linux, &mut map);
     append_artifact("linux-shell", &manifest.bin.linux_shell, &mut map);
-    append_artifact("linux-driver", &manifest.bin.linux_driver, &mut map);
+    append_artifact(
+        "linux-boot-benchmark",
+        &manifest.bin.linux_boot_benchmark,
+        &mut map,
+    );
     map
 }
 

--- a/runner/src/artifacts.rs
+++ b/runner/src/artifacts.rs
@@ -63,6 +63,8 @@ struct Bin {
     linux: Option<String>,
     #[serde(rename = "linux-shell")]
     linux_shell: Option<String>,
+    #[serde(rename = "linux-driver")]
+    linux_driver: Option<String>,
 }
 
 fn read_artifact_manifest() -> ArtifactManifest {
@@ -108,6 +110,7 @@ pub fn get_external_artifacts() -> HashMap<String, Artifact> {
     append_artifact("zephyr", &manifest.bin.zephyr, &mut map);
     append_artifact("linux", &manifest.bin.linux, &mut map);
     append_artifact("linux-shell", &manifest.bin.linux_shell, &mut map);
+    append_artifact("linux-driver", &manifest.bin.linux_driver, &mut map);
     map
 }
 

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -50,6 +50,9 @@ struct RunArgs {
     #[arg(long, action)]
     /// Activate benchmark analysis
     benchmark: bool,
+    #[arg(long, default_value = "1")]
+    /// Number of iterations for the benchmark
+    benchmark_iterations: usize,
 }
 
 #[derive(Args)]


### PR DESCRIPTION
Rework benchmark analysis code to handle multiple runs of a given binary.
Justfile command `just benchmark` can now receive an argument to control the number of run we want to execute.