### PR TITLE
Set runner as the default package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,33 +1,9 @@
-[package]
-name = "miralis"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-uart_16550 = "0.3.0"
-spin = "0.5.2"
-log = { workspace = true }
-miralis_core = { path = "crates/core" }
-miralis_abi = { path = "crates/abi" }
-config_helpers = { path = "crates/config_helpers" }
-
-[features]
-# When running on host architecture as a userspace application, such as when
-# running unit tests.
-userspace = []
-platform_visionfive2 = []
-platform_miralis = []
-
-[profile.dev]
-panic = "abort"
-opt-level = 3
-
-[profile.release]
-panic = "abort"
-codegen-units = 1
-
 [workspace]
+resolver = "2"
 members = [
+    # The Miralis sources
+    "src",
+
     # Firmware
     "firmware/csr_ops",
     "firmware/default",
@@ -59,5 +35,18 @@ members = [
     "benchmark_analyzer",
 ]
 
+# Setting the runner as the default member makes it easier to invoke (no need
+# for `--package runner`)
+default-members = ["runner"]
+
 [workspace.dependencies]
 log = "0.4.17"
+
+[profile.dev]
+panic = "abort"
+opt-level = 3
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+

--- a/justfile
+++ b/justfile
@@ -29,37 +29,37 @@ test:
 	cargo fmt --all -- --check
 
 	# Checking configs...
-	cargo run -q --package runner -- check-config ./config
+	cargo run -q -- check-config ./config
 
 	# Running integration tests...
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware ecall
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware csr_ops
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware pmp
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware breakpoint
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware mepc
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware mcause
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware mret
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware os_ctx_switch
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware sandbox
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware interrupt
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware os_ecall
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware vectored_mtvec
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware device
-	cargo run --package runner -- run --config {{qemu_virt_release}} --firmware default
+	cargo run -- run --config {{qemu_virt}} --firmware ecall
+	cargo run -- run --config {{qemu_virt}} --firmware csr_ops
+	cargo run -- run --config {{qemu_virt}} --firmware pmp
+	cargo run -- run --config {{qemu_virt}} --firmware breakpoint
+	cargo run -- run --config {{qemu_virt}} --firmware mepc
+	cargo run -- run --config {{qemu_virt}} --firmware mcause
+	cargo run -- run --config {{qemu_virt}} --firmware mret
+	cargo run -- run --config {{qemu_virt}} --firmware os_ctx_switch
+	cargo run -- run --config {{qemu_virt}} --firmware sandbox
+	cargo run -- run --config {{qemu_virt}} --firmware interrupt
+	cargo run -- run --config {{qemu_virt}} --firmware os_ecall
+	cargo run -- run --config {{qemu_virt}} --firmware vectored_mtvec
+	cargo run -- run --config {{qemu_virt}} --firmware device
+	cargo run -- run --config {{qemu_virt_release}} --firmware default
 
 	# Testing with Miralis as firmware
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware miralis
+	cargo run -- run --config {{qemu_virt}} --firmware miralis
 
 	# Testing with external projects
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware opensbi
-	cargo run --package runner -- run --config {{qemu_virt}} --firmware zephyr --max-exits 1000000
-	cargo run --package runner -- run --config {{qemu_virt_hello_world_payload}} --firmware opensbi-jump
-	cargo run --package runner -- run --config {{qemu_virt_sifive_u54}} --firmware linux
-	cargo run --package runner -- run --config {{qemu_virt_rustsbi_test_kernel}} --firmware rustsbi-qemu
+	cargo run -- run --config {{qemu_virt}} --firmware opensbi
+	cargo run -- run --config {{qemu_virt}} --firmware zephyr --max-exits 1000000
+	cargo run -- run --config {{qemu_virt_hello_world_payload}} --firmware opensbi-jump
+	cargo run -- run --config {{qemu_virt_sifive_u54}} --firmware linux
+	cargo run -- run --config {{qemu_virt_rustsbi_test_kernel}} --firmware rustsbi-qemu
 
 	# Test benchmark code
-	cargo run --package runner -- run --config {{qemu_virt_benchmark}} --firmware csr_write
-	cargo run --package runner -- run --config {{qemu_virt_benchmark}} --firmware ecall_benchmark
+	cargo run -- run --config {{qemu_virt_benchmark}} --firmware csr_write
+	cargo run -- run --config {{qemu_virt_benchmark}} --firmware ecall_benchmark
 
 	# Test firmware build
 	just build-firmware default {{qemu_virt}}
@@ -70,23 +70,23 @@ unit-test:
 
 # Run Miralis
 run firmware=default config=config:
-	cargo run --package runner -- run -v --config {{config}} --firmware {{firmware}}
+	cargo run -- run -v --config {{config}} --firmware {{firmware}}
 
 # Build Miralis with the provided config
 build config:
-	cargo run --package runner -- build --config {{config}}
+	cargo run -- build --config {{config}}
 
 # Build a given firmware with the provided config
 build-firmware firmware config=config:
-	cargo run --package runner -- build -v --config {{config}} --firmware {{firmware}}
+	cargo run -- build -v --config {{config}} --firmware {{firmware}}
 
 # Run Miralis but wait for a debugger to connect
 debug firmware=default:
-	cargo run --package runner -- run -v --firmware {{firmware}} --debug --stop
+	cargo run -- run -v --firmware {{firmware}} --debug --stop
 
 # Connect a debugger to a running Miralis instance
 gdb:
-	cargo run --package runner -- gdb
+	cargo run -- gdb
 
 # Install the rust toolchain and required components
 install-toolchain:

--- a/runner/src/artifacts.rs
+++ b/runner/src/artifacts.rs
@@ -241,6 +241,7 @@ pub fn build_target(target: Target, cfg: &Config) -> PathBuf {
             // Linker arguments
             let start_address = cfg.target.miralis.start_address.unwrap_or(0x80000000);
             let linker_args = format!("-C link-arg=-Tmisc/linker-script.x -C link-arg=--defsym=_start_address={start_address}");
+            build_cmd.arg("--package").arg("miralis");
             build_cmd.env("RUSTFLAGS", linker_args);
 
             // Environment variables
@@ -265,11 +266,10 @@ pub fn build_target(target: Target, cfg: &Config) -> PathBuf {
             build_cmd.env("RUSTFLAGS", linker_args);
             build_cmd.env("IS_TARGET_FIRMWARE", "true");
             build_cmd.envs(cfg.benchmark.build_envs());
+            build_cmd.arg("--package").arg(firmware);
 
             if firmware == "miralis" {
                 build_cmd.arg("--features").arg("platform_miralis");
-            } else {
-                build_cmd.arg("--package").arg(firmware);
             }
         }
 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "miralis"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "miralis"
+path = "main.rs"
+
+[dependencies]
+uart_16550 = "0.3.0"
+spin = "0.5.2"
+log = { workspace = true }
+miralis_core = { path = "../crates/core" }
+miralis_abi = { path = "../crates/abi" }
+config_helpers = { path = "../crates/config_helpers" }
+
+[features]
+# When running on host architecture as a userspace application, such as when
+# running unit tests.
+userspace = []
+platform_visionfive2 = []
+platform_miralis = []
+


### PR DESCRIPTION
This commit sets the runner crate as the default package. This makes it easier to call the runner, as `cargo run --` will invoke the runner directly. Prior to this commit the command was `cargo run -p runner --`, which is arguably not as nice.
As a consequence the justfile can be simplified by removing the now unnecessary `--package runner` flags.

In the future I am thinking about getting rid of the justfile entirely, and directly invoking the runner for all of our need. This would require fixing a few issue, such as stable invocations across the git history, auto-completion, and more test automation, but this would help working around some of the just limitations (such as the lack for named arguments).