### PR TITLE
Fix Keystone Create Enclave

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,13 @@ name = "test_helpers"
 version = "0.1.0"
 
 [[package]]
+name = "test_keystone_payload"
+version = "0.1.0"
+dependencies = [
+ "miralis_abi",
+]
+
+[[package]]
 name = "test_protect_payload_firmware"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     # Payload
     "payload/hello_world",
     "payload/test_protect_payload_payload",
+    "payload/test_keystone_payload",
 
     # Crates
     "crates/abi",

--- a/config/test/qemu-virt-test-keystone.toml
+++ b/config/test/qemu-virt-test-keystone.toml
@@ -1,0 +1,34 @@
+[log]
+level = "info"
+color = true
+
+[debug]
+max_firmware_exits = 2000
+
+[vcpu]
+max_pmp = 8
+
+[platform]
+nb_harts = 1
+
+[benchmark]
+enable = false
+
+[target.miralis]
+profile = "dev"
+start_address = 0x80000000
+stack_size = 0x8000
+
+[target.firmware]
+profile = "dev"
+start_address = 0x80200000
+stack_size = 0x8000
+
+[target.payload]
+name = "test_keystone_payload"
+profile = "dev"
+start_address = 0x80400000
+stack_size = 0x8000
+
+[policy]
+name = "keystone"

--- a/justfile
+++ b/justfile
@@ -11,6 +11,7 @@ qemu_virt_release := "./config/test/qemu-virt-release.toml"
 qemu_virt_hello_world_payload := "./config/test/qemu-virt-hello-world-payload.toml"
 qemu_virt_protect_payload      := "./config/test/qemu-virt-protect-payload.toml"
 qemu_virt_test_protect_payload := "./config/test/qemu-virt-test-protect-payload.toml"
+qemu_virt_test_keystone_payload := "./config/test/qemu-virt-test-keystone.toml"
 qemu_virt_hello_world_payload_spike := "./config/test/qemu-virt-hello-world-payload-spike.toml"
 qemu_virt_u_boot_payload := "./config/test/qemu-virt-u-boot-payload.toml"
 qemu_virt_sifive_u54 := "./config/test/qemu-virt-sifive-u54.toml"
@@ -78,9 +79,10 @@ test:
 	cargo run -- run --config {{qemu_virt_hello_world_payload}} --firmware opensbi-jump
 	cargo run -- run --config {{qemu_virt_u_boot_payload}} --firmware opensbi-jump
 
-	# Testing with protect payload policy
+	# Testing policies
 	cargo run -- run --config {{qemu_virt_protect_payload}} --firmware linux-lock
 	cargo run -- run --config {{qemu_virt_test_protect_payload}} --firmware test_protect_payload_firmware
+	cargo run -- run --config {{qemu_virt_test_keystone_payload}} --firmware opensbi-jump
 
 	# Testing benchmark code
 	cargo run -- run --config {{qemu_virt_benchmark}} --firmware csr_write

--- a/payload/test_keystone_payload/Cargo.toml
+++ b/payload/test_keystone_payload/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "test_keystone_payload"
+version = "0.1.0"
+edition = "2021"
+
+license = "MIT"
+
+[[bin]]
+name = "test_keystone_payload"
+path = "main.rs"
+
+[dependencies]
+miralis_abi = { path = "../../crates/abi" }

--- a/payload/test_keystone_payload/main.rs
+++ b/payload/test_keystone_payload/main.rs
@@ -1,0 +1,68 @@
+#![no_std]
+#![no_main]
+#![feature(start)]
+// ———————————————————————————————— Guest OS ———————————————————————————————— //
+
+use miralis_abi::{ecall3, log, setup_binary, success};
+
+setup_binary!(main);
+
+fn main() -> ! {
+    log::info!("Hello from test keystone payload");
+
+    pub const ILLEGAL_ARGUMENT: usize = 100008;
+    pub const MIRALIS_KEYSTONE_EID: usize = 0x08424b45;
+    pub const CREATE_ENCLAVE_FID: usize = 2001;
+
+    // Test create enclave
+    #[repr(C)]
+    struct CreateArgs {
+        epm_paddr: usize,
+        epm_size: usize,
+        utm_paddr: usize,
+        utm_size: usize,
+        runtime_paddr: usize,
+        user_paddr: usize,
+        free_paddr: usize,
+        free_requested: usize,
+    }
+
+    let valid_args = CreateArgs {
+        // Values copied from keystone
+        epm_paddr: 0x83800000,
+        epm_size: 0x200000,
+        utm_paddr: 0x83240000,
+        utm_size: 0x40000,
+        runtime_paddr: 0x8380C000,
+        user_paddr: 0x83834000,
+        free_paddr: 0x838D6000,
+        free_requested: 0x40000,
+    };
+
+    // Keystone should return SUCCESS if given valid arguments
+    unsafe {
+        ecall3(
+            MIRALIS_KEYSTONE_EID,
+            CREATE_ENCLAVE_FID,
+            &valid_args as *const CreateArgs as usize,
+            0,
+            0,
+        )
+    }
+    .expect("Failed to create enclave");
+
+    // Miralis should not crash if given an invalid argument
+    let err = unsafe {
+        ecall3(
+            MIRALIS_KEYSTONE_EID,
+            CREATE_ENCLAVE_FID,
+            0xDEADBEEFDEADBEEF,
+            0,
+            0,
+        )
+    }
+    .unwrap_err();
+    assert_eq!(err, ILLEGAL_ARGUMENT);
+
+    success()
+}

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -47,7 +47,9 @@ pub trait Architecture {
 
     /// Set csr_bits with mask
     unsafe fn set_csr_bits(csr: Csr, bits_mask: usize);
-    unsafe fn set_mpp(mode: Mode);
+
+    /// Change mstatus.MPP and return the previous mstatus.MPP
+    unsafe fn set_mpp(mode: Mode) -> Mode;
     unsafe fn write_pmp(pmp: &PmpGroup) -> PmpFlush;
     unsafe fn sfencevma(vaddr: Option<usize>, asid: Option<usize>);
     unsafe fn hfencegvma(vaddr: Option<usize>, asid: Option<usize>);
@@ -80,6 +82,14 @@ pub trait Architecture {
     /// SAFETY:
     /// None so far, TODO
     unsafe fn handle_virtual_load_store(instr: Instr, ctx: &mut VirtContext);
+
+    /// Copies dest.len() bytes from src to dest, using the provided mode to read from src.
+    /// This function can be useful to copy bytes from the virtual address space of a lower
+    /// privileged mode, to a buffer in M-mode.
+    ///
+    /// Returns whether the copy succeeded or not (for example, the copy might not succeed if we try
+    /// to read an address not accessible from the given mode).
+    unsafe fn copy_bytes_from_mode(src: *const u8, dest: &mut [u8], mode: Mode) -> Result<(), ()>;
 }
 
 // ——————————————————————————— Hardware Detection ——————————————————————————— //


### PR DESCRIPTION
The create enclave function takes as argument a pointer that points to the memory of a lower-privileged mode.
Before accessing that memory, Miralis needs to:

1. Check that the lower-privileged mode has access to that memory.
2. Read from the virtual memory if the lower-privileged mode uses virtual memory.

This PR takes care of that.