### PR TITLE
SailBugfix: Ensure least significant bits of SEPC and MEPC Are Always…

### DIFF
--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -447,7 +447,7 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
                 if value > Plat::get_max_valid_address() {
                     return;
                 }
-                self.csr.mepc = value
+                self.csr.mepc = value & !0b1 // First bit is always zero
             }
             Csr::Mcause => {
                 let cause = MCause::new(value);
@@ -483,7 +483,7 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
                 if value > Plat::get_max_valid_address() {
                     return;
                 }
-                self.csr.sepc = value
+                self.csr.sepc = value & !0b1 // First bit is always zero
             }
             Csr::Scause => {
                 let cause = MCause::new(value);


### PR DESCRIPTION
… Zero

This commit fixes an issue where the least significant bits of the SEPC and MEPC registers were not correctly set to 0. According to the RISC-V specification, these bits are always 0 to ensure proper alignment of exception return addresses.