### PR TITLE
Added option to build with a release profile (on by default)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ opt-level = 3
 
 [profile.release]
 panic = "abort"
+codegen-units = 1
 
 [workspace]
 members = [

--- a/config/example.config.toml
+++ b/config/example.config.toml
@@ -29,8 +29,6 @@ color = true
 # Maximum number of firmware exits before terminating.
 # No maximum cap if not present
 max_firmware_exits = 400
-# Option to compile using release profile (dev profile is set by default)
-debug = false
 
 [vcpu]
 # Enable support for S_mode
@@ -45,14 +43,6 @@ max_pmp = 8
 # Name of the platform (i.e. board) to compile for.
 # Default to "qemu_virt"
 name = "qemu_virt"
-
-# Miralis binary will be compiled with this value as a start address
-# Default to "0x80000000"
-start_address = 0x80000000
-
-# Firmware binary will be compiled with this value as a start address
-# Default to "0x80200000"
-firmware_address = 0x80200000
 
 # Nuber of harts (i.e. cores).
 # Default to 1.
@@ -86,3 +76,19 @@ world_switches = false
 # Number of iterations to be used by benchmark firmware.
 # What is iterated on may vary from one firmware to another.
 nb_iter = 1000
+
+[target.miralis]
+# Build profile for Miralis (dev profile is set by default)
+profile = "dev"
+
+# Miralis binary will be compiled with this value as a start address
+# Default to "0x80000000"
+start_address = 0x80000000
+
+[target.firmware]
+# Build profile for the firmware (dev profile is set by default)
+profile = "dev"
+
+# Firmware binary will be compiled with this value as a start address
+# Default to "0x80200000"
+start_address = 0x80200000

--- a/config/example.config.toml
+++ b/config/example.config.toml
@@ -29,6 +29,8 @@ color = true
 # Maximum number of firmware exits before terminating.
 # No maximum cap if not present
 max_firmware_exits = 400
+# Option to compile using release profile (dev profile is set by default)
+debug = false
 
 [vcpu]
 # Enable support for S_mode

--- a/config/test/qemu-virt-release.toml
+++ b/config/test/qemu-virt-release.toml
@@ -1,0 +1,24 @@
+# A test configuration to run on QEMU virt platform with a release profile
+
+[log]
+level = "info"
+color = true
+
+[debug]
+max_firmware_exits = 2000
+
+[vcpu]
+max_pmp = 8
+
+[platform]
+nb_harts = 1
+stack_size = 0x8000
+
+[benchmark]
+enable = false
+
+[target.miralis]
+profile = "release"
+
+[target.firmware]
+profile = "release"

--- a/config/visionfive2.toml
+++ b/config/visionfive2.toml
@@ -14,8 +14,12 @@ max_pmp = 0
 name = "visionfive2"
 nb_harts = 5
 stack_size = 0x8000
-start_address = 0x43000000
-firmware_address = 0x40000000
 
 [benchmark]
 enable = false
+
+[target.miralis]
+start_address = 0x43000000
+
+[target.firmware]
+start_address = 0x40000000

--- a/firmware/mcause/main.rs
+++ b/firmware/mcause/main.rs
@@ -22,14 +22,14 @@ fn main() -> ! {
 
     read_test(res, 0);
 
-    let secret2: usize = 0x9;
+    let mut secret2: usize;
 
     unsafe {
         asm!(
             "li {0}, 0x9",
             "csrw mcause, {0}",
             "csrr {1}, mcause",
-            in(reg) secret2,
+            out(reg) secret2,
             out(reg) res,
         );
     }
@@ -41,7 +41,7 @@ fn main() -> ! {
             "li {0}, 0x8000000000000009",
             "csrw mcause, {0}",
             "csrr {1}, mcause",
-            in(reg) secret2,
+            out(reg) secret2,
             out(reg) res,
         );
     }

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 default          := "default"
+config           := "config.toml"
 benchmark        := "ecall_benchmark"
 qemu_virt        := "./config/test/qemu-virt.toml"
 qemu_virt_2harts := "./config/test/qemu-virt.toml"
@@ -51,22 +52,22 @@ test:
 	cargo run --package runner -- run --config {{qemu_virt_benchmark}} --firmware ecall_benchmark --benchmark
 
 	# Test firmware build
-	just build-firmware {{qemu_virt}} default
+	just build-firmware default {{qemu_virt}}
 
 # Run unit tests
 unit-test:
 	cargo test --features userspace -p miralis
 
 # Run Miralis
-run firmware=default:
-	cargo run --package runner -- run -v --firmware {{firmware}}
+run firmware=default config=config:
+	cargo run --package runner -- run -v --config {{config}} --firmware {{firmware}} 
 
 # Build Miralis with the provided config
 build config:
 	cargo run --package runner -- build --config {{config}}
 
 # Build a given firmware with the provided config
-build-firmware config firmware:
+build-firmware firmware config=config:
 	cargo run --package runner -- build -v --config {{config}} --firmware {{firmware}}
 
 # Run Miralis but wait for a debugger to connect

--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ benchmark        := "ecall_benchmark"
 qemu_virt        := "./config/test/qemu-virt.toml"
 qemu_virt_2harts := "./config/test/qemu-virt.toml"
 qemu_virt_benchmark := "./config/test/qemu-virt-benchmark.toml"
+qemu_virt_release := "./config/test/qemu-virt-release.toml"
 benchmark_folder := "./benchmark-out"
 default_iterations := "1"
 
@@ -42,6 +43,7 @@ test:
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware sandbox
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware interrupt
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware os_ecall
+	cargo run --package runner -- run --config {{qemu_virt_release}} --firmware default
 
 	# Testing with external projects
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware opensbi

--- a/runner/src/config.rs
+++ b/runner/src/config.rs
@@ -45,6 +45,7 @@ pub struct Log {
 #[serde(deny_unknown_fields)]
 pub struct Debug {
     pub max_firmware_exits: Option<usize>,
+    pub debug: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Default)]

--- a/runner/src/gdb.rs
+++ b/runner/src/gdb.rs
@@ -5,8 +5,8 @@
 use std::io;
 use std::process::{exit, Command, Stdio};
 
-use crate::artifacts::{Mode, Target};
-use crate::config::read_config;
+use crate::artifacts::Target;
+use crate::config::{read_config, Profiles};
 use crate::path::get_target_dir_path;
 use crate::GdbArgs;
 
@@ -25,7 +25,7 @@ static GDB_EXECUTABLES: &[&'static str] = &[
 ///
 /// GDB can be distributed under different names, depending on the available targets, hence the
 /// need for such a function.
-fn build_gdb_command(gdb_executable: &str, mode: Mode) -> Command {
+fn build_gdb_command(gdb_executable: &str, mode: Profiles) -> Command {
     // Retrieve the path of Miralis's binary
     let mut miralis_path = get_target_dir_path(&Target::Miralis, mode);
     miralis_path.push("miralis");
@@ -45,7 +45,8 @@ fn build_gdb_command(gdb_executable: &str, mode: Mode) -> Command {
 /// Start a GDB session
 pub fn gdb(args: &GdbArgs) -> ! {
     let cfg = read_config(&args.config);
-    let mode = Mode::from_bool(cfg.debug.debug.unwrap_or(true));
+    let mode = cfg.target.miralis.profile.unwrap_or_default();
+
     for gdb in GDB_EXECUTABLES {
         let mut gdb_cmd = build_gdb_command(gdb, mode);
         match gdb_cmd.output() {

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -74,7 +74,11 @@ struct CheckConfigArgs {
 }
 
 #[derive(Args)]
-struct GdbArgs {}
+struct GdbArgs {
+    #[arg(long)]
+    /// Path to the configuration file to use
+    config: Option<PathBuf>,
+}
 
 // —————————————————————————————— Entry Point ——————————————————————————————— //
 

--- a/runner/src/path.rs
+++ b/runner/src/path.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use crate::artifacts::{Target, FIRMWARE_TARGET, MIRALIS_TARGET};
+use crate::artifacts::{Mode, Target, FIRMWARE_TARGET, MIRALIS_TARGET};
 
 /// Return the root of the workspace.
 pub fn get_workspace_path() -> PathBuf {
@@ -15,14 +15,22 @@ pub fn get_workspace_path() -> PathBuf {
 }
 
 /// Return the target directory.
-pub fn get_target_dir_path(target: &Target) -> PathBuf {
+pub fn get_target_dir_path(target: &Target, mode: Mode) -> PathBuf {
     let mut path = get_workspace_path();
     path.push("target");
     match target {
         Target::Miralis => path.push(MIRALIS_TARGET),
         Target::Firmware(_) => path.push(FIRMWARE_TARGET),
     }
-    path.push("debug"); // TODO: add support for release mode
+    match mode {
+        Mode::Debug => {
+            path.push("debug");
+        }
+        Mode::Release => {
+            path.push("release");
+        }
+    }
+
     path
 }
 

--- a/runner/src/path.rs
+++ b/runner/src/path.rs
@@ -3,7 +3,8 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use crate::artifacts::{Mode, Target, FIRMWARE_TARGET, MIRALIS_TARGET};
+use crate::artifacts::{Target, FIRMWARE_TARGET, MIRALIS_TARGET};
+use crate::config::Profiles;
 
 /// Return the root of the workspace.
 pub fn get_workspace_path() -> PathBuf {
@@ -15,7 +16,7 @@ pub fn get_workspace_path() -> PathBuf {
 }
 
 /// Return the target directory.
-pub fn get_target_dir_path(target: &Target, mode: Mode) -> PathBuf {
+pub fn get_target_dir_path(target: &Target, mode: Profiles) -> PathBuf {
     let mut path = get_workspace_path();
     path.push("target");
     match target {
@@ -23,10 +24,10 @@ pub fn get_target_dir_path(target: &Target, mode: Mode) -> PathBuf {
         Target::Firmware(_) => path.push(FIRMWARE_TARGET),
     }
     match mode {
-        Mode::Debug => {
+        Profiles::Debug => {
             path.push("debug");
         }
-        Mode::Release => {
+        Profiles::Release => {
             path.push("release");
         }
     }

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -1090,10 +1090,6 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
             }
             Csr::Mcause => {
                 let cause = MCause::new(value);
-                if cause.is_interrupt() {
-                    // TODO : does not support interrupts
-                    return;
-                }
                 match cause {
                     // Can only contain supported exception codes
                     MCause::UnknownException => (),


### PR DESCRIPTION
- Release-mode build is a default mode for building miralis and firmware.
- You can enable debug mode (dev profile) by setting `debug_compile = true` in the corresponding config.toml file.
- Release profile builds in a `release` folder instead of `debug`.
- Release profile enables all avaliable runtime optimizations, which may increase build times.
- There was an issue with Mcause firmware failing some assert checks with `incremental = false` (default option for release), so for now we explicitly set `incremental = true`. It affects the size of the binary a bit (~2kb).
- In debug mode the resulting `miralis.img` file weights _76272_ byes, in release mode it's _58416_.
- There is a question to what extent should we optimize the release build (e.g. should we strip symbols from the executables?).

Execution times for default firmware on QEMU (just as a rough estimate) :

Release:
```
real    0m0.109s
user    0m0.070s
sys     0m0.037s
```
Debug:
```
real    0m0.121s
user    0m0.074s
sys     0m0.045s
```

