### PR TITLE
Implement IPI for the protect payload policy

### DIFF
--- a/src/device/clint.rs
+++ b/src/device/clint.rs
@@ -23,6 +23,8 @@ pub struct VirtClint {
     driver: &'static Mutex<ClintDriver>,
     /// Virtual Machine Software Interrupt (MSI) map
     vmsi: [AtomicBool; PLATFORM_NB_HARTS],
+    /// Policy Machine Software Interrupt (MSI) map
+    policy_msi: [AtomicBool; PLATFORM_NB_HARTS],
 }
 
 impl DeviceAccess for VirtClint {
@@ -52,6 +54,7 @@ impl VirtClint {
         Self {
             driver,
             vmsi: [const { AtomicBool::new(false) }; PLATFORM_NB_HARTS],
+            policy_msi: [const { AtomicBool::new(false) }; PLATFORM_NB_HARTS],
         }
     }
 
@@ -174,5 +177,30 @@ impl VirtClint {
             "Invalid hart ID when clearing vMSI"
         );
         self.vmsi[hart].load(Ordering::SeqCst)
+    }
+
+    /// Mark the policy MSI as pending for each harts.
+    pub fn set_all_policy_msi(&self) {
+        for hart_idx in 0..PLATFORM_NB_HARTS {
+            self.policy_msi[hart_idx].store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// Get the policy MSI pending status for the given hart.
+    pub fn get_policy_msi(&self, hart: usize) -> bool {
+        assert!(
+            hart < PLATFORM_NB_HARTS,
+            "Invalid hart ID when clearing vMSI"
+        );
+        self.policy_msi[hart].load(Ordering::SeqCst)
+    }
+
+    /// Clear the policy MSI pending status for the given hart.
+    pub fn clear_policy_msi(&self, hart: usize) {
+        assert!(
+            hart < PLATFORM_NB_HARTS,
+            "Invalid hart ID when clearing vMSI"
+        );
+        self.policy_msi[hart].store(false, Ordering::SeqCst)
     }
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -144,4 +144,11 @@ impl ClintDriver {
         log::trace!("MSIP value written: 0x{:x} for hart {hart}", msip_value);
         Ok(())
     }
+
+    /// Create a pending MSI interrupts for each harts of the platform, including the current one.
+    pub fn trigger_msi_on_all_harts(&mut self) {
+        for i in 0..PLATFORM_NB_HARTS {
+            self.write_msip(i, 1).unwrap();
+        }
+    }
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -35,6 +35,17 @@ pub trait Platform {
     fn get_clint() -> &'static Mutex<ClintDriver>;
     fn get_vclint() -> &'static VirtClint;
 
+    /// Signal a pending policy interrupt on all cores and trigger an MSI.
+    ///
+    /// As a result the policy interrupt callback will be called into on each cores.
+    fn broadcast_policy_interrupt() {
+        // Mark values in virtual clint
+        Self::get_vclint().set_all_policy_msi();
+
+        // Fire physical clint
+        Self::get_clint().lock().trigger_msi_on_all_harts();
+    }
+
     /// Load the firmware (virtual M-mode software) and return its address.
     fn load_firmware() -> usize;
 

--- a/src/policy/default.rs
+++ b/src/policy/default.rs
@@ -37,5 +37,7 @@ impl PolicyModule for DefaultPolicy {
 
     fn switch_from_firmware_to_payload(&mut self, _: &mut VirtContext, _: &mut MiralisContext) {}
 
+    fn on_interrupt(&mut self, _ctx: &mut VirtContext, _mctx: &mut MiralisContext) {}
+
     const NUMBER_PMPS: usize = 0;
 }

--- a/src/policy/keystone.rs
+++ b/src/policy/keystone.rs
@@ -230,5 +230,7 @@ impl PolicyModule for KeystonePolicy {
         // TODO: Implement
     }
 
+    fn on_interrupt(&mut self, _ctx: &mut VirtContext, _mctx: &mut MiralisContext) {}
+
     const NUMBER_PMPS: usize = 0;
 }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -65,5 +65,13 @@ pub trait PolicyModule {
 
     fn switch_from_firmware_to_payload(&mut self, ctx: &mut VirtContext, mctx: &mut MiralisContext);
 
+    /// Callback for policy MSI.
+    ///
+    /// This function can be triggered across harts by sending a policy MSI. As such it can be used
+    /// for synchronisation between multiple harts. Note that there is no guarantee that the MSI
+    /// will be received without a delay, and as such a proper barrier must be used if
+    /// synchronisation is critical for security.
+    fn on_interrupt(&mut self, ctx: &mut VirtContext, mctx: &mut MiralisContext);
+
     const NUMBER_PMPS: usize;
 }


### PR DESCRIPTION
Now when we jump to the payload for the first time, we send an interrupt to all cores and force them to lock the memory even if they are still on the firmware