### PR TITLE
Fix to #184, installing the trap handler first

### DIFF
--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -23,13 +23,13 @@ impl MetalArch {
 
 impl Architecture for MetalArch {
     fn init() {
+        // Install trap handler
+        Self::install_handler(_raw_trap_handler as usize);
         // Initialize `medeleg` to ensure all exceptions trap to Miralis
         unsafe { Arch::write_csr(Csr::Medeleg, 0) };
         // Ensure that there are no PT set, so that firmware in U-mode
         // Wouldn't try to read physical address as virtual (with jump, for example)
         unsafe { Arch::write_csr(Csr::Satp, 0) };
-        // Install trap handler
-        Self::install_handler(_raw_trap_handler as usize);
     }
 
     #[inline]


### PR DESCRIPTION
We should install our trap handler before trying to execute any priveleged instructions, otherwise the trap will go into the SPL's trap handler (with the vs2 board, at least), which would just termitate the execution like:

```
[Unhandled exception: Illegal instruction
EPC: 000000043000fce RA: 000000004300773c TVAL: 0[000000030259673

SP:  000000004301c520 GP: 3 000000000816fb40 TP:  0000000000000000
T0:  00000000000000e0 T1:  000000004300126c T2:  ;0000000010000000
S0:  000000000816faa0 S1:  10000000043014c88 A0:  00000000430001c0
A1:  m0000000000000000 A2:  000000004300fec8 A3:  00W00000000000000
A4:  0000000000000000 A5:  00a0000004300895e A6:  ffffffffffef0000
A7:  00r00000000110000 S2:  0000000043000000 S3:  fffnfffffdeadbeef
S4:  000000000816faa0 S5:  000000000000008 S6:  000000000816fa9c
S7:  000[00000080146a8 S8:  0000000008014690 S9:  0000000000816fa78
S10: 0000000000000000 S11: 00000m00000000000 T3:  000000000000d800
T4:  fffff fffffef0800 T5:  00000000000f4240 T6:  000000 0000000000

Code: 8082 8082 7139 1517 0001 |3503 1445 4581 (9673 3025)

reset not supported yet
### ERROR ### Pleases RESET the board ###
```

In PR #184 it wasn't accounted for, so commit 99d039add34db65d5be30609d5468bfef39f0fe4 temporarily breaks the vs2 build.