### PR TITLE
SailBugfix: When value is unknown, return 0 instead of panicking

### DIFF
--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -216,7 +216,11 @@ impl RegisterContextGetter<Csr> for VirtContext {
             Csr::Vlenb => self.csr.vlenb,
 
             // Unknown
-            Csr::Unknown => panic!("Tried to access unknown CSR: {:?}", register),
+            Csr::Unknown => {
+                log::warn!("Tried to access unknown CSR: {:?}", register);
+                // Official specification returns 0x0 when the register is unknown
+                0x0
+            }
         }
     }
 }


### PR DESCRIPTION
If the register is unknown, the specification simply returns 0 instead of panicking. This commit resolves the divergence in behavior with Miralis.