### PR TITLE
SailBugfix: Enable ASID Field Updates and Validate satp Mode

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -256,14 +256,6 @@ pub mod misa {
     pub const MISA_CHANGE_FILTER: usize = 0x0000000003FFFFFF;
 }
 
-// ————————————— Supervisor Address Translation and Protection —————————————— //
-
-#[allow(unused)]
-pub mod satp {
-    /// Constant to filter out non-writable fields of the satp csr
-    pub const SATP_CHANGE_FILTER: usize = 0x00000FFFFFFFFFFF;
-}
-
 // ————————————————————————————— Machine Status ————————————————————————————— //
 
 /// Constants for the Machine Status (mstatus) CSR.


### PR DESCRIPTION
This fix addresses two issues in the satp handling logic:

It now allows writing to the ASID field, ensuring proper support for address space identifiers. It ensures that the satp register is updated only when the mode field contains a valid value. Previously, the implementation did not permit specifying the ASID field and allowed setting invalid values in the mode field, leading to non-compliance with the RISC-V specification. This commit aligns the behavior of satp with the official specification.