### PR TITLE
Build Miralis as a library

### DIFF
--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ fmt:
 # Run all the tests
 test:
 	# Running unit tests...
-	cargo test --features userspace -p miralis
+	cargo test --features userspace --lib -p miralis
 
 	# Checking formatting...
 	cargo fmt --all -- --check

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -10,6 +10,10 @@ readme = "../readme.md"
 keywords = ["riscv", "virtualization"]
 categories = ["no-std", "no-std::no-alloc", "embedded", "virtualization"]
 
+[lib]
+name = "miralis"
+path = "lib.rs"
+
 [[bin]]
 name = "miralis"
 path = "main.rs"
@@ -30,3 +34,5 @@ tiny-keccak = { version = "2.0.0", features = ["sha3"] }
 # running unit tests.
 userspace = []
 
+[lints.clippy]
+result_unit_err = "allow"

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -4,6 +4,12 @@
 //! future, we could emulate RISC-V instructions to enable running the monitor in user space, which
 //! would be very helpful for testing purpose.
 
+// Now that Miralis is built as a library we need to write proper documentation for each public
+// function. In particular Clippy lints against every unsafe function without a safety comment. We
+// do have a bunch of those in this file, we should comment them appropriately and remove this lint
+// once done.
+#![allow(clippy::missing_safety_doc)]
+
 #[cfg(not(feature = "userspace"))]
 mod metal;
 pub mod pmp;
@@ -40,12 +46,27 @@ pub trait Architecture {
     fn read_csr(csr: Csr) -> usize;
 
     /// Write into csr and return previous value
+    ///
+    /// # Safety
+    ///
+    /// This function writes to the hardware CSR, use with caution as it might change the execution
+    /// environment.
     unsafe fn write_csr(csr: Csr, value: usize) -> usize;
 
     /// Clear csr_bits with mask
+    ///
+    /// # Safety
+    ///
+    /// This function writes to the hardware CSR, use with caution as it might change the execution
+    /// environment.
     unsafe fn clear_csr_bits(csr: Csr, bits_mask: usize);
 
     /// Set csr_bits with mask
+    ///
+    /// # Safety
+    ///
+    /// This function writes to the hardware CSR, use with caution as it might change the execution
+    /// environment.
     unsafe fn set_csr_bits(csr: Csr, bits_mask: usize);
 
     /// Change mstatus.MPP and return the previous mstatus.MPP
@@ -66,7 +87,8 @@ pub trait Architecture {
     /// implement Send and Sync, meaning that it can't be shared across cores (which is enforced by
     /// the compiler and invariants in unsafe code).
     ///
-    /// SAFETY:
+    /// # Safety
+    ///
     /// This function might temporarily change the state of the hart during the detection process.
     /// For this reason it is only safe to execute as part of the core initialization, not during
     /// standard operations.
@@ -75,12 +97,11 @@ pub trait Architecture {
 
     /// Return the faulting instruction at the provided exception PC.
     ///
-    /// SAFETY:
+    /// # Safety
+    ///
     /// The trap info must correspond to a valid trap info, no further checks are performed.
     unsafe fn get_raw_faulting_instr(trap_info: &TrapInfo) -> usize;
 
-    /// SAFETY:
-    /// None so far, TODO
     unsafe fn handle_virtual_load_store(instr: Instr, ctx: &mut VirtContext);
 
     /// Copies dest.len() bytes from src to dest, using the provided mode to read from src.

--- a/src/arch/pmp.rs
+++ b/src/arch/pmp.rs
@@ -164,7 +164,7 @@ impl PmpGroup {
         }
     }
 
-    pub fn init_pmp_group(nb_pmp: usize) -> PmpGroup {
+    pub fn init_pmp_group(nb_pmp: usize, start: usize, size: usize) -> PmpGroup {
         let mut pmp = Self::new(nb_pmp);
         let virtual_devices = Plat::create_virtual_devices();
 
@@ -174,7 +174,6 @@ impl PmpGroup {
             pmp.set_inactive(ALL_CATCH_OFFSET, 0);
 
             // Protect Miralis
-            let (start, size) = Plat::get_miralis_memory_start_and_size();
             pmp.set_napot(MIRALIS_OFFSET, start, size, pmpcfg::NO_PERMISSIONS);
 
             // Protect virtual devices

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -14,7 +14,6 @@ use super::{
 use crate::arch::pmp::PmpFlush;
 use crate::arch::{HardwareCapability, PmpGroup};
 use crate::decoder::Instr;
-use crate::main;
 use crate::virt::VirtContext;
 
 static HOST_CTX: Mutex<VirtContext> = Mutex::new(VirtContext::new(
@@ -31,9 +30,6 @@ pub struct HostArch {}
 
 impl Architecture for HostArch {
     fn init() {
-        // Use main to avoid "never used" warnings.
-        let _ = main;
-
         todo!()
     }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,6 +1,5 @@
 //! Debug utils for Miralis
 
-use crate::_stack_start;
 use crate::arch::{Arch, Architecture, Csr};
 use crate::config::TARGET_STACK_SIZE;
 
@@ -35,7 +34,8 @@ const MEMORY_PATTERN: u32 = 0x0BADBED0;
 /// This function traverses the stack to check how much of the stack has been used. This relies on
 /// the stack being initialized with the proper pattern.
 ///
-/// # SAFETY:
+/// # Safety
+///
 /// This function requires stack_top and stack_bottom to point to the start and end of the stack,
 /// and that the stack is not mutated for the whole duration of the function.
 unsafe fn get_max_stack_usage(stack_top: usize, stack_bottom: usize) -> usize {
@@ -63,14 +63,15 @@ unsafe fn get_max_stack_usage(stack_top: usize, stack_bottom: usize) -> usize {
 
 /// Display debug information related to maximal stack usage
 ///
-/// # SAFETY:
+/// # Safety
+///
 /// This function assumes a single-core system for now.
-pub unsafe fn log_stack_usage() {
+pub unsafe fn log_stack_usage(stack_start: usize) {
     /// Percent usage threshold for emitting a warning.
     const WARNING_THRESHOLD: usize = 80;
 
     // Get stack usage
-    let stack_bottom = &raw const _stack_start as usize;
+    let stack_bottom = stack_start;
     let hart_id = Arch::read_csr(Csr::Mhartid);
     let stack_bottom = stack_bottom + hart_id * TARGET_STACK_SIZE;
     let stack_top = stack_bottom + TARGET_STACK_SIZE;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -775,7 +775,7 @@ mod tests {
     /// https://luplab.gitlab.io/rvcodecjs/
     #[test]
     fn system_instructions() {
-        let mctx = MiralisContext::new(unsafe { Arch::detect_hardware() });
+        let mctx = MiralisContext::new(unsafe { Arch::detect_hardware() }, 0x100000, 0x2000);
         // ECALL: Environment call.
         assert_eq!(mctx.decode(0x00000073), Instr::Ecall);
         // EBREAK: Environment break.
@@ -805,7 +805,7 @@ mod tests {
 
     #[test]
     fn csr_instructions() {
-        let mctx = MiralisContext::new(unsafe { Arch::detect_hardware() });
+        let mctx = MiralisContext::new(unsafe { Arch::detect_hardware() }, 0x100000, 0x2000);
 
         // CSRRW: Atomic Read/Write CSR.
         assert_eq!(
@@ -870,7 +870,7 @@ mod tests {
 
     #[test]
     fn access_instructions() {
-        let mctx = MiralisContext::new(unsafe { Arch::detect_hardware() });
+        let mctx = MiralisContext::new(unsafe { Arch::detect_hardware() }, 0x10000, 0x2000);
 
         assert_eq!(
             mctx.decode(0xff87b703),
@@ -1057,7 +1057,7 @@ mod tests {
 
     #[test]
     fn decode_rd() {
-        let mctx = MiralisContext::new(unsafe { Arch::detect_hardware() });
+        let mctx = MiralisContext::new(unsafe { Arch::detect_hardware() }, 0x10000, 0x2000);
 
         let base_instruction: usize = 0x30001073;
 
@@ -1112,7 +1112,7 @@ mod tests {
 
     #[test]
     fn decode_rs1() {
-        let mctx = MiralisContext::new(unsafe { Arch::detect_hardware() });
+        let mctx = MiralisContext::new(unsafe { Arch::detect_hardware() }, 0x10000, 0x2000);
 
         let base_instruction: usize = 0x30001073;
 

--- a/src/device/tester.rs
+++ b/src/device/tester.rs
@@ -75,3 +75,9 @@ impl VirtTestDevice {
         }
     }
 }
+
+impl Default for VirtTestDevice {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -26,7 +26,9 @@ pub struct ClintDriver {
 impl ClintDriver {
     /// Creates a new CLINT driver from the base address of the CLINT device.
     ///
-    /// SAFETY: this function assumes that the base address corresponds to the base address of a
+    /// # Safety
+    ///
+    /// This function assumes that the base address corresponds to the base address of a
     /// CLINT-compatible device. In addition this function assumes that a at most one [ClintDriver]
     /// is initialized with the same base address and that no other code is accessing the CLINT
     /// device.

--- a/src/host.rs
+++ b/src/host.rs
@@ -19,9 +19,9 @@ pub struct MiralisContext {
 
 impl MiralisContext {
     /// Creates a new Miralis context with default values.
-    pub fn new(hw: HardwareCapability) -> Self {
+    pub fn new(hw: HardwareCapability, start: usize, size: usize) -> Self {
         Self {
-            pmp: PmpGroup::init_pmp_group(hw.available_reg.nb_pmp),
+            pmp: PmpGroup::init_pmp_group(hw.available_reg.nb_pmp, start, size),
             hw,
             devices: Plat::create_virtual_devices(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,300 @@
+//! Miralis
+//!
+//! The Miralis library, which needs to be embedded into an executable.
+//! This library exposes two main functions: [init] and [main_loop].
+
+// Mark the crate as no_std and no_main, but only when not running tests.
+// We need both std and main to be able to run tests in user-space on the host architecture.
+#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(test), no_main)]
+
+pub mod arch;
+mod benchmark;
+pub mod config;
+pub mod debug;
+pub mod decoder;
+pub mod device;
+pub mod driver;
+pub mod host;
+pub mod logger;
+pub mod platform;
+pub mod policy;
+pub mod utils;
+pub mod virt;
+
+use arch::{Arch, Architecture, Csr, Register};
+use benchmark::{Benchmark, Counter, Scope};
+use host::MiralisContext;
+pub use platform::init;
+use platform::{Plat, Platform};
+use policy::{Policy, PolicyModule};
+use virt::traits::*;
+use virt::{ExecutionMode, ExitResult, VirtContext};
+
+/// The virtuam firmware monitor main loop.
+///
+/// Runs the firmware and payload in a loop, handling the traps and interrupts and switching world
+/// when required..
+///
+/// # Safety
+///
+/// This function will start by passing control to the firmware. The hardware must have
+/// been initialized properly (including calling `miralis::init` and loading the firmware.
+pub unsafe fn main_loop(ctx: &mut VirtContext, mctx: &mut MiralisContext, policy: &mut Policy) {
+    loop {
+        Benchmark::start_interval_counters(Scope::RunVCPU);
+
+        unsafe { Arch::run_vcpu(ctx) };
+
+        Benchmark::stop_interval_counters(Scope::RunVCPU);
+        Benchmark::start_interval_counters(Scope::HandleTrap);
+
+        if handle_trap(ctx, mctx, policy) == ExitResult::Donne {
+            return;
+        }
+
+        Benchmark::stop_interval_counters(Scope::HandleTrap);
+        Benchmark::increment_counter(Counter::TotalExits);
+    }
+}
+
+fn handle_trap(
+    ctx: &mut VirtContext,
+    mctx: &mut MiralisContext,
+    policy: &mut Policy,
+) -> ExitResult {
+    if log::log_enabled!(log::Level::Trace) {
+        log_ctx(ctx);
+    }
+
+    if let Some(max_exit) = config::MAX_FIRMWARE_EXIT {
+        if ctx.nb_exits + 1 >= max_exit {
+            log::error!("Reached maximum number of exits: {}", ctx.nb_exits);
+            Plat::exit_failure();
+        }
+    }
+
+    if ctx.trap_info.is_from_mmode() {
+        // Trap comes from M mode: Miralis
+        handle_miralis_trap(ctx);
+        return ExitResult::Continue;
+    }
+
+    // Perform emulation
+    let exec_mode = ctx.mode.to_exec_mode();
+
+    // Keep track of the number of exit
+    ctx.nb_exits += 1;
+    let result = match exec_mode {
+        ExecutionMode::Firmware => ctx.handle_firmware_trap(mctx, policy),
+        ExecutionMode::Payload => ctx.handle_payload_trap(mctx, policy),
+    };
+
+    if exec_mode == ExecutionMode::Firmware {
+        Benchmark::increment_counter(Counter::FirmwareExits);
+    }
+
+    if exec_mode != ctx.mode.to_exec_mode() {
+        Benchmark::increment_counter(Counter::WorldSwitches);
+    }
+
+    // Inject interrupts if required
+    ctx.check_and_inject_interrupts();
+
+    // Check for execution mode change
+    match (exec_mode, ctx.mode.to_exec_mode()) {
+        (ExecutionMode::Firmware, ExecutionMode::Payload) => {
+            log::debug!("Execution mode: Firmware -> Payload");
+            unsafe { ctx.switch_from_firmware_to_payload(mctx) };
+            policy.switch_from_firmware_to_payload(ctx, mctx);
+
+            unsafe {
+                // Commit the PMP to hardware
+                Arch::write_pmp(&mctx.pmp).flush();
+            }
+        }
+        (ExecutionMode::Payload, ExecutionMode::Firmware) => {
+            log::debug!(
+                "Execution mode: Payload -> Firmware ({:?})",
+                ctx.trap_info.get_cause()
+            );
+            unsafe { ctx.switch_from_payload_to_firmware(mctx) };
+            policy.switch_from_payload_to_firmware(ctx, mctx);
+
+            unsafe {
+                // Commit the PMP to hardware
+                Arch::write_pmp(&mctx.pmp).flush();
+            }
+        }
+        _ => {} // No execution mode transition
+    }
+
+    result
+}
+
+/// Handle the trap coming from miralis
+fn handle_miralis_trap(ctx: &mut VirtContext) {
+    let trap = &ctx.trap_info;
+    log::error!("Unexpected trap while executing Miralis");
+    log::error!("  cause:   {} ({:?})", trap.mcause, trap.get_cause());
+    log::error!("  mepc:    0x{:x}", trap.mepc);
+    log::error!("  mtval:   0x{:x}", trap.mtval);
+    log::error!("  mstatus: 0x{:x}", trap.mstatus);
+    log::error!("  mip:     0x{:x}", trap.mip);
+
+    todo!("Miralis trap handler entered");
+}
+
+// —————————————————————————————— Debug Helper —————————————————————————————— //
+
+/// Log the current context using the trace log level.
+fn log_ctx(ctx: &VirtContext) {
+    let trap_info = &ctx.trap_info;
+    log::trace!(
+        "Trapped on hart {}:  {:?}",
+        ctx.hart_id,
+        ctx.trap_info.get_cause()
+    );
+    log::trace!(
+        "  mstatus: 0x{:<16x} mepc: 0x{:x}",
+        trap_info.mstatus,
+        trap_info.mepc
+    );
+    log::trace!(
+        "  mtval:   0x{:<16x} exits: {}  {:?}-mode",
+        ctx.trap_info.mtval,
+        ctx.nb_exits,
+        ctx.mode
+    );
+    log::trace!(
+        "  x1  {:<16x}  x2  {:<16x}  x3  {:<16x}",
+        ctx.get(Register::X1),
+        ctx.get(Register::X2),
+        ctx.get(Register::X3)
+    );
+    log::trace!(
+        "  x4  {:<16x}  x5  {:<16x}  x6  {:<16x}",
+        ctx.get(Register::X4),
+        ctx.get(Register::X5),
+        ctx.get(Register::X6)
+    );
+    log::trace!(
+        "  x7  {:<16x}  x8  {:<16x}  x9  {:<16x}",
+        ctx.get(Register::X7),
+        ctx.get(Register::X8),
+        ctx.get(Register::X9)
+    );
+    log::trace!(
+        "  x10 {:<16x}  x11 {:<16x}  x12 {:<16x}",
+        ctx.get(Register::X10),
+        ctx.get(Register::X11),
+        ctx.get(Register::X12)
+    );
+    log::trace!(
+        "  x13 {:<16x}  x14 {:<16x}  x15 {:<16x}",
+        ctx.get(Register::X13),
+        ctx.get(Register::X14),
+        ctx.get(Register::X15)
+    );
+    log::trace!(
+        "  x16 {:<16x}  x17 {:<16x}  x18 {:<16x}",
+        ctx.get(Register::X16),
+        ctx.get(Register::X17),
+        ctx.get(Register::X18)
+    );
+    log::trace!(
+        "  x19 {:<16x}  x20 {:<16x}  x21 {:<16x}",
+        ctx.get(Register::X19),
+        ctx.get(Register::X20),
+        ctx.get(Register::X21)
+    );
+    log::trace!(
+        "  x22 {:<16x}  x23 {:<16x}  x24 {:<16x}",
+        ctx.get(Register::X22),
+        ctx.get(Register::X23),
+        ctx.get(Register::X24)
+    );
+    log::trace!(
+        "  x25 {:<16x}  x26 {:<16x}  x27 {:<16x}",
+        ctx.get(Register::X25),
+        ctx.get(Register::X26),
+        ctx.get(Register::X27)
+    );
+    log::trace!(
+        "  x28 {:<16x}  x29 {:<16x}  x30 {:<16x}",
+        ctx.get(Register::X28),
+        ctx.get(Register::X29),
+        ctx.get(Register::X30)
+    );
+    log::trace!(
+        "  x31 {:<16x}  mie {:<16x}  mip {:<16x}",
+        ctx.get(Register::X31),
+        ctx.get(Csr::Mie),
+        ctx.get(Csr::Mip)
+    );
+}
+
+// ————————————————————————————————— Tests —————————————————————————————————— //
+
+/// We test some properties after handling a trap from firmware.
+/// We simulate a trap by creating a dummy trap state for the context of the machine.
+///
+/// Mideleg must be 0: don't allow nested interrupts when running Miralis.
+/// ctx.pc must be set to the handler start address.
+/// Mie, vMie, vMideleg must not change.
+/// vMepc and vMstatus.MIE must be set to corresponding values in ctx.trap_info.
+/// vMip must be updated to the value of Mip.
+/// In case of an interrupt, Mip must be cleared: avoid Miralis to trap again.
+#[cfg(test)]
+mod tests {
+
+    use crate::arch::{mstatus, Arch, Architecture, Csr, MCause, Mode};
+    use crate::handle_trap;
+    use crate::host::MiralisContext;
+    use crate::policy::{Policy, PolicyModule};
+    use crate::virt::VirtContext;
+
+    #[test]
+    fn handle_trap_state() {
+        let hw = unsafe { Arch::detect_hardware() };
+        let mut mctx = MiralisContext::new(hw, 0x10000, 0x2000);
+        let mut policy = Policy::init();
+        let mut ctx = VirtContext::new(0, mctx.hw.available_reg.nb_pmp, mctx.hw.extensions.clone());
+
+        // Firmware is running
+        ctx.mode = Mode::M;
+
+        ctx.csr.mstatus = 0;
+        ctx.csr.mie = 0b1;
+        ctx.csr.mideleg = 0;
+        ctx.csr.mtvec = 0x80200024; // Dummy mtvec
+
+        // Simulating a trap
+        ctx.trap_info.mepc = 0x80200042; // Dummy address
+        ctx.trap_info.mstatus = 0b10000000;
+        ctx.trap_info.mcause = MCause::Breakpoint as usize; // TODO : use a real int.
+        ctx.trap_info.mip = 0b1;
+        ctx.trap_info.mtval = 0;
+
+        unsafe {
+            Arch::write_csr(Csr::Mie, 0b1);
+            Arch::write_csr(Csr::Mip, 0b1);
+            Arch::write_csr(Csr::Mideleg, 0);
+        };
+        handle_trap(&mut ctx, &mut mctx, &mut policy);
+
+        assert_eq!(Arch::read_csr(Csr::Mideleg), 0, "mideleg must be 0");
+        assert_eq!(Arch::read_csr(Csr::Mie), 0b1, "mie must be 1");
+        // assert_eq!(Arch::read_csr(Csr::Mip), 0, "mip must be 0"); // TODO : uncomment if using a real int.
+        assert_eq!(ctx.pc, 0x80200024, "pc must be at handler start");
+        assert_eq!(ctx.csr.mip, 0b1, "mip must to be updated");
+        assert_eq!(ctx.csr.mie, 1, "mie must not change");
+        assert_eq!(ctx.csr.mideleg, 0, "mideleg must not change");
+        assert_eq!(ctx.csr.mepc, 0x80200042);
+        assert_eq!(
+            (ctx.csr.mstatus & mstatus::MPIE_FILTER) >> mstatus::MPIE_OFFSET,
+            0b1,
+            "mstatus.MPIE must be set to trap_info.mstatus.MPIE"
+        );
+    }
+}

--- a/src/platform/miralis.rs
+++ b/src/platform/miralis.rs
@@ -6,14 +6,13 @@ use log::Level;
 use miralis_abi::{failure, miralis_log_fmt, success};
 use spin::Mutex;
 
-use crate::config::{
-    PLATFORM_NB_HARTS, TARGET_FIRMWARE_ADDRESS, TARGET_PAYLOAD_ADDRESS, TARGET_STACK_SIZE,
-};
+use crate::config::{TARGET_FIRMWARE_ADDRESS, TARGET_PAYLOAD_ADDRESS};
 use crate::device::clint::{VirtClint, CLINT_SIZE};
 use crate::device::tester::{VirtTestDevice, TEST_DEVICE_SIZE};
 use crate::device::{self, VirtDevice};
 use crate::driver::ClintDriver;
-use crate::{Platform, _stack_start, _start_address};
+use crate::Platform;
+
 // —————————————————————————— Platform Parameters ——————————————————————————— //
 
 const MIRALIS_START_ADDR: usize = TARGET_FIRMWARE_ADDRESS;
@@ -65,19 +64,8 @@ impl Platform for MiralisPlatform {
         FIRMWARE_START_ADDR
     }
 
-    fn get_miralis_memory_start_and_size() -> (usize, usize) {
-        let size: usize;
-        // SAFETY: The unsafe block is required to get the address of the stack and start of
-        // Miralis, which are external values defined by the linker.
-        // We also ensure that `size` is non-negative and within reasonable bounds
-        unsafe {
-            size = (_stack_start as usize)
-                .checked_sub(_start_address as usize)
-                .and_then(|diff| diff.checked_add(TARGET_STACK_SIZE * PLATFORM_NB_HARTS))
-                .unwrap();
-        }
-
-        (MIRALIS_START_ADDR, size.next_power_of_two())
+    fn get_miralis_start() -> usize {
+        MIRALIS_START_ADDR
     }
 
     fn get_max_valid_address() -> usize {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -50,7 +50,7 @@ pub trait Platform {
     fn load_firmware() -> usize;
 
     /// Returns the start and size of Miralis's own memory.
-    fn get_miralis_memory_start_and_size() -> (usize, usize);
+    fn get_miralis_start() -> usize;
 
     /// Return maximum valid address
     fn get_max_valid_address() -> usize;

--- a/src/platform/virt.rs
+++ b/src/platform/virt.rs
@@ -8,15 +8,11 @@ use spin::Mutex;
 use uart_16550::MmioSerialPort;
 
 use super::Platform;
-use crate::config::{
-    PLATFORM_NAME, PLATFORM_NB_HARTS, TARGET_FIRMWARE_ADDRESS, TARGET_STACK_SIZE,
-    TARGET_START_ADDRESS,
-};
+use crate::config::{PLATFORM_NAME, TARGET_FIRMWARE_ADDRESS, TARGET_START_ADDRESS};
 use crate::device::clint::{VirtClint, CLINT_SIZE};
 use crate::device::tester::{VirtTestDevice, TEST_DEVICE_SIZE};
 use crate::device::{self, VirtDevice};
 use crate::driver::ClintDriver;
-use crate::{_stack_start, _start_address};
 
 const SERIAL_PORT_BASE_ADDRESS: usize = 0x10000000;
 const TEST_MMIO_ADDRESS: usize = 0x100000;
@@ -103,19 +99,8 @@ impl Platform for VirtPlatform {
         FIRMWARE_START_ADDR
     }
 
-    fn get_miralis_memory_start_and_size() -> (usize, usize) {
-        let size: usize;
-        // SAFETY: The unsafe block is required to get the address of the stack and start of
-        // Miralis, which are external values defined by the linker.
-        // We also ensure that `size` is non-negative and within reasonable bounds
-        unsafe {
-            size = (_stack_start as usize)
-                .checked_sub(_start_address as usize)
-                .and_then(|diff| diff.checked_add(TARGET_STACK_SIZE * PLATFORM_NB_HARTS))
-                .unwrap();
-        }
-
-        (MIRALIS_START_ADDR, size.next_power_of_two())
+    fn get_miralis_start() -> usize {
+        MIRALIS_START_ADDR
     }
 
     fn get_max_valid_address() -> usize {

--- a/src/platform/visionfive2.rs
+++ b/src/platform/visionfive2.rs
@@ -8,14 +8,13 @@ use log::Level;
 use spin::Mutex;
 
 use crate::arch::{Arch, Architecture};
-use crate::config::{
-    PLATFORM_NB_HARTS, TARGET_FIRMWARE_ADDRESS, TARGET_STACK_SIZE, TARGET_START_ADDRESS,
-};
+use crate::config::{TARGET_FIRMWARE_ADDRESS, TARGET_START_ADDRESS};
 use crate::device::clint::{VirtClint, CLINT_SIZE};
 use crate::device::tester::{VirtTestDevice, TEST_DEVICE_SIZE};
 use crate::device::{self, VirtDevice};
 use crate::driver::ClintDriver;
-use crate::{Platform, _stack_start, _start_address};
+use crate::Platform;
+
 // —————————————————————————— Platform Parameters ——————————————————————————— //
 
 const SERIAL_PORT_BASE_ADDRESS: usize = 0x10000000;
@@ -82,19 +81,8 @@ impl Platform for VisionFive2Platform {
         FIRMWARE_START_ADDR
     }
 
-    fn get_miralis_memory_start_and_size() -> (usize, usize) {
-        let size: usize;
-        // SAFETY: The unsafe block is required to get the address of the stack and start of
-        // Miralis, which are external values defined by the linker.
-        // We also ensure that `size` is non-negative and within reasonable bounds
-        unsafe {
-            size = (_stack_start as usize)
-                .checked_sub(_start_address as usize)
-                .and_then(|diff| diff.checked_add(TARGET_STACK_SIZE * PLATFORM_NB_HARTS))
-                .unwrap();
-        }
-
-        (MIRALIS_START_ADDR, size.next_power_of_two())
+    fn get_miralis_start() -> usize {
+        MIRALIS_START_ADDR
     }
 
     fn get_max_valid_address() -> usize {


### PR DESCRIPTION
This commit turns Miralis into a library. At a high level it introduces a new `main.rs` file which contains the entry point (previously in `arch`). The main file is only expected to be compiler to RISC-V so it is allowed to contain inline assembly.
The library is intended to be re-used in multiple contexts, including as part of unit tests and symbolic execution. For that purpose inline assembly is restricted to `arch/metal.rs`.

This is only a first step in the librarification of Miralis. While this commit decouples the entry point from the rest if Miralis, the library is still taking control over much of the machine and execution.