### PR TITLE
Firmware setup for the board

### DIFF
--- a/config/example.config.toml
+++ b/config/example.config.toml
@@ -44,6 +44,14 @@ max_pmp = 8
 # Default to "qemu_virt"
 name = "qemu_virt"
 
+# Miralis binary will be compiled with this value as a start address
+# Default to "0x80000000"
+start_address = 0x80000000
+
+# Firmware binary will be compiled with this value as a start address
+# Default to "0x80200000"
+firmware_address = 0x80200000
+
 # Nuber of harts (i.e. cores).
 # Default to 1.
 nb_harts = 1

--- a/justfile
+++ b/justfile
@@ -50,6 +50,9 @@ test:
 	# Test benchmark code
 	cargo run --package runner -- run --config {{qemu_virt_benchmark}} --firmware ecall_benchmark --benchmark
 
+	# Test firmware build
+	just build-firmware {{qemu_virt}} default
+
 # Run unit tests
 unit-test:
 	cargo test --features userspace -p miralis
@@ -61,6 +64,10 @@ run firmware=default:
 # Build Miralis with the provided config
 build config:
 	cargo run --package runner -- build --config {{config}}
+
+# Build a given firmware with the provided config
+build-firmware config firmware:
+	cargo run --package runner -- build -v --config {{config}} --firmware {{firmware}}
 
 # Run Miralis but wait for a debugger to connect
 debug firmware=default:
@@ -78,11 +85,11 @@ install-toolchain:
 	rustup component add llvm-tools-preview --toolchain "$(cat rust-toolchain)"
 	cargo install cargo-binutils
 
-# The following line gives highlighting on vim
-# vim: set ft=make :
-
 benchmark firmware=benchmark iterations=default_iterations:
 	cargo run --package runner -- run -v --firmware {{firmware}} --benchmark --benchmark-iterations {{iterations}}
 
 analyze-benchmark input_path:
 	cargo run --package benchmark-analyzer -- {{input_path}}
+
+# The following line gives highlighting on vim
+# vim: set ft=make :

--- a/misc/linker-script-firmware.x
+++ b/misc/linker-script-firmware.x
@@ -26,10 +26,22 @@ SECTIONS
     *(.data)
     *(.data.*)
   }
-  .bss : {
+  .sdata : ALIGN(0x8) {
+    KEEP(*(__*))
+    *(.sdata)
+    *(.sdata.*)
+  }
+  . = ALIGN(0x8);
+  _firmware_bss_start = .;
+  .sbss : {
+    *(.sbss)
+    *(.sbss.*)
+  }
+  .bss : ALIGN(0x8) {
     *(.bss)
     *(.bss.*)
   }
+  _firmware_bss_stop = .;
 
 
   /* Then we allocate some stack space */

--- a/runner/src/build.rs
+++ b/runner/src/build.rs
@@ -1,20 +1,33 @@
 //! Build
 
-use crate::artifacts::{build_target, Target};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use crate::artifacts::{build_target, download_artifact, locate_artifact, Artifact, Target};
 use crate::config::read_config;
 use crate::BuildArgs;
 
 pub fn build(args: &BuildArgs) {
     let cfg = read_config(&args.config);
-    let miralis = build_target(Target::Miralis, &cfg);
-
-    if let Some(config) = &args.config {
-        println!(
-            "Built Miralis with config '{}', binary available at:",
-            config.display()
-        );
+    if let Some(firmware) = &args.firmware {
+        let firmware = match locate_artifact(firmware) {
+            Some(Artifact::Source { name }) => build_target(Target::Firmware(name), &cfg),
+            Some(Artifact::Downloaded { name, url }) => download_artifact(&name, &url),
+            None => PathBuf::from_str(firmware).expect("Invalid firmware path"),
+        };
+        println!("Built firmware, binary available at:");
+        println!("{}", firmware.display());
     } else {
-        println!("Built Miralis, binary available at:");
+        let miralis = build_target(Target::Miralis, &cfg);
+
+        if let Some(config) = &args.config {
+            println!(
+                "Built Miralis with config '{}', binary available at:",
+                config.display()
+            );
+        } else {
+            println!("Built Miralis, binary available at:");
+        }
+        println!("{}", miralis.display());
     }
-    println!("{}", miralis.display());
 }

--- a/runner/src/config.rs
+++ b/runner/src/config.rs
@@ -185,6 +185,18 @@ impl Platform {
                 format!("{}", stack_size),
             );
         }
+        if let Some(stack_size) = self.firmware_address {
+            envs.insert(
+                String::from("MIRALIS_PLATFORM_FIRMWARE_ADDRESS"),
+                format!("{}", stack_size),
+            );
+        }
+        if let Some(stack_size) = self.start_address {
+            envs.insert(
+                String::from("MIRALIS_PLATFORM_START_ADDRESS"),
+                format!("{}", stack_size),
+            );
+        }
         envs
     }
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -62,6 +62,9 @@ struct BuildArgs {
     #[arg(long)]
     /// Path to the configuration file to use
     config: Option<PathBuf>,
+    /// Build a firmware instead of Miralis
+    #[arg(short, long)]
+    firmware: Option<String>,
 }
 
 #[derive(Args)]

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -643,8 +643,8 @@ stack_fill_done:
     ld t5, __bss_stop
 zero_bss_loop:
     bgeu t4, t5, zero_bss_done
-    sb x0, 0(t4)
-    addi t4, t4, 1
+    sd x0, 0(t4)
+    addi t4, t4, 8
     j zero_bss_loop
 zero_bss_done:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,3 +229,11 @@ pub const BENCHMARK_NB_FIRMWARE_EXITS: bool = is_enabled!("MIRALIS_BENCHMARK_NB_
 
 /// Whether count or not number of world switches
 pub const BENCHMARK_WORLD_SWITCHES: bool = is_enabled!("MIRALIS_BENCHMARK_WORLD_SWITCHES");
+
+/// Start address of Miralis
+pub const PLATFORM_START_ADDRESS: usize =
+    parse_usize_or(option_env!("MIRALIS_PLATFORM_START_ADDRESS"), 0x80000000);
+
+/// Start address of firmware
+pub const PLATFORM_FIRMWARE_ADDRESS: usize =
+    parse_usize_or(option_env!("MIRALIS_PLATFORM_FIRMWARE_ADDRESS"), 0x80200000);

--- a/src/platform/visionfive2.rs
+++ b/src/platform/visionfive2.rs
@@ -8,7 +8,9 @@ use spin::Mutex;
 
 use super::Platform;
 use crate::arch::{Arch, Architecture};
-use crate::config::{PLATFORM_NB_HARTS, PLATFORM_STACK_SIZE};
+use crate::config::{
+    PLATFORM_FIRMWARE_ADDRESS, PLATFORM_NB_HARTS, PLATFORM_STACK_SIZE, PLATFORM_START_ADDRESS,
+};
 use crate::device::{self, VirtClint};
 use crate::driver::ClintDriver;
 use crate::{_stack_start, _start_address};
@@ -16,8 +18,9 @@ use crate::{_stack_start, _start_address};
 // —————————————————————————— Platform Parameters ——————————————————————————— //
 
 const SERIAL_PORT_BASE_ADDRESS: usize = 0x10000000;
-const MIRALIS_START_ADDR: usize = 0x43000000;
-const FIRMWARE_START_ADDR: usize = 0x40000000;
+const MIRALIS_START_ADDR: usize = PLATFORM_START_ADDRESS;
+const FIRMWARE_START_ADDR: usize = PLATFORM_FIRMWARE_ADDRESS;
+
 const CLINT_BASE: usize = 0x2000000;
 const PRIMARY_HART: usize = 1;
 

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -578,10 +578,18 @@ impl VirtContext {
             _ => {
                 if cause.is_interrupt() {
                     // TODO : For now, only care for MTIP bit
-                    todo!("Other interrupt are not yet implemented {:?}", cause);
+                    todo!(
+                        "Other interrupts are not yet implemented {:?} at {:x}",
+                        cause,
+                        self.trap_info.mepc
+                    );
                 } else {
                     // TODO : Need to match other traps
-                    todo!("Other traps are not yet implemented");
+                    todo!(
+                        "Other traps are not yet implemented {:?} at {:x}",
+                        cause,
+                        self.trap_info.mepc
+                    );
                 }
             }
         }


### PR DESCRIPTION
Tweaked the firmware setup a bit for it to work on the board properly

- *bss sections of firmware are now zeroed-out as well as miralis' sections, fixed symbols' alignment 
- Removed duplicate assignment of firmware and miralis's start addresses (in linker script and in platform definition)
- Added possibility to only build certain firmware for certain configuration, without actually running it as a payload in qemu (useful feature to build firmware for the board). Refs #135?