### PR TITLE
Set sensible interrupt mask in userspace hardware capability

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -406,6 +406,10 @@ pub mod mie {
     /// LCOFIE
     pub const LCOFIE_OFFSET: usize = 13;
     pub const LCOFIE_FILTER: usize = 0b1 << LCOFIE_OFFSET;
+
+    /// Mask with all valid interrupt bits
+    pub const ALL_INT: usize =
+        SSIE_FILTER | MSIE_FILTER | STIE_FILTER | MTIE_FILTER | SEIE_FILTER | MEIE_FILTER;
 }
 
 // ———————————————————— Machine Trap-Vector Base-Address ———————————————————— //

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -101,7 +101,7 @@ impl Architecture for HostArch {
 
     unsafe fn detect_hardware() -> HardwareCapability {
         HardwareCapability {
-            interrupts: usize::MAX,
+            interrupts: mie::ALL_INT,
             hart: 0,
             _marker: PhantomData,
             available_reg: super::RegistersCapability {


### PR DESCRIPTION
This commit sets a interrupt mask with sensible (i.e. that follow the spec) values. Before we had all bits to 1 which caused issues with symbolic execution, namely that the write to MIP was not filtered properly as it should be.