### PR TITLE
SailBugfix: Fix pmpcfg write

### DIFF
--- a/src/arch/pmp.rs
+++ b/src/arch/pmp.rs
@@ -314,7 +314,7 @@ impl PmpGroup {
             let reg_idx = idx / 8;
             let inner_idx = idx % 8;
             let shift = inner_idx * 8; // 8 bits per config
-            let cfg = (pmpcfg[reg_idx] >> shift) & 0xff;
+            let cfg = (pmpcfg[reg_idx] >> shift) & 0x7f; // Remove the lock bit
             self.set_pmpcfg(idx + offset, cfg as u8);
         }
     }

--- a/src/arch/registers.rs
+++ b/src/arch/registers.rs
@@ -246,14 +246,14 @@ impl Csr {
         | (0b1 << 7) << 48
         | (0b1 << 7) << 56;
 
-    pub const PMP_CFG_LEGAL_MASK: usize = !(0b11 << 5)
+    pub const PMP_CFG_LEGAL_MASK: usize = !((0b11 << 5)
         | (0b11 << 5) << 8
         | (0b11 << 5) << 16
         | (0b11 << 5) << 24
         | (0b11 << 5) << 32
         | (0b11 << 5) << 40
         | (0b11 << 5) << 48
-        | (0b11 << 5) << 56;
+        | (0b11 << 5) << 56);
 
     pub const PMP_ADDR_LEGAL_MASK: usize = !(0b1111111111 << 54);
 


### PR DESCRIPTION
The combination of W = 1 and R = 0 is reserved by the implementation, and our write mask was not functioning correctly. This commit addresses both issues simultaneously.