### PR TITLE
SailBugfix: Fix pmp configuration read

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -385,7 +385,14 @@ impl MiralisContext {
             0xF11 => Csr::Mvendorid,
             0xF12 => Csr::Marchid,
             0xF13 => Csr::Mimpid,
-            0x3A0..=0x3AF => Csr::Pmpcfg(csr - 0x3A0),
+            0x3A0..=0x3AF => {
+                let id = csr - 0x3A0;
+                if id % 2 == 0 {
+                    Csr::Pmpcfg(id)
+                } else {
+                    Csr::Unknown // Invalid on rv64
+                }
+            }
             0x3B0..=0x3EF => Csr::Pmpaddr(csr - 0x3B0),
             0xB00 => Csr::Mcycle,
             0xB02 => Csr::Minstret,

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -84,15 +84,17 @@ impl RegisterContextGetter<Csr> for VirtContext {
             Csr::Mimpid => self.csr.mimpid,
             Csr::Pmpcfg(pmp_cfg_idx) => {
                 if pmp_cfg_idx % 2 == 1 {
-                    // Illegal because we are in a RISCV64 setting
-                    panic!("Illegal PMP_CFG {:?}", register)
+                    // This should not happen, as we check in the decoder for the pmp index.
+                    // We return zero nontheless, because it is what the Sail implementation does,
+                    // so that way we pass the model checking step.
+                    log::warn!("Invalid pmpcfg {}", pmp_cfg_idx);
+                    return 0;
                 }
                 if pmp_cfg_idx >= self.nb_pmp / 8 {
                     // This PMP is not emulated
                     return 0;
                 }
                 self.csr.pmpcfg[pmp_cfg_idx / 2]
-                    & VirtCsr::get_pmp_cfg_filter(pmp_cfg_idx, self.nb_pmp)
             }
             Csr::Pmpaddr(pmp_addr_idx) => {
                 if pmp_addr_idx >= self.nb_pmp {


### PR DESCRIPTION
We have two divergence with the official risc-v specification. First we apply a mask on other configurations and second we panic if the value is illegal instead of returning zero. This commit fixes the divergences with the codebase.