### PR TITLE
SailBugfix: Correct MPP Value in `mstatus` During `mret` Execution

### DIFF
--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -341,6 +341,10 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
                 self.csr.misa =
                     (value & arch_misa & misa::MISA_CHANGE_FILTER & !misa::DISABLED) | misa::MXL;
 
+                if (self.csr.misa & misa::U) == 0 && mctx.hw.extensions.has_s_extension {
+                    panic!("Miralis doesn't support deactivating the U mode extension, please implement the feature")
+                }
+
                 if (self.csr.misa & misa::S) == 0 && mctx.hw.extensions.has_s_extension {
                     panic!("Miralis doesn't support deactivating the S mode extension, please implement the feature")
                 }


### PR DESCRIPTION
This bug fix resolves an issue when bit 20 of the `misa` register is equal to zero, indicating that U-mode is unavailable or disabled. In such cases, the `MPP` field in `mstatus` should be updated to reflect M-mode (`0b11`) instead of incorrectly defaulting to U-mode (`0b00`).