### PR TITLE
SailBugfix: Filter out SIP with MIDELEG bits and provide visibility f…

### DIFF
--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -148,7 +148,7 @@ impl RegisterContextGetter<Csr> for VirtContext {
             Csr::Sepc => self.csr.sepc,
             Csr::Scause => self.csr.scause,
             Csr::Stval => self.csr.stval,
-            Csr::Sip => self.get(Csr::Mip) & mie::SIE_FILTER,
+            Csr::Sip => self.get(Csr::Mip) & mie::SIE_FILTER_WITH_U & self.get(Csr::Mideleg),
             Csr::Satp => self.csr.satp,
             Csr::Scontext => self.csr.scontext,
             Csr::Stimecmp => self.csr.stimecmp,


### PR DESCRIPTION
…or userspace interrupt delegation

Our implementation in Miralis overlooks two points. First, we should also check if the MIDELEG bit is set. Second, the official specification allows the software to read the bits for user interrupt delegation.