### PR TITLE
Creation of explicit forwarding rules in the protect_payload.rs

### DIFF
--- a/firmware/test_protect_payload_firmware/main.rs
+++ b/firmware/test_protect_payload_firmware/main.rs
@@ -53,32 +53,90 @@ global_asm!(
 .align 4
 .global _raw_trap_handler
 _raw_trap_handler:
-    // Skip illegal instruction (pc += 4)
+    // Advance PC by 4 (skip instruction)
     csrrw x5, mepc, x5
-    addi x5, x5, 4
+    addi  x5, x5, 4
     csrrw x5, mepc, x5
-    // Set mscratch to 1
-    csrrw x5, mscratch, x5
-    addi x5, x0, 1
-    csrrw x5, mscratch, x5
-    // Set t6 to 0 - for test_same_registers_after_trap
-    li t6, 0
-    // If mcause is 7 or 2, it might be triggered by the instruction sd t5, 0(t6) | csrr t0, mcause
-    // Therefore we don't want to load it a second time
-    csrr t0, mcause
-    li   t1, 7
-    beq  t0, t1, skip
-    csrr t0, mcause
-    li   t1, 2
-    beq  t0, t1, skip
-    // Make sure we get an access fault and we can't to that
-    li t6, 0x80400000
-    li t5, 60
-    sd t5, 0(t6)
-skip:
-    // Return back to miralis
+
+    // Check mcause for ecall (mcause = 9)
+    csrr  t0, mcause
+    li    t1, 9
+    beq   t0, t1, test_ecall
+
+    // Set t6 to 0 for test_same_registers_after_trap
+    li    t6, 0
+
+    // Skip redundant mcause checks if already handled (mcause = 7 or 2)
+    csrr  t0, mcause
+    li    t1, 7
+    beq   t0, t1, done
+    li    t1, 2
+    beq   t0, t1, done
+
+    // Ensure payload memory cannot be altered
+    li    t6, 0x80400000
+    li    t5, 60
+    sd    t5, 0(t6)
+
+test_ecall:
+    // Handle ecall (mcause = 9)
+    csrr  t0, mcause
+    li    t1, 9
+    bne   t0, t1, done
+
+    // Verify if all input registers are equal to 60
+    li    t2, 60
+    bne   a0, t2, infinite_loop
+    bne   a1, t2, infinite_loop
+    bne   a2, t2, infinite_loop
+    bne   a3, t2, infinite_loop
+    bne   a4, t2, infinite_loop
+    bne   a5, t2, infinite_loop
+
+    // Set return values for successful ecall
+    li    a0, 61
+    li    a1, 62
+    j     done
+
+infinite_loop:
+    // Infinite loop in case of failure
+    j     infinite_loop
+
+done:
+    // Write random values into registers for testing state integrity
+    li    t0, 0x12345678
+    li    t1, 0x9abcdef0
+    li    t2, 0xdeadbeef
+    li    t3, 0xc0ffee00
+    li    t4, 0x00001234
+    li    t5, 0x56789abc
+    li    t6, 0x2468ace0
+    li    s0, 0x11111111
+    li    s1, 0x22222222
+    li    a2, 0x33333333
+    li    a3, 0x44444444
+    li    a4, 0x55555555
+    li    a5, 0x66666666
+    li    a6, 0x77777777
+    li    a7, 0x88888888
+    li    s2, 0x99999999
+    li    s3, 0xaaaaaaaa
+    li    s4, 0xbbbbbbbb
+    li    s5, 0xcccccccc
+    li    s6, 0xdddddddd
+    li    s7, 0xeeeeeeee
+    li    s8, 0xffffffff
+    li    t3, 0xabcdef01
+    li    t4, 0x23456789
+    li    t5, 0x98765432
+    li    t6, 0x10fedcba
+    li    gp, 0x00000000
+    li    sp, 0x11110000
+    li    ra, 0x22220000
+
+    // Return to Miralis
     mret
-#"
+"
 );
 
 extern "C" {

--- a/payload/test_protect_payload_payload/main.rs
+++ b/payload/test_protect_payload_payload/main.rs
@@ -60,22 +60,6 @@ macro_rules! save_registers {
 
     };
 }
-
-macro_rules! test_same_registers_after {
-    ($asm_code:expr) => {{
-        let mut regs_before = Regs::new();
-        let mut regs_after = Regs::new();
-
-        unsafe {
-            save_registers!(regs_before);
-            asm!($asm_code);
-            save_registers!(regs_after);
-        }
-
-        regs_before == regs_after
-    }};
-}
-
 // ———————————————————————————————— Guest OS ———————————————————————————————— //
 
 use core::arch::asm;
@@ -115,7 +99,16 @@ fn main() -> ! {
 }
 
 fn test_same_register_after_illegal_instruction() -> bool {
-    test_same_registers_after!("csrw mscratch, zero")
+    let mut regs_before = Regs::new();
+    let mut regs_after = Regs::new();
+
+    unsafe {
+        save_registers!(regs_before);
+        asm!("csrw mscratch, zero");
+        save_registers!(regs_after);
+    }
+
+    regs_before == regs_after
 }
 
 fn test_same_region_after_trap() -> bool {


### PR DESCRIPTION
This commit creates a small framework similar to IPRules that allows to explicitly forwards registers from the payload to the firmware and in the opposite direction. Last but not least, it creates and test a forwarding rule for ecall from S mode.