### PR TITLE
Initialization of the BSS is done by the boot hart.

### DIFF
--- a/config/example.config.toml
+++ b/config/example.config.toml
@@ -48,6 +48,10 @@ name = "qemu_virt"
 # Default to 1.
 nb_harts = 1
 
+# Id of the boot hart
+# Default to 0
+boot_hart_id = 0
+
 # Enable benchmark code and logs. Logs can then be collected to 
 # analyze a run of the program.
 [benchmark]

--- a/config/qemu-virt-benchmark.toml
+++ b/config/qemu-virt-benchmark.toml
@@ -12,6 +12,7 @@ max_pmp = 8
 
 [platform]
 nb_harts = 1
+boot_hart_id = 0
 
 [benchmark]
 enable = true

--- a/config/qemu-virt.toml
+++ b/config/qemu-virt.toml
@@ -12,6 +12,7 @@ max_pmp = 8
 
 [platform]
 nb_harts = 1
+boot_hart_id = 0
 
 [benchmark]
 enable = false

--- a/config/visionfive2.toml
+++ b/config/visionfive2.toml
@@ -13,6 +13,7 @@ max_pmp = 0
 [platform]
 name = "visionfive2"
 nb_harts = 5
+boot_hart_id = 1
 
 [benchmark]
 enable = false

--- a/runner/src/config.rs
+++ b/runner/src/config.rs
@@ -62,6 +62,7 @@ pub struct VCpu {
 pub struct Platform {
     pub name: Option<Platforms>,
     pub nb_harts: Option<usize>,
+    pub boot_hart_id: Option<usize>,
 }
 
 #[derive(Deserialize, Debug, Clone, Copy)]
@@ -204,6 +205,12 @@ impl Platform {
             envs.insert(
                 String::from("MIRALIS_PLATFORM_NB_HARTS"),
                 format!("{}", nb_harts),
+            );
+        }
+        if let Some(boot_hart_id) = self.boot_hart_id {
+            envs.insert(
+                String::from("MIRALIS_PLATFORM_BOOT_HART_ID"),
+                format!("{}", boot_hart_id),
             );
         }
         envs

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,6 +55,11 @@ pub const PLATFORM_NB_HARTS: usize = {
     }
 };
 
+/// Boot hart id
+#[allow(dead_code)] // Because rust analyzer doesn't understand that it is used in metals.rs
+pub const PLATFORM_BOOT_HART_ID: usize =
+    parse_usize_or(option_env!("MIRALIS_PLATFORM_BOOT_HART_ID"), 0);
+
 /// Whether any benchmark is enable
 pub const BENCHMARK: bool = is_enabled!("MIRALIS_BENCHMARK");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ use userspace_linker_definitions::*;
 
 pub(crate) extern "C" fn main(hart_id: usize, device_tree_blob_addr: usize) -> ! {
     // For now we simply park all the harts other than the boot one
-    if hart_id != Plat::get_primary_hart() {
+    if hart_id != config::PLATFORM_BOOT_HART_ID {
         loop {
             Arch::wfi();
             core::hint::spin_loop();

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -30,9 +30,6 @@ pub trait Platform {
     /// Load the firmware (virtual M-mode software) and return its address.
     fn load_firmware() -> usize;
 
-    // Return the ID of a hart for Miralis's boot
-    fn get_primary_hart() -> usize;
-
     /// Returns the start and size of Miralis's own memory.
     fn get_miralis_memory_start_and_size() -> (usize, usize);
 

--- a/src/platform/virt.rs
+++ b/src/platform/virt.rs
@@ -21,7 +21,6 @@ const TEST_MMIO_ADDRESS: usize = 0x100000;
 const MIRALIS_START_ADDR: usize = TARGET_START_ADDRESS;
 const FIRMWARE_START_ADDR: usize = TARGET_FIRMWARE_ADDRESS;
 const CLINT_BASE: usize = 0x2000000;
-const PRIMARY_HART: usize = 0;
 
 // ———————————————————————————— Platform Devices ———————————————————————————— //
 
@@ -75,10 +74,6 @@ impl Platform for VirtPlatform {
     fn load_firmware() -> usize {
         // We directly load the firmware from QEMU, nothing to do here.
         FIRMWARE_START_ADDR
-    }
-
-    fn get_primary_hart() -> usize {
-        PRIMARY_HART
     }
 
     fn get_miralis_memory_start_and_size() -> (usize, usize) {

--- a/src/platform/visionfive2.rs
+++ b/src/platform/visionfive2.rs
@@ -22,7 +22,6 @@ const MIRALIS_START_ADDR: usize = TARGET_START_ADDRESS;
 const FIRMWARE_START_ADDR: usize = TARGET_FIRMWARE_ADDRESS;
 
 const CLINT_BASE: usize = 0x2000000;
-const PRIMARY_HART: usize = 1;
 
 // ———————————————————————————— Platform Devices ———————————————————————————— //
 
@@ -77,10 +76,6 @@ impl Platform for VisionFive2Platform {
 
     fn load_firmware() -> usize {
         FIRMWARE_START_ADDR
-    }
-
-    fn get_primary_hart() -> usize {
-        PRIMARY_HART
     }
 
     fn get_miralis_memory_start_and_size() -> (usize, usize) {


### PR DESCRIPTION
All other hart wait for the primary hart to initialize the BSS before jumping to main. This avoids race condition on the BSS section, which should be zero.

This is maybe missing a test. How could it be tested ?

Close #151 