### PR TITLE
Add linux kernel with protect payload policy.

### DIFF
--- a/config/lock_kernel.toml
+++ b/config/lock_kernel.toml
@@ -1,0 +1,39 @@
+[policy]
+name = "protect_payload"
+
+[target.miralis]
+# Build profile for Miralis (dev profile is set by default)
+profile = "dev"
+
+# Miralis binary will be compiled with this value as a start address
+# Default to "0x80000000"
+start_address = 0x80000000
+
+# Size of the Miralis' stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000
+
+[target.firmware]
+# Build profile for the firmware (dev profile is set by default)
+profile = "dev"
+
+# Firmware binary will be compiled with this value as a start address
+# Default to "0x80200000"
+start_address = 0x80200000
+
+# Size of the firmware stack for each hart (i.e. core)
+# Default to 0x8000
+stack_size = 0x8000
+
+
+[target.payload]
+# Name or path to the payload binary
+name = "/home/francois/Bureau/kernel/linux/arch/riscv/boot/Image"
+# Start address ot the linux kernel
+start_address = 0x80400000
+
+[qemu]
+# We want to give a path to the -kernel argument in qemu
+kernel="/home/francois/Bureau/kernel/linux/arch/riscv/boot/Image"
+# Path of the linux kernel initramfs
+initrd="/home/francois/Bureau/kernel/initramfs/initramfs.cpio.gz"

--- a/justfile
+++ b/justfile
@@ -74,13 +74,12 @@ test:
 	cargo run -- run --config {{qemu_virt_hello_world_payload}} --firmware opensbi-jump
 	cargo run -- run --config {{qemu_virt_u_boot_payload}} --firmware opensbi-jump
 
-	# Test benchmark code
+	# Testing with protect payload policy
+	# cargo run -- run --config {{qemu_virt_test_protect_paylod}} --firmware test_protect_payload_firmware
+
+	# Testing benchmark code
 	cargo run -- run --config {{qemu_virt_benchmark}} --firmware csr_write
 	cargo run -- run --config {{qemu_virt_benchmark}} --firmware ecall_benchmark
-
-	# Test with different policies
-	cargo run -- run --config {{qemu_virt_protect_payload}} --firmware opensbi
-	# cargo run -- run --config {{qemu_virt_test_protect_paylod}} --firmware test_protect_payload_firmware
 
 	# Test firmware build
 	just build-firmware default {{qemu_virt}}

--- a/runner/src/config.rs
+++ b/runner/src/config.rs
@@ -74,6 +74,8 @@ pub struct Platform {
 pub struct Qemu {
     pub machine: Option<String>,
     pub cpu: Option<String>,
+    pub kernel: Option<String>,
+    pub initrd: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone, Copy)]

--- a/runner/src/run.rs
+++ b/runner/src/run.rs
@@ -85,6 +85,14 @@ fn launch_qemu(args: &RunArgs, miralis: PathBuf, firmware: PathBuf) -> ExitCode 
     if let Some(cpu) = &cfg.qemu.cpu {
         qemu_cmd.arg("-cpu").arg(cpu);
     }
+    if let Some(kernel_path) = &cfg.qemu.kernel {
+        log::info!("{}", kernel_path);
+        qemu_cmd.arg("-kernel").arg(kernel_path);
+    }
+    if let Some(initrd_path) = &cfg.qemu.initrd {
+        log::info!("{}", initrd_path);
+        qemu_cmd.arg("-initrd").arg(initrd_path);
+    }
     qemu_cmd
         .arg("-bios")
         .arg(miralis)


### PR DESCRIPTION
This commit gives the possibility to start Miralis with the linux kernel while the payload is isolated from the firmware through the protect payload policy.