### PR TITLE
Add Support for Building the VisionFive2 Image in the just File

### DIFF
--- a/justfile
+++ b/justfile
@@ -82,3 +82,10 @@ analyze-benchmark input_path:
 
 # The following line gives highlighting on vim
 # vim: set ft=make :
+
+vision-img:
+	just build config/visionfive2.toml
+	mkimage -f misc/visionfive2.its -A riscv -O u-boot -T firmware vision.img
+	curl -L -O https://github.com/epfl-dcsl/visionfive2-doc/raw/refs/heads/main/fw_payload.bin
+	@echo "Follow these instructions to run Miralis on the VisionFive2 board: https://github.com/epfl-dcsl/visionfive2-doc"
+	@echo "Follow these instruction to flash an OS on the board (section 3.3.1): https://doc-en.rvspace.org/VisionFive2/PDF/VisionFive2_QSG.pdf"

--- a/misc/visionfive2.its
+++ b/misc/visionfive2.its
@@ -1,0 +1,37 @@
+/dts-v1/;
+
+/ {
+        description = "U-boot-spl FIT image for JH7110 VisionFive2";
+        #address-cells = <2>;
+
+        images {
+                firmware {
+                        description = "miralis";
+                        data = /incbin/("../target/riscv-unknown-miralis/debug/miralis.img");
+                        type = "firmware";
+                        os = "u-boot";
+                        load = <0x0 0x43000000>;
+                        entry = <0x0 0x43000000>;
+                        compression = "none";
+                };
+
+                virtual-firmware {
+                        description = "virtual firmware";
+                        data = /incbin/("../fw_payload.bin");
+                        type = "firmware";
+                        arch = "riscv";
+                        load = <0x0 0x40000000>;
+                        compression = "none";
+                };
+        };
+
+    configurations {
+        default = "config-1";
+
+        config-1 {
+            description = "U-boot-spl FIT config for JH7110 VisionFive2";
+            firmware = "firmware";
+            loadables = "virtual-firmware";
+        };
+    };
+};


### PR DESCRIPTION
This commit introduces a new command in the just file, enabling users to build the VisionFive2 image with a single command, incorporating Miralis support.