### PR TITLE
Add payload hash function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "csr_ops"
 version = "0.1.0"
 dependencies = [
@@ -292,6 +298,7 @@ dependencies = [
  "miralis_abi",
  "miralis_core",
  "spin",
+ "tiny-keccak",
  "uart_16550",
 ]
 
@@ -474,6 +481,15 @@ name = "test_protect_payload_payload"
 version = "0.1.0"
 dependencies = [
  "miralis_abi",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/runner/src/config.rs
+++ b/runner/src/config.rs
@@ -133,6 +133,7 @@ pub struct Target {
 #[serde(deny_unknown_fields)]
 pub struct Policy {
     pub name: Option<PolicyModule>,
+    pub payload_size: Option<usize>,
 }
 
 #[derive(Deserialize, Debug, Clone, Copy)]
@@ -311,6 +312,7 @@ impl Policy {
     fn buid_envs(&self) -> HashMap<String, String> {
         let mut envs = EnvVars::new();
         envs.insert("MIRALIS_POLICY_NAME", &self.name);
+        envs.insert("PAYLOAD_HASH_SIZE", &self.payload_size);
         envs.envs
     }
 }

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -17,6 +17,8 @@ miralis_core = { path = "../crates/core" }
 miralis_abi = { path = "../crates/abi" }
 config_helpers = { path = "../crates/config_helpers" }
 config_select = { path = "../crates/config_select/" }
+# This import is only used in the protect payload policy
+tiny-keccak = { version = "2.0.0", features = ["sha3"] }
 
 [features]
 # When running on host architecture as a userspace application, such as when

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,3 +112,6 @@ pub const TARGET_STACK_SIZE: usize =
 /// See https://github.com/rust-lang/rust/issues/99515
 #[allow(unused)]
 pub const POLICY_NAME: &str = parse_str_or(option_env!("MIRALIS_POLICY_NAME"), "default_policy");
+
+/// Size of the payload to hash
+pub const PAYLOAD_HASH_SIZE: usize = parse_usize_or(option_env!("PAYLOAD_HASH_SIZE"), 0x2000000);

--- a/src/policy/protect_payload.rs
+++ b/src/policy/protect_payload.rs
@@ -1,15 +1,32 @@
 //! The protect payload policy, it protects the payload.
 
+use core::slice;
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use miralis_core::abi_protect_payload;
+use tiny_keccak::{Hasher, Sha3};
 
 use crate::arch::pmp::pmpcfg;
 use crate::arch::pmp::pmplayout::POLICY_OFFSET;
 use crate::arch::MCause::EcallFromSMode;
 use crate::arch::{MCause, Register};
+use crate::config::PAYLOAD_HASH_SIZE;
 use crate::host::MiralisContext;
 use crate::platform::{Plat, Platform};
 use crate::policy::{PolicyHookResult, PolicyModule};
 use crate::virt::{RegisterContextGetter, VirtContext};
+
+const LINUX_LOCK_PAYLOAD_HASH: [u8; 32] = [
+    241, 90, 158, 184, 200, 210, 145, 178, 30, 80, 200, 161, 56, 120, 75, 241, 68, 38, 21, 2, 248,
+    112, 128, 155, 31, 240, 37, 94, 203, 66, 243, 167,
+];
+
+const TEST_POLICY_PAYLOAD: [u8; 32] = [
+    138, 39, 74, 50, 74, 113, 151, 180, 78, 91, 92, 25, 132, 84, 192, 119, 38, 36, 19, 147, 193,
+    166, 149, 149, 158, 179, 237, 5, 158, 54, 245, 69,
+];
+
+static FIRST_JUMP: AtomicBool = AtomicBool::new(true);
 
 /// The protect payload policy module, which allow the payload to protect himself from the firmware at some point in time and enfore a boundary between the two components.
 pub struct ProtectPayloadPolicy {
@@ -17,7 +34,6 @@ pub struct ProtectPayloadPolicy {
     general_register: [usize; 32],
     rules: [ForwardingRule; ForwardingRule::NB_RULES],
     last_cause: MCause,
-    first_jump: bool,
 }
 
 impl PolicyModule for ProtectPayloadPolicy {
@@ -29,7 +45,6 @@ impl PolicyModule for ProtectPayloadPolicy {
             // It is important to let the first mode be EcallFromSMode as the firmware passes some information to the OS.
             // Setting this last_cause allows to pass the arguments during the first call.
             last_cause: MCause::EcallFromSMode,
-            first_jump: true,
         }
     }
     fn name() -> &'static str {
@@ -113,15 +128,31 @@ impl PolicyModule for ProtectPayloadPolicy {
             }
         }
 
-        // TODO: add a proper barrier to ensure synchronization
-        if self.first_jump {
-            // Lock memory from all cores
-            Plat::broadcast_policy_interrupt();
-        }
-
         // Unlock memory
         mctx.pmp.set_inactive(POLICY_OFFSET, 0x80400000);
         mctx.pmp.set_tor(POLICY_OFFSET + 1, usize::MAX, pmpcfg::RWX);
+
+        // Attempt to set `flag` to false only if it is currently true
+        if FIRST_JUMP
+            .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            // Lock memory from all cores
+            // TODO: add a proper barrier to ensure synchronization
+            Plat::broadcast_policy_interrupt();
+
+            let hashed_value = hash_payload(PAYLOAD_HASH_SIZE, ctx.pc);
+
+            let not_linux_payload = hashed_value != LINUX_LOCK_PAYLOAD_HASH;
+            let not_test_payload = hashed_value != TEST_POLICY_PAYLOAD;
+
+            if not_linux_payload && not_test_payload {
+                log::error!("Loaded payload is suspicious");
+                log::error!("Hashed value: {:?}", hashed_value);
+                log::error!("Expected value: {:?}", LINUX_LOCK_PAYLOAD_HASH);
+                panic!("Protect Payload policy: Invalid hash");
+            }
+        }
     }
 
     // In this policy module, if we receive an interrupt from Miralis, it implies we need to lock the memory
@@ -130,8 +161,6 @@ impl PolicyModule for ProtectPayloadPolicy {
         mctx.pmp.set_inactive(POLICY_OFFSET, 0x80400000);
         mctx.pmp
             .set_tor(POLICY_OFFSET + 1, usize::MAX, pmpcfg::NO_PERMISSIONS);
-
-        self.first_jump = false
     }
 
     const NUMBER_PMPS: usize = 2;
@@ -205,5 +234,32 @@ impl ForwardingRule {
     fn allow_register_out(&mut self, reg: Register) -> &mut Self {
         self.allow_out[reg as usize] = true;
         self
+    }
+}
+
+// ———————————————————————————————— Hash primitive ———————————————————————————————— //
+
+fn hash_payload(size_to_hash: usize, pc_start: usize) -> [u8; 32] {
+    let payload_start: usize = 0x80400000;
+    let payload_end: usize = 0x80400000 + size_to_hash;
+
+    assert!(
+        payload_start <= payload_end,
+        "Invalid memory range for payload hashing"
+    );
+
+    unsafe {
+        let mut hasher = Sha3::v256();
+
+        let payload_content =
+            slice::from_raw_parts(payload_start as *const u8, payload_end - payload_start);
+        hasher.update(payload_content);
+
+        hasher.update(&pc_start.to_le_bytes());
+
+        let mut hashed_value = [0u8; 32];
+        hasher.finalize(&mut hashed_value);
+
+        hashed_value
     }
 }

--- a/src/policy/protect_payload.rs
+++ b/src/policy/protect_payload.rs
@@ -10,7 +10,7 @@ use crate::arch::pmp::pmpcfg;
 use crate::arch::pmp::pmplayout::POLICY_OFFSET;
 use crate::arch::MCause::EcallFromSMode;
 use crate::arch::{MCause, Register};
-use crate::config::PAYLOAD_HASH_SIZE;
+use crate::config::{PAYLOAD_HASH_SIZE, TARGET_PAYLOAD_ADDRESS};
 use crate::host::MiralisContext;
 use crate::platform::{Plat, Platform};
 use crate::policy::{PolicyHookResult, PolicyModule};
@@ -107,7 +107,7 @@ impl PolicyModule for ProtectPayloadPolicy {
         }
 
         // Lock memory
-        mctx.pmp.set_inactive(POLICY_OFFSET, 0x80400000);
+        mctx.pmp.set_inactive(POLICY_OFFSET, TARGET_PAYLOAD_ADDRESS);
         mctx.pmp
             .set_tor(POLICY_OFFSET + 1, usize::MAX, pmpcfg::NO_PERMISSIONS);
 
@@ -129,7 +129,7 @@ impl PolicyModule for ProtectPayloadPolicy {
         }
 
         // Unlock memory
-        mctx.pmp.set_inactive(POLICY_OFFSET, 0x80400000);
+        mctx.pmp.set_inactive(POLICY_OFFSET, TARGET_PAYLOAD_ADDRESS);
         mctx.pmp.set_tor(POLICY_OFFSET + 1, usize::MAX, pmpcfg::RWX);
 
         // Attempt to set `flag` to false only if it is currently true
@@ -240,8 +240,8 @@ impl ForwardingRule {
 // ———————————————————————————————— Hash primitive ———————————————————————————————— //
 
 fn hash_payload(size_to_hash: usize, pc_start: usize) -> [u8; 32] {
-    let payload_start: usize = 0x80400000;
-    let payload_end: usize = 0x80400000 + size_to_hash;
+    let payload_start: usize = TARGET_PAYLOAD_ADDRESS;
+    let payload_end: usize = TARGET_PAYLOAD_ADDRESS + size_to_hash;
 
     assert!(
         payload_start <= payload_end,


### PR DESCRIPTION
This commits introduces a function that allows to hash the binary content of the payload. This will allow us in the future to check if the payload was loaded correctly and without malicious actions by the firmware.