### PR TITLE
Add csr write frimware for benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "csr_write_benchmark"
+version = "0.1.0"
+dependencies = [
+ "miralis_abi",
+]
+
+[[package]]
 name = "default"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "firmware/interrupt",
     "firmware/ecall_benchmark",
     "firmware/os_ecall",
+    "firmware/csr_write_benchmark",
 
     # Crates
     "crates/abi",

--- a/firmware/csr_write_benchmark/Cargo.toml
+++ b/firmware/csr_write_benchmark/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "csr_write_benchmark"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "csr_write_benchmark"
+path = "main.rs"
+
+[dependencies]
+miralis_abi = { path = "../../crates/abi" }

--- a/firmware/csr_write_benchmark/main.rs
+++ b/firmware/csr_write_benchmark/main.rs
@@ -1,0 +1,19 @@
+#![no_std]
+#![no_main]
+
+use core::arch::asm;
+
+use miralis_abi::{setup_firmware, success};
+
+setup_firmware!(main);
+
+fn main() -> ! {
+    for _ in 0..10_000 {
+        unsafe  {
+            asm!(
+                "csrw mscratch, 0x1",       // Write ot mscratch to produce a trap to Miralis
+            );
+        }
+    }
+    success();
+}


### PR DESCRIPTION
Add a simple firmware that only performs writes to a csr in order to benchmark emulation handling of a csr write. Benchmarks aims to be tested on the board.