### PR TITLE
Add U-boot test in the CI / CD pipeline

### DIFF
--- a/config/test/qemu-virt-u-boot-payload.toml
+++ b/config/test/qemu-virt-u-boot-payload.toml
@@ -1,0 +1,56 @@
+# A test configuration to run on QEMU virt platform
+
+[log]
+level = "info"
+color = true
+
+[debug]
+max_firmware_exits = 2000
+
+[vcpu]
+max_pmp = 8
+
+[platform]
+nb_harts = 1
+
+[benchmark]
+enable = false
+
+[target.miralis]
+# Build profile for Miralis (dev profile is set by default)
+profile = "dev"
+
+# Miralis binary will be compiled with this value as a start address
+# Default to "0x80000000"
+start_address = 0x80000000
+
+# Size of the Miralis' stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000
+
+[target.firmware]
+# Build profile for the firmware (dev profile is set by default)
+profile = "dev"
+
+# Firmware binary will be compiled with this value as a start address
+# Default to "0x80200000"
+start_address = 0x80200000
+
+# Size of the firmware stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000
+
+[target.payload]
+# Name or path to the payload binary
+name = "u-boot-exit"
+
+# Build profile for the payload (dev profile is set by default)
+profile = "dev"
+
+# Payload binary will be compiled with this value as a start address
+# Default to "0x80400000"
+start_address = 0x80400000
+
+# Size of the payload stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000

--- a/justfile
+++ b/justfile
@@ -9,6 +9,7 @@ spike_virt_benchmark := "./config/test/spike-virt-benchmark.toml"
 qemu_virt_release := "./config/test/qemu-virt-release.toml"
 qemu_virt_hello_world_payload := "./config/test/qemu-virt-hello-world-payload.toml"
 qemu_virt_hello_world_payload_spike := "./config/test/qemu-virt-hello-world-payload-spike.toml"
+qemu_virt_u_boot_payload := "./config/test/qemu-virt-u-boot-payload.toml"
 qemu_virt_sifive_u54 := "./config/test/qemu-virt-sifive-u54.toml"
 qemu_virt_sifive_u54_spike := "./config/test/qemu-virt-sifive-u54-spike.toml"
 qemu_virt_rustsbi_test_kernel := "./config/test/qemu-rustsbi-test-kernel.toml"
@@ -64,9 +65,12 @@ test:
 	# Testing with external projects
 	cargo run -- run --config {{qemu_virt}} --firmware opensbi
 	cargo run -- run --config {{qemu_virt}} --firmware zephyr --max-exits 1000000
-	cargo run -- run --config {{qemu_virt_hello_world_payload}} --firmware opensbi-jump
 	cargo run -- run --config {{qemu_virt_sifive_u54}} --firmware linux
 	cargo run -- run --config {{qemu_virt_rustsbi_test_kernel}} --firmware rustsbi-qemu
+
+	# Testing with S-mode payloads
+	cargo run -- run --config {{qemu_virt_hello_world_payload}} --firmware opensbi-jump
+	cargo run -- run --config {{qemu_virt_u_boot_payload}} --firmware opensbi-jump
 
 	# Test benchmark code
 	cargo run -- run --config {{qemu_virt_benchmark}} --firmware csr_write

--- a/misc/artifacts.toml
+++ b/misc/artifacts.toml
@@ -39,3 +39,13 @@ repo = "https://github.com/CharlyCst/miralis-artifact-rustsbi"
 description = "A test-kernel for RustSBI on qemu."
 url = "https://github.com/CharlyCst/miralis-artifact-rustsbi/releases/download/v0.1.3/test-kernel.bin"
 repo = "https://github.com/CharlyCst/miralis-artifact-rustsbi"
+
+[bin.u-boot]
+description = "A U-boot bootloader "
+url = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.4/u-boot.bin"
+repo = "https://github.com/CharlyCst/miralis-artifact-opensbi"
+
+[bin.u-boot-exit]
+description = "A U-boot bootloader that exits just before jumping to the OS"
+url = "https://github.com/CharlyCst/miralis-artifact-opensbi/releases/download/v0.2.4/u-boot-exit.bin"
+repo = "https://github.com/CharlyCst/miralis-artifact-opensbi"


### PR DESCRIPTION
U-Boot is a universal bootloader used to initialize system hardware and load the operating system. The test terminates execution just before transferring control to the OS. This approach focuses on verifying U-Boot’s functionality without requiring the full boot sequence.