### PR TITLE
Decode `sfence.vma` with registers

### DIFF
--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -370,8 +370,29 @@ impl Architecture for MetalArch {
         );
     }
 
-    unsafe fn sfence_vma() {
-        asm!("sfence.vma")
+    unsafe fn sfence_vma(vaddr: Option<usize>, asid: Option<usize>) {
+        match (vaddr, asid) {
+            (None, None) => asm!("sfence.vma"),
+            (None, Some(asid)) => {
+                asm!(
+                    "sfence.vma x0, {asid}",
+                    asid = in(reg) asid,
+                )
+            }
+            (Some(vaddr), None) => {
+                asm!(
+                    "sfence.vma {vaddr}, x0",
+                    vaddr = in(reg) vaddr
+                )
+            }
+            (Some(vaddr), Some(asid)) => {
+                asm!(
+                    "sfence.vma {vaddr}, {asid}",
+                    vaddr = in(reg) vaddr,
+                    asid = in(reg) asid
+                )
+            }
+        }
     }
 
     unsafe fn clear_csr_bits(csr: Csr, bits_mask: usize) {

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -48,7 +48,7 @@ pub trait Architecture {
     unsafe fn set_csr_bits(csr: Csr, bits_mask: usize);
     unsafe fn set_mpp(mode: Mode);
     unsafe fn write_pmp(pmp: &PmpGroup);
-    unsafe fn sfence_vma();
+    unsafe fn sfence_vma(vaddr: Option<usize>, asid: Option<usize>);
     unsafe fn run_vcpu(ctx: &mut VirtContext);
 
     /// Wait for interrupt

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -75,7 +75,7 @@ impl Architecture for HostArch {
         instr as usize
     }
 
-    unsafe fn sfence_vma() {
+    unsafe fn sfence_vma(_vaddr: Option<usize>, _asid: Option<usize>) {
         log::debug!("Userspace sfence.vma");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,7 @@ pub(crate) extern "C" fn main(_hart_id: usize, device_tree_blob_addr: usize) -> 
         Arch::set_mpp(arch::Mode::U);
         // Update the PMPs prior to first entry
         Arch::write_pmp(&mctx.pmp);
-        Arch::sfence_vma();
+        Arch::sfence_vma(None, None);
         // Initialize `medeleg` to ensure all exceptions trap to Miralis
         Arch::write_csr(Csr::Medeleg, 0);
 


### PR DESCRIPTION
According to specification, `sfence.vma` can be used with registers. (https://riscv-software-src.github.io/riscv-unified-db/html/generic_rv64/insts/sfence.vma.html)

The decoder need then to be modified to handle this kind of `sfence.vma`.

Close #172 