### PR TITLE
Add support for vectored mtvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "vectored_mtvec"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "miralis_abi",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "firmware/sandbox",
     "firmware/interrupt",
     "firmware/os_ecall",
+    "firmware/vectored_mtvec",
     "firmware/benchmark/ecall_benchmark",
     "firmware/benchmark/csr_write",
 

--- a/firmware/vectored_mtvec/Cargo.toml
+++ b/firmware/vectored_mtvec/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vectored_mtvec"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "vectored_mtvec"
+path = "main.rs"
+
+[dependencies]
+miralis_abi = { path = "../../crates/abi" }
+log = { workspace = true }

--- a/firmware/vectored_mtvec/main.rs
+++ b/firmware/vectored_mtvec/main.rs
@@ -1,0 +1,103 @@
+#![no_std]
+#![no_main]
+
+use core::arch::{asm, global_asm};
+use core::hint::spin_loop;
+
+use miralis_abi::{failure, setup_binary, success};
+
+setup_binary!(main);
+
+fn main() -> ! {
+    // Set mtvec to vectored mode at base _raw_interrupt_trap_handler
+    // Then produce an interrupt (MTI) to fall inside the vector
+    // The redirection should end in success_trap_handler
+    unsafe {
+        let _raw_interrupt_trap_handler = _raw_interrupt_trap_handler as usize | 0b1;
+
+        asm!(
+            "csrw mtvec, {handler}",       // Setup trap handler
+            "csrw mideleg, 0",
+            "csrs mstatus, {mstatus_mie}", // Enable interrupts (MIE)
+            "csrs mie, {mtie}",            // Enable machine timer interrupt (MTIE)
+            handler = in(reg) _raw_interrupt_trap_handler,
+            mstatus_mie = in(reg) 0x8,
+            mtie = in(reg) 0x80,
+        );
+    }
+
+    // Setup a timer deadline in the past to trap directly
+    set_mtimecmp_future_value();
+
+    for _ in 0..10_000 {
+        spin_loop()
+    }
+
+    // The trap handler should exit, if we reach that point the handler did not do its job
+    log::error!("Firmware didn't trapped!");
+    failure()
+}
+
+// ———————————————————————————— Timer Interrupt ————————————————————————————— //
+
+const CLINT_BASE: usize = 0x2000000;
+const MTIMECMP_OFFSET: usize = 0x4000;
+
+// Set mtimecmp value in the future
+fn set_mtimecmp_future_value() {
+    let future_time = 0;
+
+    let mtimecmp_ptr = (CLINT_BASE + MTIMECMP_OFFSET) as *mut usize; // TODO: add support for different harts
+    unsafe {
+        mtimecmp_ptr.write_volatile(future_time);
+    }
+}
+
+// —————————————————————————————— Trap Handler —————————————————————————————— //
+
+/// This function should be called from the raw trap handler
+extern "C" fn success_trap_handler() {
+    success();
+}
+
+/// This function should be called from the raw trap handler
+extern "C" fn failure_trap_handler() {
+    let mcause: usize;
+    unsafe {
+        asm!(
+            "csrr {mcause}, mcause",
+            mcause = out(reg) mcause,
+        )
+    };
+    log::info!("mcause: ox{:x}", mcause);
+    failure();
+}
+
+// Define your vector table
+global_asm!(
+    r#"
+.text
+.align 4
+.global _raw_interrupt_trap_handler
+_raw_interrupt_trap_handler:
+    j {failure_trap_handler} // 0: User Software Interrupt
+    j {failure_trap_handler} // 1: Supervisor Software Interrupt
+    j {failure_trap_handler} // 2: Reserved
+    j {failure_trap_handler} // 3: Machine Software Interrupt
+    j {failure_trap_handler} // 4: User Timer Interrupt
+    j {failure_trap_handler} // 5: Supervisor Timer Interrupt
+    j {failure_trap_handler} // 6: Reserved
+    j {success_trap_handler} // 7: Machine Timer Interrupt
+    j {failure_trap_handler} // 8: User External Interrupt
+    j {failure_trap_handler} // 9: Supervisor External Interrupt
+    j {failure_trap_handler} // 10: Reserved
+    j {failure_trap_handler} // 11: Machine External Interrupt
+
+"#,
+    failure_trap_handler = sym failure_trap_handler,
+    success_trap_handler = sym success_trap_handler,
+);
+
+extern "C" {
+    fn _raw_interrupt_trap_handler();
+}

--- a/justfile
+++ b/justfile
@@ -42,6 +42,7 @@ test:
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware sandbox
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware interrupt
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware os_ecall
+	cargo run --package runner -- run --config {{qemu_virt}} --firmware vectored_mtvec
 	cargo run --package runner -- run --config {{qemu_virt_release}} --firmware default
 
 	# Testing with Miralis as firmware

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -345,3 +345,31 @@ pub mod mie {
     pub const LCOFIE_OFFSET: usize = 13;
     pub const LCOFIE_FILTER: usize = 0b1 << LCOFIE_OFFSET;
 }
+
+// ———————————————————— Machine Trap-Vector Base-Address ———————————————————— //
+
+#[allow(unused)]
+pub mod mtvec {
+    /// Constant to filter out MODE bits of mtvec
+    pub const MODE_FILTER: usize = 0b11;
+
+    /// Constant to filter out BASE bits of mtvec
+    pub const BASE_FILTER: usize = usize::MAX & !MODE_FILTER;
+
+    /// Privilege modes
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub enum Mode {
+        /// User
+        Direct = 0,
+        /// Machine
+        Vectored = 1,
+    }
+
+    pub fn get_mode(mtvec: usize) -> Mode {
+        match mtvec & MODE_FILTER {
+            0 => Mode::Direct,
+            1 => Mode::Vectored,
+            _ => panic!("Invalid trap-vector mode."),
+        }
+    }
+}

--- a/src/arch/trap.rs
+++ b/src/arch/trap.rs
@@ -48,6 +48,14 @@ impl MCause {
     pub fn is_interrupt(self) -> bool {
         self as usize & INTERRUPT_BIT != 0
     }
+
+    pub fn cause_number(cause: usize) -> usize {
+        if (cause as isize) < 0 {
+            cause ^ INTERRUPT_BIT
+        } else {
+            cause
+        }
+    }
 }
 
 // —————————————————————————————— Conversions ——————————————————————————————— //


### PR DESCRIPTION
Modify a bit `virt.rs` and `mod.rs` to support vectored `mtvec`. 
This is tested with RustSBI and a new test in the firmware folder.

We can probably create a repo for RustSBI and add it to the CI if we want now. #67 

Close #167 
