### PR TITLE
Refactored load&store instructions

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -373,3 +373,41 @@ pub mod mtvec {
         }
     }
 }
+
+// ——————————————————————— Width of Access Instructions —————————————————————— //
+
+/// Represents different data widths:
+///  - `Byte`: 8 bits (1 byte)
+///  - `Byte2`: 16 bits (2 bytes)
+///  - `Byte4`: 32 bits (4 bytes)
+///  - `Byte8`: 64 bits (8 bytes)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Width {
+    Byte = 8,
+    Byte2 = 16,
+    Byte4 = 32,
+    Byte8 = 64,
+}
+
+impl Width {
+    pub fn to_bits(&self) -> usize {
+        *self as usize
+    }
+
+    pub fn to_bytes(&self) -> usize {
+        self.to_bits() / 8
+    }
+}
+
+impl From<usize> for Width {
+    fn from(value: usize) -> Self {
+        match value {
+            8 => Width::Byte,
+            16 => Width::Byte2,
+            32 => Width::Byte4,
+            64 => Width::Byte8,
+            _ => panic!("Invalid width value"),
+        }
+    }
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -2,48 +2,10 @@
 
 use spin::Mutex;
 
+use crate::arch::Width;
 use crate::driver::{clint, ClintDriver};
 
 // ———————————————————————————— Virtual Devices ————————————————————————————— //
-
-/// Represents different data widths:
-///  - `Byte`: 8 bits (1 byte)
-///  - `Byte2`: 16 bits (2 bytes)
-///  - `Byte4`: 32 bits (4 bytes)
-///  - `Byte8`: 64 bits (8 bytes)
-pub enum Width {
-    Byte = 8,
-    Byte2 = 16,
-    Byte4 = 32,
-    Byte8 = 64,
-}
-
-impl Width {
-    pub fn to_bits(&self) -> usize {
-        match self {
-            Width::Byte => 8,
-            Width::Byte2 => 16,
-            Width::Byte4 => 32,
-            Width::Byte8 => 64,
-        }
-    }
-
-    pub fn to_bytes(&self) -> usize {
-        self.to_bits() / 8
-    }
-}
-
-impl From<usize> for Width {
-    fn from(value: usize) -> Self {
-        match value {
-            8 => Width::Byte,
-            16 => Width::Byte2,
-            32 => Width::Byte4,
-            64 => Width::Byte8,
-            _ => panic!("Invalid width value"),
-        }
-    }
-}
 
 /// Represents a virtual memory-mapped device
 pub struct VirtDevice {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -5,7 +5,7 @@ use core::ptr;
 use crate::config::{self, PLATFORM_NB_HARTS};
 
 pub mod clint {
-    use crate::device::Width;
+    use crate::arch::Width;
 
     pub const MSIP_OFFSET: usize = 0x0;
     pub const MTIMECMP_OFFSET: usize = 0x4000;


### PR DESCRIPTION
**Summary**

Previously, our codebase was suboptimal for the organization of load and store instructions. Each ISA instruction had its own separate enum field, resulting in redundancy and maintenance challenges. However, many load and store instructions share their meaningful fields.

**Key Changes**

- Common Structure: By identifying a common structure for load and store instructions, it was possible to reduce the number of enum variants—from 12 down to just 2. This streamlined approach ensures scalability even if we decide to add support for floating-point or double-precision load and store instructions in the future.
- Refactored Handlers: Sequentially refactored the handlers for load and store operations, consolidating them into just 2 functions. This reduction in repetition simplifies the codebase and improves maintainability.
- Unsigned Load Support: Adding support for unsigned loads became trivial after these changes, so i decided to leave it on the same branch.