### PR TITLE
SailBugfix: Correct alignment mask application for sepc reads

### DIFF
--- a/firmware/csr_ops/main.rs
+++ b/firmware/csr_ops/main.rs
@@ -54,11 +54,11 @@ fn test_mscratch() {
 // ————————————————————————————— Write to MEPC —————————————————————————————— //
 
 fn test_mepc() {
-    let secret: usize = 0x42;
+    let secret: usize = 0x40;
     let res: usize;
     unsafe {
         asm!(
-            "li {0}, 0x42",
+            "li {0}, 0x40",
             "csrw mepc, {0}",
             "csrr {1}, mepc",
             in(reg) secret,

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -147,7 +147,7 @@ impl RegisterContextGetter<Csr> for VirtContext {
             Csr::Scounteren => self.csr.scounteren as usize,
             Csr::Senvcfg => self.csr.senvcfg,
             Csr::Sscratch => self.csr.sscratch,
-            Csr::Sepc => self.csr.sepc,
+            Csr::Sepc => self.csr.sepc & self.pc_alignment_mask(),
             Csr::Scause => self.csr.scause,
             Csr::Stval => self.csr.stval,
             Csr::Sip => self.get(Csr::Mip) & mie::SIE_FILTER,

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -137,7 +137,7 @@ impl RegisterContextGetter<Csr> for VirtContext {
             Csr::Dscratch1 => todo!(),              // TODO : normal read
             Csr::Mconfigptr => self.csr.mconfigptr, // Read-only
             Csr::Tselect => !self.csr.tselect,
-            Csr::Mepc => self.csr.mepc,
+            Csr::Mepc => self.csr.mepc & self.pc_alignment_mask(),
             Csr::Mcause => self.csr.mcause,
             Csr::Mtval => self.csr.mtval,
             //Supervisor-level CSRs

--- a/src/virt/mod.rs
+++ b/src/virt/mod.rs
@@ -7,7 +7,7 @@ mod world_switch;
 pub use csr::traits;
 pub use emulator::ExitResult;
 
-use crate::arch::{mie, ExtensionsCapability, Mode, TrapInfo};
+use crate::arch::{mie, misa, ExtensionsCapability, Mode, TrapInfo};
 
 /// The execution mode, either virtualized firmware or native payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -140,6 +140,15 @@ impl VirtContext {
             nb_exits: 0,
             hart_id,
             extensions: available_extension,
+        }
+    }
+
+    /// Expected PC alignment, depending on the C extension.
+    pub fn pc_alignment_mask(&self) -> usize {
+        if (self.csr.misa & misa::C != 0) || (misa::DISABLED & misa::C != 0) {
+            !0b00
+        } else {
+            !0b10
         }
     }
 }


### PR DESCRIPTION
The RISC-V specification mandates applying an alignment mask when accessing the sepc register. This ensures that the program counter (pc) aligns properly according to the underlying instruction set (e.g., word alignment for RV32 or RV64). In Miralis, this alignment mask was not applied.