### PR TITLE
Improve PMP flushing ergonomics

### DIFF
--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -4,6 +4,7 @@ use core::marker::PhantomData;
 use core::{ptr, usize};
 
 use super::{Arch, Architecture, Csr, MCause, Mode, RegistersCapability, TrapInfo};
+use crate::arch::pmp::PmpFlush;
 use crate::arch::{mstatus, parse_mpp_return_mode, HardwareCapability, PmpGroup, Width};
 use crate::config::{PLATFORM_BOOT_HART_ID, TARGET_STACK_SIZE};
 use crate::decoder::Instr;
@@ -327,7 +328,7 @@ impl Architecture for MetalArch {
         Self::write_csr(Csr::Mstatus, (mstatus & !mstatus::MPP_FILTER) | value);
     }
 
-    unsafe fn write_pmp(pmp: &PmpGroup) {
+    unsafe fn write_pmp(pmp: &PmpGroup) -> PmpFlush {
         let pmpaddr = pmp.pmpaddr();
         let pmpcfg = pmp.pmpcfg();
         let nb_pmp = pmp.nb_pmp as usize;
@@ -344,6 +345,8 @@ impl Architecture for MetalArch {
             let cfg = pmpcfg[idx];
             write_pmpcfg(idx * 2, cfg);
         }
+
+        PmpFlush()
     }
 
     unsafe fn get_raw_faulting_instr(trap_info: &TrapInfo) -> usize {

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -11,7 +11,7 @@ mod registers;
 mod trap;
 mod userspace;
 
-use pmp::PmpGroup;
+use pmp::{PmpFlush, PmpGroup};
 pub use registers::{Csr, Register};
 pub use trap::{MCause, TrapInfo};
 
@@ -48,7 +48,7 @@ pub trait Architecture {
     /// Set csr_bits with mask
     unsafe fn set_csr_bits(csr: Csr, bits_mask: usize);
     unsafe fn set_mpp(mode: Mode);
-    unsafe fn write_pmp(pmp: &PmpGroup);
+    unsafe fn write_pmp(pmp: &PmpGroup) -> PmpFlush;
     unsafe fn sfencevma(vaddr: Option<usize>, asid: Option<usize>);
     unsafe fn hfencegvma(vaddr: Option<usize>, asid: Option<usize>);
     unsafe fn hfencevvma(vaddr: Option<usize>, asid: Option<usize>);

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -9,6 +9,7 @@ use core::{ptr, usize};
 use spin::Mutex;
 
 use super::{mie, mstatus, Architecture, Csr, MCause, Mode};
+use crate::arch::pmp::PmpFlush;
 use crate::arch::{HardwareCapability, PmpGroup};
 use crate::decoder::Instr;
 use crate::main;
@@ -37,7 +38,7 @@ impl Architecture for HostArch {
         Self::write_csr(Csr::Mstatus, (mstatus & !mstatus::MPP_FILTER) | value);
     }
 
-    unsafe fn write_pmp(pmp: &PmpGroup) {
+    unsafe fn write_pmp(pmp: &PmpGroup) -> PmpFlush {
         let pmpaddr = pmp.pmpaddr();
         let pmpcfg = pmp.pmpcfg();
         let nb_pmp = pmp.nb_pmp as usize;
@@ -53,6 +54,8 @@ impl Architecture for HostArch {
             let cfg = pmpcfg[idx];
             HOST_CTX.lock().csr.pmpcfg[idx * 2] = cfg;
         }
+
+        PmpFlush()
     }
 
     unsafe fn run_vcpu(_ctx: &mut crate::virt::VirtContext) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,8 +143,7 @@ pub(crate) extern "C" fn main(_hart_id: usize, device_tree_blob_addr: usize) -> 
         // Set return address, mode and PMP permissions
         Arch::set_mpp(arch::Mode::U);
         // Update the PMPs prior to first entry
-        Arch::write_pmp(&mctx.pmp);
-        Arch::sfencevma(None, None);
+        Arch::write_pmp(&mctx.pmp).flush();
 
         // Configure the firmware context
         ctx.set(Register::X10, hart_id);

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -785,8 +785,7 @@ impl VirtContext {
             mctx.pmp.set(last_pmp_idx, usize::MAX, pmpcfg::NAPOT);
         }
         // Commit the PMP to hardware
-        Arch::write_pmp(&mctx.pmp);
-        Arch::sfencevma(None, None);
+        Arch::write_pmp(&mctx.pmp).flush();
     }
 
     /// Loads the S-mode CSR registers into the virtual context and install sensible values (mostly
@@ -870,8 +869,7 @@ impl VirtContext {
         mctx.pmp
             .set(last_pmp_idx, usize::MAX, pmpcfg::RWX | pmpcfg::NAPOT);
         // Commit the PMP to hardware
-        Arch::write_pmp(&mctx.pmp);
-        Arch::sfencevma(None, None);
+        Arch::write_pmp(&mctx.pmp).flush();
     }
 }
 


### PR DESCRIPTION
This patch modifies `write_pmp` to return a `#[must_use]` struct that can be consumed to flush the caches, which is required to apply the changes in the PMP configuration.
This will make it easier to use the PMP properly, as the compiler will rise an error if the caches are not flushed after a PMP change.