### PR TITLE
SailBugfix: Filter out SIE with MIDELEG bits and provide visibility f…

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -366,6 +366,9 @@ pub mod mie {
     /// Constant to filter out SIE bits of mstatus
     pub const SIE_FILTER: usize = SSIE_FILTER | STIE_FILTER | SEIE_FILTER | LCOFIE_FILTER;
 
+    /// Constant to filter out SIE and UIE bits of mstatus
+    pub const SIE_FILTER_WITH_U: usize = SIE_FILTER | UEIE_FILTER | USIE_FILTER | UTIE_FILTER;
+
     /// Constant to filter out writable bits of mie.
     pub const MIE_WRITE_FILTER: usize = SIE_FILTER | MSIE_FILTER | MTIE_FILTER | MEIE_FILTER;
 

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -142,7 +142,7 @@ impl RegisterContextGetter<Csr> for VirtContext {
             Csr::Mtval => self.csr.mtval,
             //Supervisor-level CSRs
             Csr::Sstatus => self.get(Csr::Mstatus) & mstatus::SSTATUS_FILTER,
-            Csr::Sie => self.get(Csr::Mie) & mie::SIE_FILTER,
+            Csr::Sie => self.get(Csr::Mie) & mie::SIE_FILTER_WITH_U & self.get(Csr::Mideleg),
             Csr::Stvec => self.csr.stvec,
             Csr::Scounteren => self.csr.scounteren as usize,
             Csr::Senvcfg => self.csr.senvcfg,


### PR DESCRIPTION
…or userspace interrupt delegation

Our implementation in Miralis overlooks two points. First, we should also check if the MIDELEG bit is set. Second, the official specification allows the software to read the bits for user interrupt delegation.