### PR TITLE
Bugfix: forward signals to GDB on Unix platforms

### DIFF
--- a/runner/src/gdb.rs
+++ b/runner/src/gdb.rs
@@ -2,6 +2,7 @@
 //!
 //! The gdb subcommand launches a GDB session and attach it to a running Miralis instance.
 
+use core::panic;
 use std::io;
 use std::process::{exit, Command, Stdio};
 
@@ -49,6 +50,25 @@ pub fn gdb(args: &GdbArgs) -> ! {
 
     for gdb in GDB_EXECUTABLES {
         let mut gdb_cmd = build_gdb_command(gdb, mode);
+
+        // On Unix systems we can exec into the GDB command, this is a better solution as all
+        // signals will be redirected to GDB rather than being handled by the parent process (i.e.
+        // the runner).
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::process::CommandExt;
+            let err = gdb_cmd.exec();
+            if let io::ErrorKind::NotFound = err.kind() {
+                // This GDB executable is not installed, try another one
+                continue;
+            } else {
+                panic!("Failed to run GDB: {:?}", err);
+            }
+        }
+
+        // On non-unix system we simply spawn a new process. This is not ideal, as the runner won't
+        // relay signals, but it is the best we can do without adding too much complexity.
+        #[allow(unreachable_code)]
         match gdb_cmd.output() {
             Ok(_) => exit(0), // Successfully launched GDB
             Err(err) => {


### PR DESCRIPTION
The runner is responsible for spawning the GDB process, because the GDB command depends on the configuration.
Prior to this patch GDB was spawned as a new process separate from the runner. This has the unfortunate consequences that GDB does not receive signals (most notably Ctrl-C) as they are intercepted by the runner process in the foreground.
To fix this we now start the GDB process with `exec` on Unix platforms, therefore replacing the runner process by a brand new GDB process in the foreground. On non-Unix platforms we keep the old (buggy) behavior for now by simplicity.