### PR TITLE
SailBugFix: Correct mvendorid to 32 bits as per RISC-V specification

### DIFF
--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -123,7 +123,7 @@ impl Architecture for HostArch {
             Csr::Mtvec => ctx.csr.mtvec,
             Csr::Mscratch => ctx.csr.mscratch,
             Csr::Mip => ctx.csr.mip,
-            Csr::Mvendorid => ctx.csr.mvendorid,
+            Csr::Mvendorid => ctx.csr.mvendorid as usize,
             Csr::Marchid => ctx.csr.marchid,
             Csr::Mimpid => ctx.csr.mimpid,
             Csr::Pmpcfg(index) => ctx.csr.pmpcfg[index],
@@ -203,7 +203,7 @@ impl Architecture for HostArch {
             Csr::Mtvec => ctx.csr.mtvec = value,
             Csr::Mscratch => ctx.csr.mscratch = value,
             Csr::Mip => ctx.csr.mip = value, // TODO : add write filter
-            Csr::Mvendorid => ctx.csr.mvendorid = value,
+            Csr::Mvendorid => ctx.csr.mvendorid = value as u32,
             Csr::Marchid => ctx.csr.marchid = value,
             Csr::Mimpid => ctx.csr.mimpid = value,
             Csr::Pmpcfg(index) => ctx.csr.pmpcfg[index] = value,

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -79,7 +79,7 @@ impl RegisterContextGetter<Csr> for VirtContext {
             }
             Csr::Mtvec => self.csr.mtvec,
             Csr::Mscratch => self.csr.mscratch,
-            Csr::Mvendorid => self.csr.mvendorid,
+            Csr::Mvendorid => self.csr.mvendorid as usize,
             Csr::Marchid => self.csr.marchid,
             Csr::Mimpid => self.csr.mimpid,
             Csr::Pmpcfg(pmp_cfg_idx) => {

--- a/src/virt/mod.rs
+++ b/src/virt/mod.rs
@@ -143,7 +143,7 @@ pub struct VirtCsr {
     pub mie: usize,
     pub mip: usize,
     pub mtvec: usize,
-    pub mvendorid: usize,
+    pub mvendorid: u32,
     pub marchid: usize,
     pub mimpid: usize,
     pub mcycle: usize,


### PR DESCRIPTION
According to the official RISC-V specification: "The mvendorid CSR is a 32-bit read-only register."

Previously, this register was incorrectly emulated as a 64-bit register, which deviated from the standard. This commit rectifies the issue by implementing mvendorid as a 32-bit register, ensuring compliance with the specification.