### PR TITLE
Add command spike-test

### DIFF
--- a/config/test/qemu-rustsbi-test-kernel-spike.toml
+++ b/config/test/qemu-rustsbi-test-kernel-spike.toml
@@ -1,0 +1,57 @@
+# A test configuration to run on QEMU virt platform
+
+[log]
+level = "info"
+color = true
+
+[debug]
+max_firmware_exits = 2000
+
+[vcpu]
+max_pmp = 8
+
+[platform]
+nb_harts = 1
+name = "spike"
+
+[benchmark]
+enable = false
+
+[target.miralis]
+# Build profile for Miralis (dev profile is set by default)
+profile = "dev"
+
+# Miralis binary will be compiled with this value as a start address
+# Default to "0x80000000"
+start_address = 0x80000000
+
+# Size of the Miralis' stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000
+
+[target.firmware]
+# Build profile for the firmware (dev profile is set by default)
+profile = "dev"
+
+# Firmware binary will be compiled with this value as a start address
+# Default to "0x80200000"
+start_address = 0x80200000
+
+# Size of the firmware stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000
+
+[target.payload]
+# Name or path to the payload binary
+name = "rustsbi-test-kernel"
+
+# Build profile for the payload (dev profile is set by default)
+profile = "dev"
+
+# Payload binary will be compiled with this value as a start address
+# Default to "0x80400000"
+start_address = 0x80400000
+
+# Size of the payload stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000

--- a/config/test/qemu-virt-hello-world-payload-spike.toml
+++ b/config/test/qemu-virt-hello-world-payload-spike.toml
@@ -1,0 +1,57 @@
+# A test configuration to run on QEMU virt platform
+
+[log]
+level = "info"
+color = true
+
+[debug]
+max_firmware_exits = 2000
+
+[vcpu]
+max_pmp = 8
+
+[platform]
+nb_harts = 1
+name = "spike"
+
+[benchmark]
+enable = false
+
+[target.miralis]
+# Build profile for Miralis (dev profile is set by default)
+profile = "dev"
+
+# Miralis binary will be compiled with this value as a start address
+# Default to "0x80000000"
+start_address = 0x80000000
+
+# Size of the Miralis' stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000
+
+[target.firmware]
+# Build profile for the firmware (dev profile is set by default)
+profile = "dev"
+
+# Firmware binary will be compiled with this value as a start address
+# Default to "0x80200000"
+start_address = 0x80200000
+
+# Size of the firmware stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000
+
+[target.payload]
+# Name or path to the payload binary
+name = "hello_world"
+
+# Build profile for the payload (dev profile is set by default)
+profile = "dev"
+
+# Payload binary will be compiled with this value as a start address
+# Default to "0x80400000"
+start_address = 0x80400000
+
+# Size of the payload stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000

--- a/config/test/qemu-virt-sifive-u54-spike.toml
+++ b/config/test/qemu-virt-sifive-u54-spike.toml
@@ -1,0 +1,23 @@
+# A simple configuration to run on QEMU virt platform
+
+[log]
+level = "info"
+color = true
+
+[debug]
+# max_firmware_exits = 2000
+
+[vcpu]
+max_pmp = 8
+
+[platform]
+nb_harts = 1
+boot_hart_id = 0
+name = "spike"
+
+[benchmark]
+enable = false
+
+[qemu]
+machine = "virt"
+cpu = "sifive-u54"

--- a/justfile
+++ b/justfile
@@ -1,13 +1,17 @@
 default          := "default"
 config           := "config.toml"
 benchmark        := "ecall_benchmark"
+spike            := "./config/spike.toml"
 qemu_virt        := "./config/test/qemu-virt.toml"
 qemu_virt_2harts := "./config/test/qemu-virt.toml"
 qemu_virt_benchmark := "./config/test/qemu-virt-benchmark.toml"
 qemu_virt_release := "./config/test/qemu-virt-release.toml"
 qemu_virt_hello_world_payload := "./config/test/qemu-virt-hello-world-payload.toml"
+qemu_virt_hello_world_payload_spike := "./config/test/qemu-virt-hello-world-payload-spike.toml"
 qemu_virt_sifive_u54 := "./config/test/qemu-virt-sifive-u54.toml"
+qemu_virt_sifive_u54_spike := "./config/test/qemu-virt-sifive-u54-spike.toml"
 qemu_virt_rustsbi_test_kernel := "./config/test/qemu-rustsbi-test-kernel.toml"
+qemu_virt_rustsbi_test_kernel_spike := "./config/test/qemu-rustsbi-test-kernel-spike.toml"
 benchmark_folder := "./benchmark-out"
 default_iterations := "1"
 
@@ -63,6 +67,33 @@ test:
 
 	# Test firmware build
 	just build-firmware default {{qemu_virt}}
+
+spike-test:
+	# Running integration tests...
+	cargo run -- run --config {{spike}} --firmware ecall
+	cargo run -- run --config {{spike}} --firmware csr_ops
+	cargo run -- run --config {{spike}} --firmware pmp
+	cargo run -- run --config {{spike}} --firmware breakpoint
+	cargo run -- run --config {{spike}} --firmware mepc
+	cargo run -- run --config {{spike}} --firmware mcause
+	cargo run -- run --config {{spike}} --firmware mret
+	cargo run -- run --config {{spike}} --firmware os_ctx_switch
+	cargo run -- run --config {{spike}} --firmware sandbox
+	cargo run -- run --config {{spike}} --firmware interrupt
+	cargo run -- run --config {{spike}} --firmware os_ecall
+	cargo run -- run --config {{spike}} --firmware vectored_mtvec
+	cargo run -- run --config {{spike}} --firmware device
+	cargo run -- run --config {{spike}} --firmware default
+
+	# Testing with Miralis as firmware
+	cargo run -- run --config {{spike}} --firmware miralis
+
+	# Testing with external projects
+	# cargo run -- run --config {{spike}} --firmware opensbi
+	cargo run -- run --config {{spike}} --firmware zephyr --max-exits 1000000
+	# cargo run -- run --config {{qemu_virt_hello_world_payload_spike}} --firmware opensbi-jump
+	# cargo run -- run --config {{qemu_virt_sifive_u54_spike}} --firmware linux
+	# cargo run -- run --config {{qemu_virt_rustsbi_test_kernel_spike}} --firmware rustsbi-qemu
 
 # Run unit tests
 unit-test:


### PR DESCRIPTION
This commit adds the command spike-test and allow to run tests with the spike simulator. As some firmware still have a few issues with spike, they are commented out at the moment.