### PR TITLE
Add RustSBI to the CI.

### DIFF
--- a/config/test/qemu-rustsbi-test-kernel.toml
+++ b/config/test/qemu-rustsbi-test-kernel.toml
@@ -1,0 +1,56 @@
+# A test configuration to run on QEMU virt platform
+
+[log]
+level = "info"
+color = true
+
+[debug]
+max_firmware_exits = 2000
+
+[vcpu]
+max_pmp = 8
+
+[platform]
+nb_harts = 1
+
+[benchmark]
+enable = false
+
+[target.miralis]
+# Build profile for Miralis (dev profile is set by default)
+profile = "dev"
+
+# Miralis binary will be compiled with this value as a start address
+# Default to "0x80000000"
+start_address = 0x80000000
+
+# Size of the Miralis' stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000
+
+[target.firmware]
+# Build profile for the firmware (dev profile is set by default)
+profile = "dev"
+
+# Firmware binary will be compiled with this value as a start address
+# Default to "0x80200000"
+start_address = 0x80200000
+
+# Size of the firmware stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000
+
+[target.payload]
+# Name or path to the payload binary
+name = "rustsbi-test-kernel"
+
+# Build profile for the payload (dev profile is set by default)
+profile = "dev"
+
+# Payload binary will be compiled with this value as a start address
+# Default to "0x80400000"
+start_address = 0x80400000
+
+# Size of the payload stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000

--- a/justfile
+++ b/justfile
@@ -7,6 +7,7 @@ qemu_virt_benchmark := "./config/test/qemu-virt-benchmark.toml"
 qemu_virt_release := "./config/test/qemu-virt-release.toml"
 qemu_virt_hello_world_payload := "./config/test/qemu-virt-hello-world-payload.toml"
 qemu_virt_sifive_u54 := "./config/test/qemu-virt-sifive-u54.toml"
+qemu_virt_rustsbi_test_kernel := "./config/test/qemu-rustsbi-test-kernel.toml"
 benchmark_folder := "./benchmark-out"
 default_iterations := "1"
 
@@ -53,6 +54,7 @@ test:
 	cargo run --package runner -- run --config {{qemu_virt}} --firmware zephyr --max-exits 1000000
 	cargo run --package runner -- run --config {{qemu_virt_hello_world_payload}} --firmware opensbi-jump
 	cargo run --package runner -- run --config {{qemu_virt_sifive_u54}} --firmware linux
+	cargo run --package runner -- run --config {{qemu_virt_rustsbi_test_kernel}} --firmware rustsbi-qemu
 
 	# Test benchmark code
 	cargo run --package runner -- run --config {{qemu_virt_benchmark}} --firmware csr_write

--- a/misc/artifacts.toml
+++ b/misc/artifacts.toml
@@ -29,3 +29,13 @@ repo = "https://github.com/CharlyCst/miralis-artifact-opensbi"
 description = "A Zephyr image which summons two threads that print in round-robin several times before exiting."
 url = "https://github.com/CharlyCst/miralis-artifact-zephyr/releases/download/v0.1.1/zephyr.bin"
 repo = "https://github.com/CharlyCst/miralis-artifact-zephyr"
+
+[bin.rustsbi-qemu]
+description = "A RustSBI image mode for qemu. It is supposed to work in pairs with a test-kenel."
+url = "https://github.com/CharlyCst/miralis-artifact-rustsbi/releases/download/v0.1.3/rustsbi-qemu.bin"
+repo = "https://github.com/CharlyCst/miralis-artifact-rustsbi"
+
+[bin.rustsbi-test-kernel]
+description = "A test-kernel for RustSBI on qemu."
+url = "https://github.com/CharlyCst/miralis-artifact-rustsbi/releases/download/v0.1.3/test-kernel.bin"
+repo = "https://github.com/CharlyCst/miralis-artifact-rustsbi"


### PR DESCRIPTION
Two binaries, that work together, are added. The first one is the [rustsbi](https://github.com/rustsbi/rustsbi-qemu) binary, and the second one is a test-kernel that can be used as a payload with it.

We need to wait for #168 to be merged.

Close #67 