### PR TITLE
Add support for policy modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,14 @@ name = "config_helpers"
 version = "0.1.0"
 
 [[package]]
+name = "config_select"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "csr_ops"
 version = "0.1.0"
 dependencies = [
@@ -242,6 +250,7 @@ name = "miralis"
 version = "0.1.0"
 dependencies = [
  "config_helpers",
+ "config_select",
  "log",
  "miralis_abi",
  "miralis_core",
@@ -292,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -394,9 +403,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/abi",
     "crates/core",
     "crates/config_helpers",
+    "crates/config_select",
 
     # Tooling
     "runner",

--- a/config/qemu-keystone.toml
+++ b/config/qemu-keystone.toml
@@ -1,0 +1,18 @@
+# A simple configuration to run on QEMU with the Keystone policy
+
+[log]
+level = "info"
+color = true
+
+[vcpu]
+max_pmp = 8
+
+[platform]
+nb_harts = 1
+boot_hart_id = 0
+
+[benchmark]
+enable = false
+
+[policy]
+name = "keystone"

--- a/crates/config_select/Cargo.toml
+++ b/crates/config_select/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "config_select"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "2.0"
+quote = "1.0"

--- a/crates/config_select/src/lib.rs
+++ b/crates/config_select/src/lib.rs
@@ -1,0 +1,92 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream, Result};
+use syn::{LitStr, Path, Token};
+
+/// A proc macro to select one path based on an environment variable.
+///
+/// Usage:
+///
+/// ```rs
+/// pub type Plat = select_env!["MyEnvVariable":
+///     "value1" => miralis::MiralisPlatform
+///     "value2" => visionfive2::VisionFive2Platform
+///     _        => virt::VirtPlatform
+/// ];
+/// ```
+#[proc_macro]
+pub fn select_env(tokens: TokenStream) -> TokenStream {
+    let select_macro: SelectMacro = syn::parse(tokens).expect("Failed to parse proc maco");
+    let env = std::env::var(&select_macro.env_var).ok();
+
+    // Search for an arm matching the value of the macro
+    if let Some(env) = &env {
+        for arm in &select_macro.arms {
+            let Some(item) = &arm.item else {
+                continue;
+            };
+            if item == env {
+                let target = &arm.target;
+                return TokenStream::from(quote!(#target));
+            }
+        }
+    }
+
+    // Or by default an arm with the '_' pattern
+    if let Some(default_case) = select_macro.arms.iter().find(|arm| arm.item.is_none()) {
+        let target = &default_case.target;
+        return TokenStream::from(quote!(#target));
+    } else {
+        // If no arm matches
+        if let Some(env) = &env {
+            panic!(
+                "Environement variable '{}' has value '{}' which doesn't match any case",
+                &select_macro.env_var, &env
+            );
+        } else {
+            panic!(
+                "Environment variable '{}' is not set, but there is no default case",
+                &select_macro.env_var
+            );
+        }
+    }
+}
+
+struct SelectMacro {
+    env_var: String,
+    arms: Vec<ChoicePair>,
+}
+
+impl Parse for SelectMacro {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let env_var = input.parse::<LitStr>()?;
+        input.parse::<Token![:]>()?;
+        let mut arms = Vec::new();
+        while let Ok(pair) = input.parse::<ChoicePair>() {
+            arms.push(pair);
+        }
+        Ok(Self {
+            env_var: env_var.value(),
+            arms,
+        })
+    }
+}
+
+struct ChoicePair {
+    item: Option<String>,
+    target: syn::Path,
+}
+
+impl Parse for ChoicePair {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let item = if let Ok(_) = input.parse::<Token![_]>() {
+            None
+        } else {
+            Some(input.parse::<LitStr>()?.value())
+        };
+        input.parse::<Token![=>]>()?;
+        let target = input.parse::<Path>()?;
+
+        Ok(ChoicePair { item, target })
+    }
+}

--- a/runner/src/artifacts.rs
+++ b/runner/src/artifacts.rs
@@ -11,7 +11,7 @@ use std::{env, fs};
 
 use serde::Deserialize;
 
-use crate::config::{Config, Platforms, Profiles};
+use crate::config::{Config, Profiles};
 use crate::path::{
     get_artifact_manifest_path, get_artifacts_path, get_target_config_path, get_target_dir_path,
     get_workspace_path, is_older,
@@ -246,18 +246,6 @@ pub fn build_target(target: Target, cfg: &Config) -> PathBuf {
 
             // Environment variables
             build_cmd.envs(cfg.build_envs());
-
-            // Features
-            if let Some(plat) = cfg.platform.name {
-                match plat {
-                    Platforms::QemuVirt | Platforms::Spike => {
-                        // Nothing to do, default platform
-                    }
-                    Platforms::VisionFive2 => {
-                        build_cmd.arg("--features").arg("platform_visionfive2");
-                    }
-                }
-            }
         }
 
         Target::Firmware(ref firmware) => {
@@ -269,7 +257,7 @@ pub fn build_target(target: Target, cfg: &Config) -> PathBuf {
             build_cmd.arg("--package").arg(firmware);
 
             if firmware == "miralis" {
-                build_cmd.arg("--features").arg("platform_miralis");
+                build_cmd.env("MIRALIS_PLATFORM_NAME", "miralis");
             }
         }
 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -14,11 +14,10 @@ log = { workspace = true }
 miralis_core = { path = "../crates/core" }
 miralis_abi = { path = "../crates/abi" }
 config_helpers = { path = "../crates/config_helpers" }
+config_select = { path = "../crates/config_select/" }
 
 [features]
 # When running on host architecture as a userspace application, such as when
 # running unit tests.
 userspace = []
-platform_visionfive2 = []
-platform_miralis = []
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,13 +18,16 @@ mod driver;
 mod host;
 mod logger;
 mod platform;
+mod policy;
 mod utils;
 mod virt;
+
 use arch::pmp::pmpcfg;
 use arch::{pmp, Arch, Architecture};
 use benchmark::{Benchmark, Counter, Scope};
 use config::PLATFORM_NAME;
 use platform::{init, Plat, Platform};
+use policy::{Policy, PolicyModule};
 
 use crate::arch::{misa, Csr, Register};
 use crate::host::MiralisContext;
@@ -66,14 +69,15 @@ pub(crate) extern "C" fn main(_hart_id: usize, device_tree_blob_addr: usize) -> 
     init();
     log::info!("Hello, world!");
     log::info!("Platform name: {}", Plat::name());
+    log::info!("Policy module: {}", Policy::name());
     log::info!("Hart ID: {}", hart_id);
-    log::info!("misa:    0x{:x}", Arch::read_csr(Csr::Misa));
-    log::info!(
+    log::debug!("misa:    0x{:x}", Arch::read_csr(Csr::Misa));
+    log::debug!(
         "vmisa:   0x{:x}",
         Arch::read_csr(Csr::Misa) & !misa::DISABLED
     );
-    log::info!("mstatus: 0x{:x}", Arch::read_csr(Csr::Mstatus));
-    log::info!("DTS address: 0x{:x}", device_tree_blob_addr);
+    log::debug!("mstatus: 0x{:x}", Arch::read_csr(Csr::Mstatus));
+    log::debug!("DTS address: 0x{:x}", device_tree_blob_addr);
 
     log::info!("Preparing jump into firmware");
     let firmware_addr = Plat::load_firmware();

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod virt;
 use arch::pmp::pmpcfg;
 use arch::{pmp, Arch, Architecture};
 use benchmark::{Benchmark, Counter, Scope};
+use config::PLATFORM_NAME;
 use platform::{init, Plat, Platform};
 
 use crate::arch::{misa, Csr, Register};
@@ -152,7 +153,7 @@ pub(crate) extern "C" fn main(_hart_id: usize, device_tree_blob_addr: usize) -> 
     // In case we compile Miralis as firmware, we stop execution at that point for the moment
     // This allows us to run Miralis on top as an integration test for the moment
     // In the future, we plan to run Miralis "as firmware" running a firmware
-    if cfg!(feature = "platform_miralis") {
+    if PLATFORM_NAME == "miralis" {
         log::info!("Successfully initialized Miralis as a firmware");
         Plat::exit_success();
     }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -4,6 +4,7 @@ pub mod visionfive2;
 
 use core::fmt;
 
+use config_select::select_env;
 use log::Level;
 use spin::Mutex;
 
@@ -13,15 +14,15 @@ use crate::driver::ClintDriver;
 use crate::{config, device, logger};
 
 /// Export the current platform.
-/// For now, only QEMU's Virt board is supported
-#[cfg(not(any(feature = "platform_visionfive2", feature = "platform_miralis")))]
-pub type Plat = virt::VirtPlatform;
-
-#[cfg(all(feature = "platform_visionfive2", not(feature = "platform_miralis")))]
-pub type Plat = visionfive2::VisionFive2Platform;
-
-#[cfg(feature = "platform_miralis")]
-pub type Plat = miralis::MiralisPlatform;
+///
+/// We use a custom proc macro that checks the value of an environment variable and select the
+/// appropriate platform accordingly. This makes it possible to avoid adding an ever increasing set
+/// of features and `#[cfg]` guards to select a platform.
+pub type Plat = select_env!["MIRALIS_PLATFORM_NAME":
+    "miralis"     => miralis::MiralisPlatform
+    "visionfive2" => visionfive2::VisionFive2Platform
+    _             => virt::VirtPlatform
+];
 
 pub trait Platform {
     fn name() -> &'static str;

--- a/src/policy/default.rs
+++ b/src/policy/default.rs
@@ -1,0 +1,22 @@
+//! The default policy module, which enforces no policy.
+
+use crate::policy::{PolicyHookResult, PolicyModule};
+use crate::virt::VirtContext;
+
+/// The default policy module, which doesn't enforce any isolation between the firmware and the
+/// rest of the system.
+pub struct DefaultPolicy {}
+
+impl PolicyModule for DefaultPolicy {
+    fn name() -> &'static str {
+        "Default Policy"
+    }
+
+    fn ecall_from_firmware(_ctx: &mut VirtContext) -> PolicyHookResult {
+        PolicyHookResult::Ignore
+    }
+
+    fn ecall_from_payload(_ctx: &mut VirtContext) -> PolicyHookResult {
+        PolicyHookResult::Ignore
+    }
+}

--- a/src/policy/keystone.rs
+++ b/src/policy/keystone.rs
@@ -1,0 +1,38 @@
+//! The Keystone security policy
+//!
+//! This policy module enforces the Keystone policies, i.e. it enables the creation of user-level
+//! enclaves by leveraging PMP for memory isolation.
+
+use crate::arch::Register;
+use crate::policy::{PolicyHookResult, PolicyModule};
+use crate::{RegisterContextGetter, VirtContext};
+
+/// The Keystone FID
+///
+/// See https://github.com/keystone-enclave/keystone/blob/80ffb2f9d4e774965589ee7c67609b0af051dc8b/sdk/include/shared/sm_call.h#L5C47-L5C57
+const KEYSTONE_FID: usize = 0x08424b45;
+
+/// The keystone policy module
+///
+/// See https://keystone-enclave.org/
+pub struct KeystonePolicy {}
+
+impl PolicyModule for KeystonePolicy {
+    fn name() -> &'static str {
+        "Keystone Policy"
+    }
+
+    fn ecall_from_firmware(_ctx: &mut VirtContext) -> PolicyHookResult {
+        PolicyHookResult::Ignore
+    }
+
+    fn ecall_from_payload(ctx: &mut VirtContext) -> PolicyHookResult {
+        let fid = ctx.get(Register::X17);
+        if fid == KEYSTONE_FID {
+            // TODO: do something with the ecall
+            PolicyHookResult::Overwrite
+        } else {
+            PolicyHookResult::Ignore
+        }
+    }
+}

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -1,0 +1,52 @@
+//! Policy Modules
+//!
+//! This modules holds the definitions of policy modules for Miralis.
+
+use config_select::select_env;
+
+use crate::virt::VirtContext;
+
+mod default;
+mod keystone;
+
+pub type Policy = select_env!["MIRALIS_POLICY_NAME":
+    "keystone" => keystone::KeystonePolicy
+    _          => default::DefaultPolicy
+];
+
+/// The result of a call into a policy hook function
+///
+/// A policy module can either overwrite standard Miralis emulation, or ignore an event and let
+/// Miralis perform standard handling of the event. For instance the [DefaultPolicy] module which
+/// does not enforce any restriction will return [PolicyHookResult::Ignore] for most of the policy
+/// hooks.
+#[derive(Debug, Clone, Copy)]
+pub enum PolicyHookResult {
+    /// Signal to Miralis that the policy module already handled the event, no further actions are
+    /// required.
+    Overwrite,
+    /// Signal to Miralis that the policy module did not handle the event, Miralis will proceed
+    /// normally.
+    Ignore,
+}
+
+impl PolicyHookResult {
+    pub fn overwrites(self) -> bool {
+        match self {
+            PolicyHookResult::Overwrite => true,
+            PolicyHookResult::Ignore => false,
+        }
+    }
+}
+
+/// A Miralis firmware isolation policy
+///
+/// By default Miralis does not enforce isolation between the firmware and the rest of the system,
+/// therefore without any policy the firmware is not restricted in any way.
+/// The role of a policy module is to enforce a set of policies on the firmware, for instance
+/// restricting which memory is accessible to the firmware, how which `ecall`s are intercepted.
+pub trait PolicyModule {
+    fn name() -> &'static str;
+    fn ecall_from_firmware(ctx: &mut VirtContext) -> PolicyHookResult;
+    fn ecall_from_payload(ctx: &mut VirtContext) -> PolicyHookResult;
+}


### PR DESCRIPTION
This patch adds bare bone support for policy modules in Miralis. Policy
modules are a new mechanism to define policies that should be enforced
by Miralis. By default Miralis does not isolate the rest of the system
from the virtualieed firmware, therefore does not provide any security
guarantee on its own.
As different systems requires different isolation policies (e.g. protect
VMs or user-level enclaves) we add a new modular mechanism to defined
policies within Miralis through Policy Modules. A policy module simply
implements the trait and can be selected through our config mechanism.
In multiple places of Miralis we will add hooks that can be leveraged by
policy modules to interpose on some events, enabling the definition of
custom policies.

This patch introduces two policy modules: the default policy which
provides no further isolation, and the Keystone policy which is
currently a placeholder but will be used in the future to implement the
Keystone ABI and policies. As of this commit it is possible to run a
firmware with the Keystone policy using:

```
just run default config/qemu-keystone.toml
```