### PR TITLE
Bugfix: properly display debug message in runner

### DIFF
--- a/runner/src/artifacts.rs
+++ b/runner/src/artifacts.rs
@@ -226,8 +226,6 @@ pub fn build_target(target: Target, cfg: &Config) -> PathBuf {
             }
         }
     };
-    let path = get_target_dir_path(&target, mode);
-    log::info!("Path: {:?}", path);
 
     let mut build_cmd = Command::new(env!("CARGO"));
     build_cmd

--- a/runner/src/logger.rs
+++ b/runner/src/logger.rs
@@ -47,10 +47,9 @@ impl log::Log for RunnerLogger {
                 Level::Warn => {
                     println!("\x1b[33m{}\x1b[0m", record.args());
                 }
-                Level::Info => {
+                Level::Info | Level::Debug | Level::Trace => {
                     println!("{}", record.args());
                 }
-                _ => {}
             }
         }
     }

--- a/runner/src/run.rs
+++ b/runner/src/run.rs
@@ -136,7 +136,7 @@ fn launch_qemu(args: &RunArgs, miralis: PathBuf, firmware: PathBuf) -> ExitCode 
     }
 
     log::debug!(
-        "{}\n{}",
+        "{} {}",
         QEMU,
         qemu_cmd
             .get_args()


### PR DESCRIPTION
The runner was recently updated with a new logging facility, but turns out it was not displaying debug-level messages even with the `--verbose` flag.
This commit fixes the issue, and cleans the output a bit more by removing another non-useful log. The runner now properly displays the QEMU command when invoked with verbose.