### PR TITLE
Add a way to test a config directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "config_helpers",
  "serde",
  "toml",
+ "walkdir",
 ]
 
 [[package]]
@@ -317,6 +318,15 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "sandbox"
@@ -433,6 +443,25 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-sys"

--- a/justfile
+++ b/justfile
@@ -26,10 +26,7 @@ test:
 	cargo fmt --all -- --check
 
 	# Checking configs...
-	cargo run -q --package runner -- check-config ./config/example.config.toml
-	cargo run -q --package runner -- check-config ./config/qemu-virt.toml
-	cargo run -q --package runner -- check-config ./config/visionfive2.toml
-	cargo run -q --package runner -- check-config ./config/qemu-virt-benchmark.toml
+	cargo run -q --package runner -- check-config ./config
 
 	# Running integration tests...
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware ecall

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -9,3 +9,4 @@ serde = { version = "1.0.196", features = ["derive"] }
 toml = "0.8.10"
 benchmark_analyzer = { path = "../benchmark_analyzer" }
 config_helpers = { path = "../crates/config_helpers" }
+walkdir = "2"

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -63,7 +63,7 @@ struct BuildArgs {
 
 #[derive(Args)]
 struct CheckConfigArgs {
-    /// Path to the configuration
+    /// Path to the configuration file or directory
     config: PathBuf,
 }
 


### PR DESCRIPTION
The argument config for the check-config command of the runner can now be the path of a folder. In the latter case, the runner will walk the directory, filter toml file and test them.

Close #148 