### PR TITLE
SailBugfix: mcycle and minstret are not read-only registers

### DIFF
--- a/firmware/csr_ops/perf_counters.rs
+++ b/firmware/csr_ops/perf_counters.rs
@@ -20,7 +20,7 @@ fn test_simple_regs() {
             out(reg) res,
         );
     }
-    assert_eq!(res, 0);
+    assert_eq!(res, 0x42);
 
     // Test minstret
     unsafe {
@@ -32,7 +32,7 @@ fn test_simple_regs() {
             out(reg) res,
         );
     }
-    assert_eq!(res, 0);
+    assert_eq!(res, 0x42);
 
     // Test mcountinhibit
     unsafe {

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -423,8 +423,8 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
                 }
                 self.csr.pmpaddr[pmp_addr_idx] = Csr::PMP_ADDR_LEGAL_MASK & value;
             }
-            Csr::Mcycle => (),                    // Read-only 0
-            Csr::Minstret => (),                  // Read-only 0
+            Csr::Mcycle => self.csr.mcycle = value,
+            Csr::Minstret => self.csr.minstret = value,
             Csr::Mhpmcounter(_counter_idx) => (), // Read-only 0
             Csr::Mcountinhibit => (),             // Read-only 0
             Csr::Mhpmevent(_event_idx) => (),     // Read-only 0


### PR DESCRIPTION
Miralis incorrectly treats the mcycle and minstret registers as read-only, which contradicts the official RISC-V specification. This commit resolves the discrepancy to align Miralis's behavior with the specification.