### PR TITLE
SailBugfix: Fix write mask for SIP

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -385,12 +385,18 @@ pub mod mie {
     pub const MIDELEG_READ_ONLY_ZERO: usize = MSIE_FILTER | MTIE_FILTER | MEIE_FILTER;
 
     // Mie fields constants
+    /// USIE
+    pub const USIE_OFFSET: usize = 0;
+    pub const USIE_FILTER: usize = 0b1 << USIE_OFFSET;
     /// SSIE
     pub const SSIE_OFFSET: usize = 1;
     pub const SSIE_FILTER: usize = 0b1 << SSIE_OFFSET;
     /// MSIE
     pub const MSIE_OFFSET: usize = 3;
     pub const MSIE_FILTER: usize = 0b1 << MSIE_OFFSET;
+    /// UTIE
+    pub const UTIE_OFFSET: usize = 4;
+    pub const UTIE_FILTER: usize = 0b1 << UTIE_OFFSET;
     /// STIE
     pub const STIE_OFFSET: usize = 5;
     pub const STIE_FILTER: usize = 0b1 << STIE_OFFSET;

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -4,6 +4,7 @@
 //! specification.
 
 use super::{VirtContext, VirtCsr};
+use crate::arch::mie::MEIE_FILTER;
 use crate::arch::mstatus::{MBE_FILTER, SBE_FILTER, UBE_FILTER};
 use crate::arch::pmp::pmpcfg;
 use crate::arch::{hstatus, menvcfg, mie, misa, mstatus, Arch, Architecture, Csr, Register};
@@ -291,15 +292,15 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
                     mprv,
                 );
                 // MBE - We currently don't implement the feature as it is a very nice feature
-                if new_value & MBE_FILTER != 0 {
+                if new_value & mstatus::MBE_FILTER != 0 {
                     todo!("MBE filter is not implemented - please implement it");
                 }
                 // SBE - We currently don't implement the feature as it is a very nice feature
-                if new_value & SBE_FILTER != 0 {
+                if new_value & mstatus::SBE_FILTER != 0 {
                     todo!("SBE filter is not implemented - please implement it");
                 }
                 // UBE - We currently don't implement the feature as it is a very nice feature
-                if new_value & UBE_FILTER != 0 {
+                if new_value & mstatus::UBE_FILTER != 0 {
                     todo!("UBE filter is not implemented - please implement it");
                 }
                 // TVM & TSR are read only when no S-mode is available
@@ -541,10 +542,20 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
             Csr::Scause => self.csr.scause = value,
             Csr::Stval => self.csr.stval = value,
             Csr::Sip => {
-                // Clear S bits
-                let mip = self.get(Csr::Mip) & !mie::SIE_FILTER;
-                // Set S bits to new value
-                self.set_csr(Csr::Mip, mip | (value & mie::SIE_FILTER), mctx);
+                if self.csr.mideleg & mie::SSIE_FILTER != 0 {
+                    self.csr.mip = (value & mie::SSIE_FILTER) | (!mie::SSIE_FILTER & self.csr.mip);
+                }
+
+                if self.csr.misa & misa::N != 0 {
+                    if self.csr.mideleg & mie::UEIE_FILTER != 0 {
+                        self.csr.mip =
+                            (value & mie::UEIE_FILTER) | (!mie::UEIE_FILTER & self.csr.mip);
+                    }
+                    if self.csr.mideleg & mie::USIE_FILTER != 0 {
+                        self.csr.mip =
+                            (value & mie::USIE_FILTER) | (!mie::USIE_FILTER & self.csr.mip);
+                    }
+                }
             }
             Csr::Satp => {
                 let satp_mode = (value >> 60) & 0b1111;


### PR DESCRIPTION
The current Miralis implementation can only modify the SIE field, whereas the RISC-V implementation can also modify the UEIE and USIE fields.