### PR TITLE
Fix for issue #182 on the VisionFive2 board

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -137,8 +137,6 @@ pub(crate) extern "C" fn main(_hart_id: usize, device_tree_blob_addr: usize) -> 
         // Update the PMPs prior to first entry
         Arch::write_pmp(&mctx.pmp);
         Arch::sfence_vma(None, None);
-        // Initialize `medeleg` to ensure all exceptions trap to Miralis
-        Arch::write_csr(Csr::Medeleg, 0);
 
         // Configure the firmware context
         ctx.set(Register::X10, hart_id);


### PR DESCRIPTION
The value of physical satp was non-zero on some harts, so firmware in u-mode tried to interpret physical address as virtual on some non-priveleged instructions 
Now we preventively set physical satp to 0 on the board, so that whatever board's spl does with satp before miralis - won't pose an issue
Also moved initial csr setup to architecture init() to clean up code a bit