### PR TITLE
Disable "Debug Console Extension" in the protect payload policy.

### DIFF
--- a/config/ubuntu.toml
+++ b/config/ubuntu.toml
@@ -22,3 +22,5 @@ name = "opensbi-jump"
 [target.payload]
 name = "u-boot"
 
+[policy]
+name = "protect_payload"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,3 +43,18 @@ pub mod abi_protect_payload {
     /// Ecall to lock the payload
     pub const MIRALIS_PROTECT_PAYLOAD_LOCK_FID: usize = 0x1;
 }
+
+// ———————————————————————————— RISCV SBI Definitions ————————————————————————————— //
+
+// Constants to idenfity the various SBI codes we use in Miralis
+// Documentation available here: https://github.com/riscv-non-isa/riscv-sbi-doc
+
+pub mod sbi_codes {
+
+    // SBI return codes used in Miralis
+    pub const SBI_ERR_DENIED: usize = (-4_i64) as usize;
+
+    // SBI EIDs and FIDs
+    /// The debug console extension defines a generic mechanism for boot-time early prints.
+    pub const SBI_DEBUG_CONSOLE_EXTENSION_EID: usize = 0x4442434E;
+}

--- a/src/virt/emulator.rs
+++ b/src/virt/emulator.rs
@@ -441,6 +441,14 @@ impl VirtContext {
             MCause::EcallFromSMode if self.get(Register::X17) == abi::MIRALIS_EID => {
                 return self.handle_ecall();
             }
+            MCause::EcallFromSMode => {
+                log::debug!(
+                    "Forwarding ecall from s-mode with values 0x{:x}, 0x{:x} to the firmware",
+                    self.get(Register::X16),
+                    self.get(Register::X17)
+                );
+                self.emulate_jump_trap_handler();
+            }
             MCause::MachineTimerInt => {
                 self.handle_machine_timer_interrupt(mctx);
             }


### PR DESCRIPTION
Currently, Ubuntu tries to use the "Debug Console Extension" during the early stages of the boot. This extension is currently incompatible with the protect payload policy, and we explicitly disable it. In the future, we could implement bounce buffers.