### PR TITLE
Add timeout to github CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ env:
 jobs:
   Miralis:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       RUSTFLAGS: --deny warnings
     steps:

--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -10,6 +10,7 @@ env:
 jobs:
   Miralis:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       RUSTFLAGS: --deny warnings
     steps:


### PR DESCRIPTION
This commit configures a timout of 30 minutes on the CI tests. We just got a CI pipeline running for 6 hours, this commit should prevent that.