### PR TITLE
Benchmark compute basic stats during runtime

### DIFF
--- a/benchmark_analyzer/src/main.rs
+++ b/benchmark_analyzer/src/main.rs
@@ -33,12 +33,12 @@ fn main() {
             .map(|file_path| read_file_content(&file_path))
             .for_each(|c| parse_content(c, &mut map_type_tag_values));
 
-        compute_statistics(&map_type_tag_values, path.read_dir().unwrap().count());
+        compute_statistics(&map_type_tag_values);
     } else {
         let content = read_file_content(path);
         parse_content(content, &mut map_type_tag_values);
 
-        compute_statistics(&map_type_tag_values, 1);
+        compute_statistics(&map_type_tag_values);
     }
 }
 

--- a/config/example.config.toml
+++ b/config/example.config.toml
@@ -54,6 +54,9 @@ nb_harts = 1
 # Enable all benchmark
 enable = false
 
+# Benchmarking will log every value
+log_everything = true
+
 # Benchmark execution time
 time = false
 

--- a/config/example.config.toml
+++ b/config/example.config.toml
@@ -54,8 +54,8 @@ nb_harts = 1
 # Enable all benchmark
 enable = false
 
-# Benchmarking will log every value
-log_everything = true
+# Print in csv_format, useful for analysis
+csv_format = true
 
 # Benchmark execution time
 time = false

--- a/config/qemu-virt-benchmark.toml
+++ b/config/qemu-virt-benchmark.toml
@@ -15,6 +15,7 @@ nb_harts = 1
 
 [benchmark]
 enable = true
+csv_format = true
 time = true
 instruction = true
 nb_exits = true

--- a/crates/abi/src/lib.rs
+++ b/crates/abi/src/lib.rs
@@ -39,6 +39,16 @@ pub fn failure() -> ! {
     }
 }
 
+/// Ask Miralis to end benchmark and print results.
+pub fn miralis_end_benchmark() -> ! {
+    unsafe { miralis_ecall(abi::MIRALIS_BENCHMARK_FID).ok() };
+
+    // Loop forever, this should never happen as Miralis will terminate the execution before.
+    loop {
+        hint::spin_loop();
+    }
+}
+
 // ————————————————————————————— Firmware Setup ————————————————————————————— //
 
 /// Configure the firmware entry point and panic handler.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -32,11 +32,13 @@ We do have an artifact named `opensbi`, so the runner will check if it is alread
 ## Benchmark
 
 Different benchmark can be run with `just benchmark`.
-This command computes and prints some statistics about a run of Miralis.
+This command computes and prints some statistics about a run of Miralis with a given binary.
 
-The default behaviour is counting the number of retired instructions of function `run_vcpu` and `handle_trap` called in `main.rs` with the `default` firmware. You can specify the binary you want to benchmark with `just benchmark <binaries>`. For example, if you want to benchmark `linux` you can run `just benchmark linux`. 
+The binary should call Miralis to print the benchmark results at the end of its execution. Statistics are computed during the runtime in a streaming maner.
 
-One can choose which benchmark to run in the `benchmark` section of the `config.toml` file. The field `enable` is overwritten to true when running this command.
+You can specify the binary you want to benchmark with `just benchmark <binaries>` (by default it is `ecall_benchmark`). For example, if you want to benchmark `linux` you can run `just benchmark linux`. 
 
-If you collect output of a run into a file, you can feed the file to the just `analyze-benchmark` command to get the statistics of the run.
+One can choose what to benchmark in the `benchmark` section of the `config.toml` file. The field `enable` is overwritten to true when running this command.
+
+If you collect output of a run into file (should be in csv format using `csv_format` in the config), you can feed the file to the just `analyze-benchmark` command to get the statistics of the run. You can also put multiple files of multiple runs into a folder and give the path of the folder. This will compute the average of all runs.
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -31,14 +31,9 @@ We do have an artifact named `opensbi`, so the runner will check if it is alread
 
 ## Benchmark
 
-Different benchmark can be run with `just benchmark`.
-This command computes and prints some statistics about a run of Miralis with a given binary.
+One can choose to activate benchmarking and what to benchmark in the `benchmark` section of the `config.toml` file.
 
-The binary should call Miralis to print the benchmark results at the end of its execution. Statistics are computed during the runtime in a streaming maner.
+Statistics are computed during the runtime in a streaming maner, then printed at the end of the run, either in a fancy way or in csv format. The firmware should ecall Miralis with FID 3 in order to ends the benchmark before exiting.
 
-You can specify the binary you want to benchmark with `just benchmark <binaries>` (by default it is `ecall_benchmark`). For example, if you want to benchmark `linux` you can run `just benchmark linux`. 
-
-One can choose what to benchmark in the `benchmark` section of the `config.toml` file. The field `enable` is overwritten to true when running this command.
-
-If you collect output of a run into file (should be in csv format using `csv_format` in the config), you can feed the file to the just `analyze-benchmark` command to get the statistics of the run. You can also put multiple files of multiple runs into a folder and give the path of the folder. This will compute the average of all runs.
+If you collect the csv output of a run into file (should be in csv format using `csv_format` in the config), you can feed the file to the just `analyze-benchmark` command to get the statistics of the run. You can also put multiple files of multiple runs into a folder and give the path of the folder. This will compute the average of all runs.
 

--- a/firmware/benchmark/csr_write/main.rs
+++ b/firmware/benchmark/csr_write/main.rs
@@ -3,7 +3,7 @@
 
 use core::arch::asm;
 
-use miralis_abi::{setup_firmware, success, BENCHMARK_NB_ITER};
+use miralis_abi::{miralis_end_benchmark, setup_firmware, BENCHMARK_NB_ITER};
 
 setup_firmware!(main);
 
@@ -15,5 +15,6 @@ fn main() -> ! {
             );
         }
     }
-    success();
+
+    miralis_end_benchmark()
 }

--- a/justfile
+++ b/justfile
@@ -50,8 +50,8 @@ test:
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware zephyr --max-exits 1000000
 
 	# Test benchmark code
-	cargo run --package runner -- run --config {{qemu_virt_benchmark}} --firmware csr_write --benchmark
-	cargo run --package runner -- run --config {{qemu_virt_benchmark}} --firmware ecall_benchmark --benchmark
+	cargo run --package runner -- run --config {{qemu_virt_benchmark}} --firmware csr_write
+	cargo run --package runner -- run --config {{qemu_virt_benchmark}} --firmware ecall_benchmark
 
 	# Test firmware build
 	just build-firmware default {{qemu_virt}}
@@ -87,10 +87,6 @@ install-toolchain:
 	rustup component add rust-src --toolchain "$(cat rust-toolchain)"
 	rustup component add llvm-tools-preview --toolchain "$(cat rust-toolchain)"
 	cargo install cargo-binutils
-
-# Run a firwmare with benchmark settings. The firmware should call for benchmark printing before exiting
-benchmark firmware=benchmark iterations=default_iterations:
-	cargo run --package runner -- run -v --config {{qemu_virt_benchmark}} --firmware {{firmware}} --benchmark --benchmark-iterations {{iterations}}
 
 analyze-benchmark input_path:
 	cargo run --package benchmark_analyzer -- {{input_path}}

--- a/justfile
+++ b/justfile
@@ -88,9 +88,6 @@ install-toolchain:
 	rustup component add llvm-tools-preview --toolchain "$(cat rust-toolchain)"
 	cargo install cargo-binutils
 
-# The following line gives highlighting on vim
-# vim: set ft=make :
-
 # Run a firwmare with benchmark settings. The firmware should call for benchmark printing before exiting
 benchmark firmware=benchmark iterations=default_iterations:
 	cargo run --package runner -- run -v --config {{qemu_virt_benchmark}} --firmware {{firmware}} --benchmark --benchmark-iterations {{iterations}}

--- a/justfile
+++ b/justfile
@@ -88,8 +88,12 @@ install-toolchain:
 	rustup component add llvm-tools-preview --toolchain "$(cat rust-toolchain)"
 	cargo install cargo-binutils
 
+# The following line gives highlighting on vim
+# vim: set ft=make :
+
+# Run a firwmare with benchmark settings. The firmware should call for benchmark printing before exiting
 benchmark firmware=benchmark iterations=default_iterations:
-	cargo run --package runner -- run -v --firmware {{firmware}} --benchmark --benchmark-iterations {{iterations}}
+	cargo run --package runner -- run -v --config {{qemu_virt_benchmark}} --firmware {{firmware}} --benchmark --benchmark-iterations {{iterations}}
 
 analyze-benchmark input_path:
 	cargo run --package benchmark_analyzer -- {{input_path}}

--- a/runner/src/config.rs
+++ b/runner/src/config.rs
@@ -75,6 +75,7 @@ pub enum Platforms {
 #[serde(deny_unknown_fields)]
 pub struct Benchmark {
     pub enable: Option<bool>,
+    pub log_everything: Option<bool>,
     pub time: Option<bool>,
     pub instruction: Option<bool>,
     pub nb_exits: Option<bool>,
@@ -213,6 +214,12 @@ impl Benchmark {
         let mut envs = HashMap::new();
         if let Some(enable) = self.enable {
             envs.insert(String::from("MIRALIS_BENCHMARK"), format!("{}", enable));
+        }
+        if let Some(log_everything) = self.log_everything {
+            envs.insert(
+                String::from("MIRALIS_BENCHMARK_LOG_EVERYTHING"),
+                format!("{}", log_everything),
+            );
         }
         if let Some(time) = self.time {
             envs.insert(String::from("MIRALIS_BENCHMARK_TIME"), format!("{}", time));

--- a/runner/src/config.rs
+++ b/runner/src/config.rs
@@ -75,7 +75,7 @@ pub enum Platforms {
 #[serde(deny_unknown_fields)]
 pub struct Benchmark {
     pub enable: Option<bool>,
-    pub log_everything: Option<bool>,
+    pub csv_format: Option<bool>,
     pub time: Option<bool>,
     pub instruction: Option<bool>,
     pub nb_exits: Option<bool>,
@@ -215,10 +215,10 @@ impl Benchmark {
         if let Some(enable) = self.enable {
             envs.insert(String::from("MIRALIS_BENCHMARK"), format!("{}", enable));
         }
-        if let Some(log_everything) = self.log_everything {
+        if let Some(csv_format) = self.csv_format {
             envs.insert(
-                String::from("MIRALIS_BENCHMARK_LOG_EVERYTHING"),
-                format!("{}", log_everything),
+                String::from("MIRALIS_BENCHMARK_CSV_FORMAT"),
+                format!("{}", csv_format),
             );
         }
         if let Some(time) = self.time {

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -47,12 +47,6 @@ struct RunArgs {
     #[arg(long)]
     /// Path to the configuration file to use
     config: Option<PathBuf>,
-    #[arg(long, action)]
-    /// Activate benchmark analysis
-    benchmark: bool,
-    #[arg(long, default_value = "1")]
-    /// Number of iterations for the benchmark
-    benchmark_iterations: usize,
 }
 
 #[derive(Args)]

--- a/runner/src/run.rs
+++ b/runner/src/run.rs
@@ -83,7 +83,8 @@ pub fn run(args: &RunArgs) {
     }
 
     if args.benchmark {
-        let mut map_type_tag_values: HashMap<String, HashMap<String, Vec<usize>>> = HashMap::new();
+        let mut stat_counter_values_map: HashMap<String, HashMap<String, Vec<usize>>> =
+            HashMap::new();
 
         print!("Progress... [");
         for i in 0..args.benchmark_iterations {
@@ -106,10 +107,10 @@ pub fn run(args: &RunArgs) {
                 .map(String::from)
                 .collect();
 
-            benchmark::parse_content(lines, &mut map_type_tag_values);
+            benchmark::parse_content(lines, &mut stat_counter_values_map);
         }
 
-        benchmark::compute_statistics(&map_type_tag_values, args.benchmark_iterations);
+        benchmark::compute_statistics(&stat_counter_values_map);
     } else {
         let exit_status = qemu_cmd.status().expect("Failed to run QEMU");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,7 +58,8 @@ pub const PLATFORM_NB_HARTS: usize = {
 /// Whether any benchmark is enable
 pub const BENCHMARK: bool = is_enabled!("MIRALIS_BENCHMARK");
 
-pub const BENCHMARK_LOG_EVERYTHING: bool = is_enabled!("MIRALIS_BENCHMARK_LOG_EVERYTHING");
+/// Whether print in csv format or not
+pub const BENCHMARK_CSV_FORMAT: bool = is_enabled!("MIRALIS_BENCHMARK_CSV_FORMAT");
 
 /// Whether execution time benchmarking is enabled
 pub const BENCHMARK_TIME: bool = is_enabled!("MIRALIS_BENCHMARK_TIME");

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,8 @@ pub const PLATFORM_NB_HARTS: usize = {
 /// Whether any benchmark is enable
 pub const BENCHMARK: bool = is_enabled!("MIRALIS_BENCHMARK");
 
+pub const BENCHMARK_LOG_EVERYTHING: bool = is_enabled!("MIRALIS_BENCHMARK_LOG_EVERYTHING");
+
 /// Whether execution time benchmarking is enabled
 pub const BENCHMARK_TIME: bool = is_enabled!("MIRALIS_BENCHMARK_TIME");
 

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -8,7 +8,7 @@ use crate::arch::{
     mie, misa, mstatus, parse_mpp_return_mode, satp, Arch, Architecture, Csr, HardwareCapability,
     MCause, Mode, Register, TrapInfo,
 };
-use crate::benchmark::{Benchmark, Counter};
+use crate::benchmark::Benchmark;
 use crate::decoder::{decode, Instr};
 use crate::device::VirtDevice;
 use crate::host::MiralisContext;
@@ -656,9 +656,7 @@ impl VirtContext {
                 self.pc += 4;
             }
             abi::MIRALIS_BENCHMARK_FID => {
-                Benchmark::record_counter(Counter::FirmwareExits, "final firmware exits");
-                Benchmark::record_counter(Counter::TotalExits, "final exits");
-                Benchmark::record_counter(Counter::WorldSwitches, "final world switches");
+                Benchmark::record_counters();
                 Plat::exit_success();
             }
             _ => panic!("Invalid Miralis FID: 0x{:x}", fid),


### PR DESCRIPTION
Modification of benchmark to allow stats to be computed during runtime to avoid periodic printing. This only allow firmware or payload that ends with a benchmark ecall to miralis to be benchmarked.