### PR TITLE
Automatically collect statistics when pushing on main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [ "main", "ci" ]
   pull_request:
     branches: [ "main", "ci" ]
 

--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -1,0 +1,40 @@
+name: Push Stats
+
+on:
+  push:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  Miralis:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: --deny warnings
+    steps:
+      # Checkout the Miralis repository
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }} # Ignore automatic merge commit
+      # Checkout the Miralis stats repository 
+    - uses: actions/checkout@v4
+      with:
+        repository: 'CharlyCst/miralis-commit-stats'
+        token: '${{ secrets.MIRALIS_STATS_REPO }}'
+        path: 'stats'
+    - uses: extractions/setup-just@v2 # Install `just`
+    - name: Setup Toolchain
+      run: just install-toolchain
+    - name: Push stats
+      shell: bash
+      run: |
+        ./misc/push_stats.sh --commit
+        cd stats
+        git config user.name "Miralis Bot"
+        git config user.email "<>"
+        git add .
+        git commit -m "[Automated] push stats from Miralis CI"
+        git push
+
+

--- a/misc/push_stats.sh
+++ b/misc/push_stats.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# This script pushes statistics from the current commit into a separate repository.
+# It is meant to execute in the CI after a successful merge and assumes it runs on a GNU-flavored Linux system.
+
+miralis_stats_repo_path="stats"
+miralis_stats_file="stats.csv"
+miralis_stats_csv_path="$miralis_stats_repo_path/$miralis_stats_file"
+if [ ! -f "$miralis_stats_csv_path" ]; then
+    echo "CSV stats file '$miralis_stats_csv_path' not found!"
+    exit 1
+fi
+
+release_config="./config/test/qemu-virt-release.toml"
+if [ ! -f "$release_config" ]; then
+    echo "Config file '$release_config' not found!"
+    exit 1
+fi
+
+# ———————————————————————————————— Git commit ———————————————————————————————— #
+
+git_commit="$(git rev-parse HEAD)"
+
+# ——————————————————————————————————— Date ——————————————————————————————————— #
+
+current_date="$(date +"%Y-%m-%d")"
+
+# ——————————————————————————————— Miralis size ——————————————————————————————— #
+
+# First we build Miralis in release mode
+start=`date +%s.%N`
+miralis_img_path="$(just build $release_config | tail -n 1)"
+end=`date +%s.%N`
+build_time=$(echo $end - $start | bc)
+
+# Then we get the size of the image
+if [ "$(uname)" == "Darwin" ]; then
+    # MacOS
+    miralis_size="$(stat -f %z $miralis_img_path)"
+else
+    # Linux
+    miralis_size="$(stat --format=%s $miralis_img_path)"
+fi
+
+# ———————————————————————————————— Push stats ———————————————————————————————— #
+
+echo "Commit: $git_commit"
+echo "Current date: $current_date"
+echo "Miralis size: $miralis_size bytes"
+echo "Build time: $build_time"
+
+if [ "$1" = "--commit" ]; then
+    csv_entry="$git_commit, $current_date, $miralis_size, $build_time"
+    echo $csv_entry >> "$miralis_stats_csv_path"
+    echo "Added CSV entry to $miralis_stats_csv_path"
+fi


### PR DESCRIPTION
This commit adds a new github workflow that runs when pushing commits on main. The workflow collects statistics about Miralis, for now binary size and cold build time, and pushes them to another repository (https://github.com/CharlyCst/miralis-commit-stats).

The current implementation is a bit fragile, it is kind of hard to write a somewhat portable and robust bash script. Because the script is not portable enough it is not tested in the main CI, maybe at some point we will want to integrate this functionality into the runner.