### PR TITLE
SailBugfix: Make misa read only

### DIFF
--- a/firmware/csr_ops/main.rs
+++ b/firmware/csr_ops/main.rs
@@ -306,89 +306,21 @@ fn test_mcause() {
 
 fn test_misa() {
     let misa: u64;
-    unsafe {
-        // Read the misa CSR into the variable misa
-        asm!("csrr {}, misa", out(reg) misa);
-    }
-    if (misa & (1 << 7)) == 0 {
-        test_misa_no_h()
-    } else {
-        test_misa_h()
-    }
-}
+    let res: u64;
 
-fn test_misa_h() {
-    const MISA: usize = 0x8000000000141181;
-    let mut res: usize;
+    // Read the misa CSR into the variable misa
+    unsafe { asm!("csrr {}, misa", out(reg) misa) };
+
+    // Try to write bits to the misa CSR
     unsafe {
         asm!(
-        "li {0}, 0x80000000001411a9",
-        "csrw misa, {0}",
-        "csrr {1}, misa",
-        out(reg) _,
-        out(reg) res,
+        "csrw misa, {all}",
+        "csrr {res}, misa",
+        all = in(reg) u64::MAX, // All bits to 1
+        res = out(reg) res,
         );
     }
-    assert_eq!(res, MISA, "Unexpected misa");
-
-    unsafe {
-        asm!(
-        "li {0}, 0x800000000FFFFFFF",
-        "csrw misa, {0}",
-        "csrr {1}, misa",
-        out(reg) _,
-        out(reg) res,
-        );
-    }
-    assert_eq!(res, MISA, "Could write misa bits that should be zero");
-
-    unsafe {
-        asm!(
-        "li {0}, 0x00000000001411a9",
-        "csrw misa, {0}",
-        "csrr {1}, misa",
-        out(reg) _,
-        out(reg) res,
-        );
-    }
-    assert_eq!(res, MISA, "Could clean upper misa bit");
-}
-
-fn test_misa_no_h() {
-    const MISA: usize = 0x8000000000141101;
-    let mut res: usize;
-    unsafe {
-        asm!(
-        "li {0}, 0x8000000000141129",
-        "csrw misa, {0}",
-        "csrr {1}, misa",
-        out(reg) _,
-        out(reg) res,
-        );
-    }
-    assert_eq!(res, MISA, "Unexpected misa");
-
-    unsafe {
-        asm!(
-        "li {0}, 0x800000000FFFFFFF",
-        "csrw misa, {0}",
-        "csrr {1}, misa",
-        out(reg) _,
-        out(reg) res,
-        );
-    }
-    assert_eq!(res, MISA, "Could write misa bits that should be zero");
-
-    unsafe {
-        asm!(
-        "li {0}, 0x0000000000141129",
-        "csrw misa, {0}",
-        "csrr {1}, misa",
-        out(reg) _,
-        out(reg) res,
-        );
-    }
-    assert_eq!(res, MISA, "Could clean upper misa bit");
+    assert_eq!(res, misa, "misa CSR is exprected to be read-only");
 }
 
 // ————————————————— Machine Configuration Pointer register ————————————————— //

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,11 +73,7 @@ pub(crate) extern "C" fn main(_hart_id: usize, device_tree_blob_addr: usize) -> 
         // Configure the firmware context
         ctx.set(Register::X10, hart_id);
         ctx.set(Register::X11, device_tree_blob_addr);
-        ctx.set_csr(
-            Csr::Misa,
-            Arch::read_csr(Csr::Misa) & !misa::DISABLED,
-            &mut mctx,
-        );
+        ctx.csr.misa = Arch::read_csr(Csr::Misa) & !misa::DISABLED;
         ctx.pc = firmware_addr;
 
         if DELEGATE_PERF_COUNTER {

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -6,7 +6,7 @@
 use super::{VirtContext, VirtCsr};
 use crate::arch::mstatus::{MBE_FILTER, SBE_FILTER, UBE_FILTER};
 use crate::arch::pmp::pmpcfg;
-use crate::arch::{hstatus, menvcfg, mie, misa, mstatus, Arch, Architecture, Csr, Register};
+use crate::arch::{hstatus, menvcfg, mie, mstatus, Arch, Architecture, Csr, Register};
 use crate::{debug, MiralisContext, Plat, Platform};
 
 /// A module exposing the traits to manipulate registers of a virtual context.
@@ -355,25 +355,7 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
 
                 self.csr.mstatus = new_value;
             }
-            Csr::Misa => {
-                // misa shows the extensions available : we cannot have more than possible in hardware
-                let arch_misa: usize = Arch::read_csr(Csr::Misa);
-                // Update misa to a legal value
-                self.csr.misa =
-                    (value & arch_misa & misa::MISA_CHANGE_FILTER & !misa::DISABLED) | misa::MXL;
-
-                if (self.csr.misa & misa::U) == 0 && mctx.hw.extensions.has_s_extension {
-                    panic!("Miralis doesn't support deactivating the U mode extension, please implement the feature")
-                }
-
-                if (self.csr.misa & misa::S) == 0 && mctx.hw.extensions.has_s_extension {
-                    panic!("Miralis doesn't support deactivating the S mode extension, please implement the feature")
-                }
-
-                if (self.csr.misa & misa::H) == 0 && mctx.hw.extensions.has_h_extension {
-                    panic!("Miralis doesn't support deactivating the H mode extension, please implement the feature")
-                }
-            }
+            Csr::Misa => {} // Read only register, we don't support deactivating extensions in Miralis
             Csr::Mie => self.csr.mie = value & hw.interrupts & mie::MIE_WRITE_FILTER,
             Csr::Mip => {
                 let value = value & hw.interrupts & mie::MIP_WRITE_FILTER;


### PR DESCRIPTION
According to the official risc-v specification, the Misa bit can be read only. This fits the best with the fact that we don't want to explicitly emulate disabling instructions in Miralis.