### PR TITLE
Add support for skipping Spike tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,12 @@ jobs:
         echo ""
         echo "QEMU version:"
         qemu-system-riscv64 --version
+    - name: Download Spike
+      run: |
+        wget --no-verbose https://github.com/epfl-dcsl/spike-ci-artifact/releases/download/v0.1.3/spike
+        chmod +x spike
+        echo "$PWD" >> $GITHUB_PATH
+        sudo apt install device-tree-compiler
     - name: Test
       # Specify shell to enforce fail fast behavior, see:
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/config/test/spike.toml
+++ b/config/test/spike.toml
@@ -1,0 +1,16 @@
+# A simple configuration to run on the Spike platform
+
+[log]
+level = "info"
+color = true
+
+[debug]
+max_firmware_exits = 1000000
+
+[vcpu]
+max_pmp = 8
+
+[platform]
+nb_harts = 1
+name = "spike"
+

--- a/justfile
+++ b/justfile
@@ -34,7 +34,7 @@ test:
 	cargo clippy -p benchmark_analyzer
 
 	# Run integration tests...
-	cargo run -- test
+	cargo run -- test --strict
 
 	# Test firmware build
 	just build-firmware default {{qemu_virt}}

--- a/miralis.toml
+++ b/miralis.toml
@@ -23,6 +23,9 @@ path = "config/test/qemu-virt-keystone.toml"
 [config.qemu-virt-benchmark]
 path = "config/test/qemu-virt-benchmark.toml"
 
+[config.spike]
+path = "config/test/spike.toml"
+
 ## ——————————————————————————— Integration Tests ———————————————————————————— ##
 
 [test.ecall]
@@ -188,4 +191,11 @@ firmware = "opensbi-jump"
 payload = "test_keystone_payload"
 config = "qemu-virt-keystone"
 description = "Integration test for the protect payload policy, with a custom firmware and payload"
+
+## —————————————————————————————— Spike Tests ——————————————————————————————— ##
+
+[test.spike-ecall]
+firmware = "ecall"
+config = "spike"
+description = "The most basic test, which directly exit with an ecall to Miralis"
 

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -79,6 +79,9 @@ struct BuildArgs {
 struct TestArgs {
     /// Prefix of the tests to run, all if none
     pattern: Option<String>,
+    /// The command will succeed only if all tests can be run successfully
+    #[arg(long, action)]
+    strict: bool,
 }
 
 #[derive(Args)]

--- a/runner/src/run.rs
+++ b/runner/src/run.rs
@@ -17,8 +17,11 @@ use crate::RunArgs;
 
 // ————————————————————————————— QEMU Arguments ————————————————————————————— //
 
-const QEMU: &str = "qemu-system-riscv64";
-const SPIKE: &str = "spike";
+/// The QEMU executable
+pub const QEMU: &str = "qemu-system-riscv64";
+
+/// The Spike executable
+pub const SPIKE: &str = "spike";
 
 #[rustfmt::skip]
 const QEMU_ARGS: &[&str] = &[
@@ -219,4 +222,26 @@ pub fn get_spike_cmd(cfg: &Config, miralis: PathBuf, firmware: PathBuf) -> Resul
 
 fn raw_to_elf(raw_path: &str) -> &str {
     &raw_path[..raw_path.len() - 4]
+}
+
+/// Returns true if QEMU is available.
+pub fn qemu_is_available() -> bool {
+    let mut qemu_cmd = Command::new(QEMU);
+    qemu_cmd.arg("--version");
+    qemu_cmd
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    qemu_cmd.status().is_ok()
+}
+
+/// Returns true if Spike is available.
+pub fn spike_is_available() -> bool {
+    let mut spike_cmd = Command::new(SPIKE);
+    spike_cmd.arg("--help");
+    spike_cmd
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    spike_cmd.status().is_ok()
 }

--- a/runner/src/test.rs
+++ b/runner/src/test.rs
@@ -141,7 +141,18 @@ pub fn run_tests(args: &TestArgs) -> ExitCode {
         );
     }
 
-    ExitCode::SUCCESS
+    if args.strict {
+        // Strict runs are successful only if all tests run successfully. They fail if some tests
+        // are skipped.
+        if stats.success == stats.total {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::FAILURE
+        }
+    } else {
+        // Otherwise we consider it a success, even if we skipped some tests
+        ExitCode::SUCCESS
+    }
 }
 
 /// Run one test, building the required artifacts as needed.


### PR DESCRIPTION
This PR adds support for running Spike tests in the CI as well as skipping tests if the emulator is not available (which avoids breaking tests on user machines without Spike).

A limitations of Spike tests is that they don't work with OpenSBI shutdown as it requires loading OpenSBI as an ELF for Spike to locate the `tohost` symbol, thus there is no Linux Spike test yet. The best option here is most likely to re-compile OpenSBI with a patch to use an ecall to Miralis shuting down on Spike.