### PR TITLE
Add runner command to list artifact

### DIFF
--- a/runner/src/artifacts.rs
+++ b/runner/src/artifacts.rs
@@ -16,6 +16,7 @@ use crate::path::{
     get_artifact_manifest_path, get_artifacts_path, get_target_config_path, get_target_dir_path,
     get_workspace_path, is_older,
 };
+use crate::ArtifactArgs;
 
 // —————————————————————————— Target & Build Info ——————————————————————————— //
 
@@ -60,10 +61,8 @@ struct ArtifactManifest {
 #[derive(Deserialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 struct Bin {
-    #[allow(dead_code)] // TODO: remove when eventually used
     description: Option<String>,
     url: Option<String>,
-    #[allow(dead_code)] // TODO: remove when eventually used
     repo: Option<String>,
 }
 
@@ -360,4 +359,34 @@ pub fn download_artifact(name: &str, url: &str) -> PathBuf {
     }
 
     artifact
+}
+
+// ————————————————————————————— List artifacts ————————————————————————————— //
+
+pub fn list_artifacts(args: &ArtifactArgs) {
+    // Collect and sort the artifacts
+    let manifest = read_artifact_manifest();
+    let mut artifacts: Vec<(&String, &Bin)> = manifest.bin.iter().collect();
+    artifacts.sort_by_key(|(name, _)| *name);
+
+    // Display the list
+    for (name, metadata) in artifacts {
+        if args.markdown {
+            // Print as markdown
+            println!("## {}\n", name);
+            if let Some(ref desc) = metadata.description {
+                println!("{}", desc);
+            }
+            if let Some(ref url) = metadata.url {
+                println!("- [Download link]({})", url);
+            }
+            if let Some(ref repo) = metadata.repo {
+                println!("- [Source repository]({})", repo)
+            }
+            println!("");
+        } else {
+            // Otherwise simply print the name
+            println!("{}", name)
+        }
+    }
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -27,6 +27,8 @@ enum Subcommands {
     CheckConfig(CheckConfigArgs),
     /// Start GDB and connect to a running instance
     Gdb(GdbArgs),
+    /// List the artifacts
+    Artifact(ArtifactArgs),
 }
 
 #[derive(Args)]
@@ -74,6 +76,13 @@ struct GdbArgs {
     config: Option<PathBuf>,
 }
 
+#[derive(Args)]
+struct ArtifactArgs {
+    #[arg(long, action)]
+    /// Print the list of artifacts in markdown format
+    markdown: bool,
+}
+
 // —————————————————————————————— Entry Point ——————————————————————————————— //
 
 fn main() {
@@ -83,5 +92,6 @@ fn main() {
         Subcommands::Build(args) => build::build(&args),
         Subcommands::Gdb(args) => gdb::gdb(&args),
         Subcommands::CheckConfig(args) => config::check_config(&args),
+        Subcommands::Artifact(args) => artifacts::list_artifacts(&args),
     };
 }


### PR DESCRIPTION
This patch adds a new `artifact` command to the runner that lists the available artifacts. The command takes an optional `--markdown` argument that prints the list of artifacts plus their description and metadata in markdown. The markdown output is intended for auto-generating documentation, which we will use in the Miralis website.