### PR TITLE
Fix bug related to Sstc extension

### DIFF
--- a/src/virt.rs
+++ b/src/virt.rs
@@ -728,13 +728,6 @@ impl VirtContext {
             mstatus::MPP_FILTER,
             self.mode.to_bits(),
         );
-        Arch::write_csr(Csr::Mstatus, mstatus & !mstatus::MIE_FILTER);
-        Arch::write_csr(Csr::Mideleg, self.csr.mideleg);
-        Arch::write_csr(Csr::Medeleg, self.csr.medeleg);
-        Arch::write_csr(Csr::Mcounteren, self.csr.mcounteren);
-
-        Arch::write_csr(Csr::Mie, self.csr.mie);
-        Arch::write_csr(Csr::Mip, self.csr.mip);
 
         if mctx.hw.available_reg.senvcfg {
             Arch::write_csr(Csr::Senvcfg, self.csr.senvcfg);
@@ -743,6 +736,14 @@ impl VirtContext {
         if mctx.hw.available_reg.menvcfg {
             Arch::write_csr(Csr::Menvcfg, self.csr.menvcfg);
         }
+
+        Arch::write_csr(Csr::Mstatus, mstatus & !mstatus::MIE_FILTER);
+        Arch::write_csr(Csr::Mideleg, self.csr.mideleg);
+        Arch::write_csr(Csr::Medeleg, self.csr.medeleg);
+        Arch::write_csr(Csr::Mcounteren, self.csr.mcounteren);
+
+        Arch::write_csr(Csr::Mie, self.csr.mie);
+        Arch::write_csr(Csr::Mip, self.csr.mip);
 
         // If S extension is present - save the registers
         if mctx.hw.extensions.has_s_extension {


### PR DESCRIPTION
## Background
The MSB of the `menvcfg` register is used to enable/disable the "Sstc" extension ( 'Ss' for Privileged arch and Supervisor-level extensions, and 'tc' for timecmp).

This extension serves to provide S mode with its own CSR-based timer interrupt facility that it can directly manage to provide its own timer service thus eliminating the overheads for emulating S/HS-mode timers and timer interrupt generation up in M-mode.

A new register `stimecmp` can be used for that. If the `time` CSR (representing the current time) reaches or exceeds the value in `stimecmp`, the supervisor timer interrupt is triggered by setting the STIP bit in the `mip` and `sip` registers.

Additionally, the behavior of some CSRs will be changed.
#### Changes to `mip` and `mie`
- Without the extension, the mip.STIP bit is writable by M-mode to deliver timer interrupts to S mode
- With the extension, the mip.STIP bit is read-only and reflects the S mode timer interrupt signal

#### Changes to `sip` and `sie`
- Without the extension, sip.STIP is read-only and set by the execution environment
- With the extension, sip.STIP is read-only and reflects the S mode timer interrupt signal

#### Changes to `mcounteren`
- Without the extension, `mcounteren` controls access to the `time` register
- With the extension, `mcounteren` controls access to the `time`, `stimecmp` and `vstimecmp`

#### Changes to Hypervisor registers
Similar changes are applied to the `vstimecmp`, `vhip`, `hip`, `hie` and `hcounteren` registers (check section 16.2 of the ISA for all the details)

## Bug
The bug comes from writing to the `mip` register before the `menvcfg` register. What happens in that situation is that the `mip.STIP` bit will be overridden, which can cancel or set a pending interrupt. However, we should not override that bit when the Sstc extension is enabled (i.e. when the MSB of `menvcfg` is 1).

## Solution
We should make sure to write the `menvcfg` register before the `mip` register, which will automatically make `mip.STIP` bit read-only if the Sstc extension is enabled.

