### PR TITLE
Add U-boot ci/cd test with strict protect payload policy

### DIFF
--- a/miralis.toml
+++ b/miralis.toml
@@ -189,6 +189,12 @@ firmware = "linux-lock"
 config = "qemu-virt-protect-payload"
 description = "Integration test for the protect payload policy, running Linux with OpenSBI"
 
+[test.protect-payload-uboot]
+firmware = "opensbi-jump"
+payload = "u-boot-exit"
+config = "qemu-virt-protect-payload"
+description = "Integration test for the protect payload policy, running U-boot with OpenSBI"
+
 [test.protect-payload-misaligned]
 firmware = "misaligned_op"
 config = "spike-protect-payload"


### PR DESCRIPTION
We want to test Miralis on the board with the strict protect payload policy. Since we start the load the kernel with u-boot, we want to make sure this component works with the strict protect payload policy.