### PR TITLE
Improved Stack Size Configuration for Firmware

### DIFF
--- a/config/example.config.toml
+++ b/config/example.config.toml
@@ -48,10 +48,6 @@ name = "qemu_virt"
 # Default to 1.
 nb_harts = 1
 
-# Size of the stack for each hart (i.e. core)
-# Default to 0x8000
-stack_size = 0x8000
-
 # Enable benchmark code and logs. Logs can then be collected to 
 # analyze a run of the program.
 [benchmark]
@@ -85,6 +81,10 @@ profile = "dev"
 # Default to "0x80000000"
 start_address = 0x80000000
 
+# Size of the Miralis' stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000
+
 [target.firmware]
 # Build profile for the firmware (dev profile is set by default)
 profile = "dev"
@@ -92,3 +92,7 @@ profile = "dev"
 # Firmware binary will be compiled with this value as a start address
 # Default to "0x80200000"
 start_address = 0x80200000
+
+# Size of the firmware stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000

--- a/config/qemu-virt-benchmark.toml
+++ b/config/qemu-virt-benchmark.toml
@@ -12,7 +12,6 @@ max_pmp = 8
 
 [platform]
 nb_harts = 1
-stack_size = 0x8000
 
 [benchmark]
 enable = true

--- a/config/qemu-virt.toml
+++ b/config/qemu-virt.toml
@@ -12,7 +12,6 @@ max_pmp = 8
 
 [platform]
 nb_harts = 1
-stack_size = 0x8000
 
 [benchmark]
 enable = false

--- a/config/test/qemu-virt-2harts.toml
+++ b/config/test/qemu-virt-2harts.toml
@@ -12,7 +12,6 @@ max_pmp = 8
 
 [platform]
 nb_harts = 2
-stack_size = 0x8000
 
 [benchmark]
 enable = false

--- a/config/test/qemu-virt-benchmark.toml
+++ b/config/test/qemu-virt-benchmark.toml
@@ -12,7 +12,6 @@ max_pmp = 8
 
 [platform]
 nb_harts = 1
-stack_size = 0x8000
 
 [benchmark]
 enable = true

--- a/config/test/qemu-virt-release.toml
+++ b/config/test/qemu-virt-release.toml
@@ -12,13 +12,13 @@ max_pmp = 8
 
 [platform]
 nb_harts = 1
-stack_size = 0x8000
 
 [benchmark]
 enable = false
 
 [target.miralis]
 profile = "release"
+stack_size = 0x8000
 
 [target.firmware]
 profile = "release"

--- a/config/test/qemu-virt.toml
+++ b/config/test/qemu-virt.toml
@@ -12,7 +12,6 @@ max_pmp = 8
 
 [platform]
 nb_harts = 1
-stack_size = 0x8000
 
 [benchmark]
 enable = false

--- a/config/visionfive2.toml
+++ b/config/visionfive2.toml
@@ -13,13 +13,13 @@ max_pmp = 0
 [platform]
 name = "visionfive2"
 nb_harts = 5
-stack_size = 0x8000
 
 [benchmark]
 enable = false
 
 [target.miralis]
 start_address = 0x43000000
+stack_size = 0x8000
 
 [target.firmware]
 start_address = 0x40000000

--- a/misc/linker-script-firmware.x
+++ b/misc/linker-script-firmware.x
@@ -1,5 +1,3 @@
-STACK_SIZE = 0x8000;
-
 SECTIONS
 {
   /* Start address */
@@ -45,13 +43,7 @@ SECTIONS
 
 
   /* Then we allocate some stack space */
-  .stack : ALIGN(0x1000)
-   {
-      . = ALIGN(8);
-      _stack_bottom = .;
-      . = . + STACK_SIZE;
-      . = ALIGN(8);
-      _stack_top = .;
-   }
+  . = ALIGN(0x1000);
+  _stack_bottom = .;
 }
 

--- a/runner/src/config.rs
+++ b/runner/src/config.rs
@@ -61,7 +61,6 @@ pub struct VCpu {
 pub struct Platform {
     pub name: Option<Platforms>,
     pub nb_harts: Option<usize>,
-    pub stack_size: Option<usize>,
 }
 
 #[derive(Deserialize, Debug, Clone, Copy)]
@@ -96,6 +95,7 @@ pub struct Targets {
 pub struct Target {
     pub profile: Option<Profiles>,
     pub start_address: Option<usize>,
+    pub stack_size: Option<usize>,
 }
 
 #[derive(Deserialize, Debug, Clone, Copy, Default)]
@@ -105,19 +105,6 @@ pub enum Profiles {
     Debug,
     #[serde(rename = "release")]
     Release,
-}
-
-#[derive(Deserialize, Debug, Default, Clone, Copy)]
-#[serde(deny_unknown_fields)]
-pub struct Address {
-    pub miralis: Option<StartAddress>,
-    pub firmware: Option<StartAddress>,
-}
-
-#[derive(Deserialize, Debug, Default, Clone, Copy)]
-#[serde(deny_unknown_fields)]
-pub struct StartAddress {
-    pub start_address: Option<usize>,
 }
 
 // ————————————————————————— Environment Variables —————————————————————————— //
@@ -217,12 +204,6 @@ impl Platform {
                 format!("{}", nb_harts),
             );
         }
-        if let Some(stack_size) = self.stack_size {
-            envs.insert(
-                String::from("MIRALIS_PLATFORM_STACK_SIZE"),
-                format!("{}", stack_size),
-            );
-        }
         envs
     }
 }
@@ -275,13 +256,23 @@ impl Targets {
         let mut envs = HashMap::new();
         let firmware_address = self.firmware.start_address.unwrap_or(0x80200000);
         envs.insert(
-            String::from("MIRALIS_PLATFORM_FIRMWARE_ADDRESS"),
+            String::from("MIRALIS_TARGET_FIRMWARE_ADDRESS"),
             format!("{}", firmware_address),
         );
         let start_address = self.miralis.start_address.unwrap_or(0x80000000);
         envs.insert(
-            String::from("MIRALIS_PLATFORM_START_ADDRESS"),
+            String::from("MIRALIS_TARGET_START_ADDRESS"),
             format!("{}", start_address),
+        );
+        let firmware_stack_size = self.firmware.stack_size.unwrap_or(0x8000);
+        envs.insert(
+            String::from("MIRALIS_TARGET_STACK_SIZE"),
+            format!("{}", firmware_stack_size),
+        );
+        let stack_size = self.miralis.stack_size.unwrap_or(0x8000);
+        envs.insert(
+            String::from("MIRALIS_TARGET_FIRMWARE_STACK_SIZE"),
+            format!("{}", stack_size),
         );
         envs
     }

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -752,7 +752,7 @@ stack_start_loop:
     bgeu t4, t2, stack_start_done
     add t3, t3, t1       // Add space for one more stack
     addi t4, t4, 1       // Increment counter
-    j stack_start_done
+    j stack_start_loop
 
 stack_start_done:
     add t0, t0, t3       // The actual start of our stack

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -5,7 +5,7 @@ use core::{ptr, usize};
 
 use super::{Architecture, Csr, MCause, Mode, RegistersCapability, TrapInfo};
 use crate::arch::{mstatus, HardwareCapability, PmpGroup};
-use crate::config::PLATFORM_STACK_SIZE;
+use crate::config::TARGET_STACK_SIZE;
 use crate::virt::VirtContext;
 use crate::{_bss_start, _bss_stop, _stack_start, main};
 
@@ -807,7 +807,7 @@ __bss_stop:
 //
 // This can be removed once `asm_const` gets stabilized. See:
 // https://github.com/rust-lang/rust/issues/93332
-static STACK_SIZE: usize = PLATFORM_STACK_SIZE;
+static STACK_SIZE: usize = TARGET_STACK_SIZE;
 
 // ————————————————————————————— Context Switch ————————————————————————————— //
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,10 +55,6 @@ pub const PLATFORM_NB_HARTS: usize = {
     }
 };
 
-/// The stack size for each Miralis thread (one per hart).
-pub const PLATFORM_STACK_SIZE: usize =
-    parse_usize_or(option_env!("MIRALIS_PLATFORM_STACK_SIZE"), 0x8000);
-
 /// Whether any benchmark is enable
 pub const BENCHMARK: bool = is_enabled!("MIRALIS_BENCHMARK");
 
@@ -78,9 +74,13 @@ pub const BENCHMARK_NB_FIRMWARE_EXITS: bool = is_enabled!("MIRALIS_BENCHMARK_NB_
 pub const BENCHMARK_WORLD_SWITCHES: bool = is_enabled!("MIRALIS_BENCHMARK_WORLD_SWITCHES");
 
 /// Start address of Miralis
-pub const PLATFORM_START_ADDRESS: usize =
-    parse_usize_or(option_env!("MIRALIS_PLATFORM_START_ADDRESS"), 0x80000000);
+pub const TARGET_START_ADDRESS: usize =
+    parse_usize_or(option_env!("MIRALIS_TARGET_START_ADDRESS"), 0x80000000);
 
 /// Start address of firmware
-pub const PLATFORM_FIRMWARE_ADDRESS: usize =
-    parse_usize_or(option_env!("MIRALIS_PLATFORM_FIRMWARE_ADDRESS"), 0x80200000);
+pub const TARGET_FIRMWARE_ADDRESS: usize =
+    parse_usize_or(option_env!("MIRALIS_TARGET_FIRMWARE_ADDRESS"), 0x80200000);
+
+/// The stack size for each Miralis thread (one per hart)
+pub const TARGET_STACK_SIZE: usize =
+    parse_usize_or(option_env!("MIRALIS_TARGET_STACK_SIZE"), 0x8000);

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -2,7 +2,7 @@
 
 use crate::_stack_start;
 use crate::arch::{Arch, Architecture, Csr};
-use crate::config::PLATFORM_STACK_SIZE;
+use crate::config::TARGET_STACK_SIZE;
 
 // ————————————————————————————— Logging Utils —————————————————————————————— //
 
@@ -72,12 +72,12 @@ pub unsafe fn log_stack_usage() {
     // Get stack usage
     let stack_bottom = (&_stack_start) as *const u8 as usize;
     let hart_id = Arch::read_csr(Csr::Mhartid);
-    let stack_bottom = stack_bottom + hart_id * PLATFORM_STACK_SIZE;
-    let stack_top = stack_bottom + PLATFORM_STACK_SIZE;
+    let stack_bottom = stack_bottom + hart_id * TARGET_STACK_SIZE;
+    let stack_top = stack_bottom + TARGET_STACK_SIZE;
     let max_stack_usage = get_max_stack_usage(stack_top, stack_bottom);
 
     // Compute percentage with one 1 decimal precision
-    let permil = (1000 * max_stack_usage + PLATFORM_STACK_SIZE / 2) / PLATFORM_STACK_SIZE;
+    let permil = (1000 * max_stack_usage + TARGET_STACK_SIZE / 2) / TARGET_STACK_SIZE;
     let percent = permil / 10;
     let decimal = permil % 100;
 

--- a/src/platform/virt.rs
+++ b/src/platform/virt.rs
@@ -8,7 +8,7 @@ use uart_16550::MmioSerialPort;
 
 use super::Platform;
 use crate::config::{
-    PLATFORM_FIRMWARE_ADDRESS, PLATFORM_NB_HARTS, PLATFORM_STACK_SIZE, PLATFORM_START_ADDRESS,
+    PLATFORM_NB_HARTS, TARGET_FIRMWARE_ADDRESS, TARGET_STACK_SIZE, TARGET_START_ADDRESS,
 };
 use crate::device::{self, VirtClint};
 use crate::driver::ClintDriver;
@@ -18,8 +18,8 @@ use crate::{_stack_start, _start_address};
 
 const SERIAL_PORT_BASE_ADDRESS: usize = 0x10000000;
 const TEST_MMIO_ADDRESS: usize = 0x100000;
-const MIRALIS_START_ADDR: usize = PLATFORM_START_ADDRESS;
-const FIRMWARE_START_ADDR: usize = PLATFORM_FIRMWARE_ADDRESS;
+const MIRALIS_START_ADDR: usize = TARGET_START_ADDRESS;
+const FIRMWARE_START_ADDR: usize = TARGET_FIRMWARE_ADDRESS;
 const CLINT_BASE: usize = 0x2000000;
 const PRIMARY_HART: usize = 0;
 
@@ -89,7 +89,7 @@ impl Platform for VirtPlatform {
         unsafe {
             size = (_stack_start as usize)
                 .checked_sub(_start_address as usize)
-                .and_then(|diff| diff.checked_add(PLATFORM_STACK_SIZE * PLATFORM_NB_HARTS))
+                .and_then(|diff| diff.checked_add(TARGET_STACK_SIZE * PLATFORM_NB_HARTS))
                 .unwrap();
         }
 

--- a/src/platform/visionfive2.rs
+++ b/src/platform/visionfive2.rs
@@ -9,7 +9,7 @@ use spin::Mutex;
 use super::Platform;
 use crate::arch::{Arch, Architecture};
 use crate::config::{
-    PLATFORM_FIRMWARE_ADDRESS, PLATFORM_NB_HARTS, PLATFORM_STACK_SIZE, PLATFORM_START_ADDRESS,
+    PLATFORM_NB_HARTS, TARGET_FIRMWARE_ADDRESS, TARGET_STACK_SIZE, TARGET_START_ADDRESS,
 };
 use crate::device::{self, VirtClint};
 use crate::driver::ClintDriver;
@@ -18,8 +18,8 @@ use crate::{_stack_start, _start_address};
 // —————————————————————————— Platform Parameters ——————————————————————————— //
 
 const SERIAL_PORT_BASE_ADDRESS: usize = 0x10000000;
-const MIRALIS_START_ADDR: usize = PLATFORM_START_ADDRESS;
-const FIRMWARE_START_ADDR: usize = PLATFORM_FIRMWARE_ADDRESS;
+const MIRALIS_START_ADDR: usize = TARGET_START_ADDRESS;
+const FIRMWARE_START_ADDR: usize = TARGET_FIRMWARE_ADDRESS;
 
 const CLINT_BASE: usize = 0x2000000;
 const PRIMARY_HART: usize = 1;
@@ -91,7 +91,7 @@ impl Platform for VisionFive2Platform {
         unsafe {
             size = (_stack_start as usize)
                 .checked_sub(_start_address as usize)
-                .and_then(|diff| diff.checked_add(PLATFORM_STACK_SIZE * PLATFORM_NB_HARTS))
+                .and_then(|diff| diff.checked_add(TARGET_STACK_SIZE * PLATFORM_NB_HARTS))
                 .unwrap();
         }
 


### PR DESCRIPTION
Previously, the stack size was defined as a lump value in a linker script, but now a more flexible approach was adopted.
The value is defined per-hart in a config file, similar to how it was done in miralis.

The asm part of stack size configuration is <s>copy pasted</s> heavily inspired by miralis' setup as well.

And since after those changes there were two `stack_size` options in the config file, it was decided to move the  `stack_size` option from `[platform]` section to the accrding `[target]` section, so firmware's per-hart stack size is defined in `[target.firmware]`, and miralis' in `[target.miralis]`.