### PR TITLE
Add support for virtual PLIC

### DIFF
--- a/src/arch/pmp.rs
+++ b/src/arch/pmp.rs
@@ -210,7 +210,7 @@ impl PmpGroup {
 
     pub fn init_pmp_group(nb_pmp: usize, start: usize, size: usize) -> PmpGroup {
         let mut pmp = Self::new(nb_pmp);
-        let virtual_devices = Plat::create_virtual_devices();
+        let virtual_devices = Plat::get_virtual_devices();
 
         // Configure PMP registers, if available
         if pmp.nb_pmp >= 8 {

--- a/src/device/clint.rs
+++ b/src/device/clint.rs
@@ -7,9 +7,8 @@ use crate::config::PLATFORM_NB_HARTS;
 use crate::debug;
 use crate::device::{DeviceAccess, Width};
 use crate::driver::clint::{
-    MSIP_OFFSET, MSIP_WIDTH, MTIMECMP_OFFSET, MTIMECMP_WIDTH, MTIME_OFFSET,
+    ClintDriver, MSIP_OFFSET, MSIP_WIDTH, MTIMECMP_OFFSET, MTIMECMP_WIDTH, MTIME_OFFSET,
 };
-use crate::driver::ClintDriver;
 use crate::virt::VirtContext;
 
 // ————————————————————————————— Virtual CLINT —————————————————————————————— //

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -4,6 +4,7 @@ use crate::arch::Width;
 use crate::virt::VirtContext;
 
 pub mod clint;
+pub mod plic;
 pub mod tester;
 
 // ———————————————————————————— Virtual Devices ————————————————————————————— //

--- a/src/device/plic.rs
+++ b/src/device/plic.rs
@@ -1,0 +1,125 @@
+//! Virtual PLIC device
+//!
+//! This modules implements a virtual PLIC device, that is the front-end of the virtual device
+//! exposed to the virtual firmware.
+//!
+//! For the specification of the PLIC see here:
+//! https://github.com/riscv/riscv-plic-spec/releases/tag/1.0.0
+
+use spin::Mutex;
+
+use crate::debug;
+use crate::device::{DeviceAccess, Width};
+use crate::driver::plic::PlicDriver;
+use crate::virt::VirtContext;
+
+// —————————————————————————————— Virtual PLIC —————————————————————————————— //
+
+/// Size of the address space covered by the PLIC.
+pub const PLIC_SIZE: usize = 0x4000000;
+
+/// Represents a virtual PLIC (Platform-Level Interrupt Controller) device
+#[derive(Debug)]
+pub struct VirtPlic {
+    /// A driver for the physical CLINT
+    driver: &'static Mutex<PlicDriver>,
+}
+
+impl DeviceAccess for VirtPlic {
+    fn read_device(
+        &self,
+        offset: usize,
+        r_width: Width,
+        _ctx: &mut VirtContext,
+    ) -> Result<usize, &'static str> {
+        log::trace!("read PLIC at offset 0x{:x}", offset);
+        let plic = self.driver.lock();
+
+        // TODO: for now we don't virtualize the PLIC, but simply implement a pass-through
+        // We should implement a proper virtualization.
+        unsafe {
+            let ptr = plic.add_base_offset(offset);
+            let val = match r_width {
+                Width::Byte => (ptr as *const u8).read_volatile() as usize,
+                Width::Byte2 => (ptr as *const u16).read_volatile() as usize,
+                Width::Byte4 => (ptr as *const u32).read_volatile() as usize,
+                Width::Byte8 => (ptr as *const u64).read_volatile() as usize,
+            };
+
+            Ok(val)
+        }
+    }
+
+    fn write_device(
+        &self,
+        offset: usize,
+        w_width: Width,
+        value: usize,
+        _ctx: &mut VirtContext,
+    ) -> Result<(), &'static str> {
+        // Validate the write width and alignment
+        if offset % 4 != 0 && w_width != Width::Byte4 {
+            debug::warn_once!(
+                "Unexpected write width/alignment: offset 0x{:x}, width: {}",
+                offset,
+                w_width as u8
+            );
+
+            // We return early in this case, simply discarding the write
+            return Ok(());
+        }
+
+        // Log some information, for debugging purpose
+        match offset {
+            0x000000..0x001000 => {
+                log::trace!("Setting interrupt {} to priority 0x{:x}", offset / 4, value)
+            }
+            0x002000..0x200000 => {
+                let context = (offset - 0x002000) / 0x80;
+                let source_group = ((offset - 0x002000) % 0x80) * 8;
+                log::trace!(
+                    "Setting enable bits for sources {}-{} to 0x{:x} on context {}",
+                    source_group,
+                    source_group + 31,
+                    value,
+                    context
+                );
+            }
+            0x200000..0x400000 => {
+                let context = (offset - 0x200000) % 0x1000;
+                match offset % 0x1000 {
+                    0 => log::trace!(
+                        "Set priority threshold for context {} to 0x{:x}",
+                        context,
+                        value
+                    ),
+                    4 => log::trace!("Complete interrupt {} on context {}", value, context),
+                    _ => log::trace!("Write to reserved area at offset 0x{:x}", offset),
+                }
+            }
+            _ => log::debug!("Writting to unknon PLIC region at offset 0x{:x}", offset),
+        }
+        let plic = self.driver.lock();
+
+        // TODO: for now we don't virtualize the PLIC, but simply implement a pass-through
+        // We should implement a proper virtualization.
+        unsafe {
+            let ptr = plic.add_base_offset(offset);
+            match w_width {
+                Width::Byte => (ptr as *mut u8).write_volatile(value as u8),
+                Width::Byte2 => (ptr as *mut u16).write_volatile(value as u16),
+                Width::Byte4 => (ptr as *mut u32).write_volatile(value as u32),
+                Width::Byte8 => (ptr as *mut u64).write_volatile(value as u64),
+            }
+
+            Ok(())
+        }
+    }
+}
+
+impl VirtPlic {
+    /// Creates a new virtual PLIC device backed by a physical PLIC.
+    pub const fn new(driver: &'static Mutex<PlicDriver>) -> Self {
+        Self { driver }
+    }
+}

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,0 +1,8 @@
+//! # Drivers
+//!
+//! This module regroups various drivers used by Miralis. While Miralis doesn't virtualize devices
+//! such as disks and network card, it does virtualize some of the devices required to multiplex
+//! interrupts, such as the CLINT and PLIC.
+
+pub mod clint;
+pub mod plic;

--- a/src/driver/plic.rs
+++ b/src/driver/plic.rs
@@ -1,0 +1,32 @@
+//! # PLIC Driver
+//!
+//! This module implements a driver for the RISC-V PLIC (Plaftform-Level Interrupt Controller). It
+//! is inteded to be used as a back-end for the virtual PLIC device.
+//!
+//! For the PLIC spec see here:
+//! https://github.com/riscv/riscv-plic-spec/releases/tag/1.0.0
+
+#[derive(Clone, Debug)]
+pub struct PlicDriver {
+    /// The base address of the physical PLIC.
+    base: usize,
+}
+
+impl PlicDriver {
+    /// Creates a new PLIC driver from the base address of the PLIC device.
+    ///
+    /// # Safety
+    ///
+    /// This function assumes that the base address corresponds to the base address of a
+    /// PLIC-compatible device. In addition this function assumes that a at most one [PlicDriver]
+    /// is initialized with the same base address and that no other code is accessing the PLIC
+    /// device.
+    pub const unsafe fn new(base: usize) -> Self {
+        Self { base }
+    }
+
+    /// Add an offset to the base of the PLIC and return the resulting address.
+    pub fn add_base_offset(&self, offset: usize) -> usize {
+        self.base.checked_add(offset).expect("Invalid offset")
+    }
+}

--- a/src/host.rs
+++ b/src/host.rs
@@ -14,7 +14,7 @@ pub struct MiralisContext {
     /// Hardware capabilities of the core (hart).
     pub hw: HardwareCapability,
     /// List of device with PMP
-    pub devices: [device::VirtDevice; 2],
+    pub devices: &'static [device::VirtDevice],
 }
 
 impl MiralisContext {
@@ -23,7 +23,7 @@ impl MiralisContext {
         Self {
             pmp: PmpGroup::init_pmp_group(hw.available_reg.nb_pmp, start, size),
             hw,
-            devices: Plat::create_virtual_devices(),
+            devices: Plat::get_virtual_devices(),
         }
     }
 }

--- a/src/platform/miralis.rs
+++ b/src/platform/miralis.rs
@@ -9,7 +9,7 @@ use spin::Mutex;
 use crate::config::{TARGET_FIRMWARE_ADDRESS, TARGET_PAYLOAD_ADDRESS};
 use crate::device::clint::{VirtClint, CLINT_SIZE};
 use crate::device::tester::{VirtTestDevice, TEST_DEVICE_SIZE};
-use crate::device::{self, VirtDevice};
+use crate::device::VirtDevice;
 use crate::driver::ClintDriver;
 use crate::Platform;
 
@@ -33,6 +33,22 @@ static VIRT_CLINT: VirtClint = VirtClint::new(&CLINT_MUTEX);
 
 /// The virtual test device.
 static VIRT_TEST_DEVICE: VirtTestDevice = VirtTestDevice::new();
+
+/// The list of virtual devices exposed on the platform.
+static VIRT_DEVICES: &[VirtDevice; 2] = &[
+    VirtDevice {
+        start_addr: CLINT_BASE,
+        size: CLINT_SIZE,
+        name: "CLINT",
+        device_interface: &VIRT_CLINT,
+    },
+    VirtDevice {
+        start_addr: TEST_DEVICE_BASE,
+        size: TEST_DEVICE_SIZE,
+        name: "TEST",
+        device_interface: &VIRT_TEST_DEVICE,
+    },
+];
 
 // ———————————————————————————————— Platform ———————————————————————————————— //
 
@@ -72,22 +88,8 @@ impl Platform for MiralisPlatform {
         usize::MAX
     }
 
-    fn create_virtual_devices() -> [VirtDevice; 2] {
-        let virtual_clint: device::VirtDevice = VirtDevice {
-            start_addr: CLINT_BASE,
-            size: CLINT_SIZE,
-            name: "CLINT",
-            device_interface: &VIRT_CLINT,
-        };
-
-        let virtual_test_device: device::VirtDevice = VirtDevice {
-            start_addr: TEST_DEVICE_BASE,
-            size: TEST_DEVICE_SIZE,
-            name: "TEST",
-            device_interface: &VIRT_TEST_DEVICE,
-        };
-
-        [virtual_clint, virtual_test_device]
+    fn get_virtual_devices() -> &'static [VirtDevice] {
+        VIRT_DEVICES
     }
 
     fn get_clint() -> &'static Mutex<ClintDriver> {

--- a/src/platform/miralis.rs
+++ b/src/platform/miralis.rs
@@ -10,7 +10,7 @@ use crate::config::{TARGET_FIRMWARE_ADDRESS, TARGET_PAYLOAD_ADDRESS};
 use crate::device::clint::{VirtClint, CLINT_SIZE};
 use crate::device::tester::{VirtTestDevice, TEST_DEVICE_SIZE};
 use crate::device::VirtDevice;
-use crate::driver::ClintDriver;
+use crate::driver::clint::ClintDriver;
 use crate::Platform;
 
 // —————————————————————————— Platform Parameters ——————————————————————————— //
@@ -56,6 +56,7 @@ pub struct MiralisPlatform {}
 
 impl Platform for MiralisPlatform {
     const NB_HARTS: usize = usize::MAX;
+    const NB_VIRT_DEVICES: usize = 2;
 
     fn name() -> &'static str {
         "Miralis"

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -31,7 +31,7 @@ pub trait Platform {
     fn debug_print(level: Level, args: fmt::Arguments);
     fn exit_success() -> !;
     fn exit_failure() -> !;
-    fn create_virtual_devices() -> [device::VirtDevice; 2];
+    fn get_virtual_devices() -> &'static [device::VirtDevice];
     fn get_clint() -> &'static Mutex<ClintDriver>;
     fn get_vclint() -> &'static VirtClint;
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -11,7 +11,7 @@ use spin::Mutex;
 // Re-export virt platform by default for now
 use crate::arch::{Arch, Architecture};
 use crate::device::clint::VirtClint;
-use crate::driver::ClintDriver;
+use crate::driver::clint::ClintDriver;
 use crate::{device, logger};
 
 /// Export the current platform.
@@ -56,6 +56,7 @@ pub trait Platform {
     fn get_max_valid_address() -> usize;
 
     const NB_HARTS: usize;
+    const NB_VIRT_DEVICES: usize;
 }
 
 pub fn init() {
@@ -64,4 +65,12 @@ pub fn init() {
 
     // Trap handler
     Arch::init();
+
+    // Ideally we would like to check this statically, until we find a good solution we assert it
+    // at runtime.
+    assert_eq!(
+        Plat::NB_VIRT_DEVICES,
+        Plat::get_virtual_devices().len(),
+        "Mismatch between advertised number of devices and returned value"
+    );
 }

--- a/src/platform/virt.rs
+++ b/src/platform/virt.rs
@@ -11,7 +11,7 @@ use super::Platform;
 use crate::config::{PLATFORM_NAME, TARGET_FIRMWARE_ADDRESS, TARGET_START_ADDRESS};
 use crate::device::clint::{VirtClint, CLINT_SIZE};
 use crate::device::tester::{VirtTestDevice, TEST_DEVICE_SIZE};
-use crate::device::{self, VirtDevice};
+use crate::device::VirtDevice;
 use crate::driver::ClintDriver;
 
 const SERIAL_PORT_BASE_ADDRESS: usize = 0x10000000;
@@ -48,6 +48,22 @@ static VIRT_CLINT: VirtClint = VirtClint::new(&CLINT_MUTEX);
 
 /// The virtual test device.
 static VIRT_TEST_DEVICE: VirtTestDevice = VirtTestDevice::new();
+
+/// The list of virtual devices exposed on the platform.
+static VIRT_DEVICES: &[VirtDevice; 2] = &[
+    VirtDevice {
+        start_addr: CLINT_BASE,
+        size: CLINT_SIZE,
+        name: "CLINT",
+        device_interface: &VIRT_CLINT,
+    },
+    VirtDevice {
+        start_addr: TEST_DEVICE_BASE,
+        size: TEST_DEVICE_SIZE,
+        name: "TEST",
+        device_interface: &VIRT_TEST_DEVICE,
+    },
+];
 
 // ———————————————————————————————— Platform ———————————————————————————————— //
 
@@ -107,22 +123,8 @@ impl Platform for VirtPlatform {
         usize::MAX
     }
 
-    fn create_virtual_devices() -> [VirtDevice; 2] {
-        let virtual_clint: device::VirtDevice = VirtDevice {
-            start_addr: CLINT_BASE,
-            size: CLINT_SIZE,
-            name: "CLINT",
-            device_interface: &VIRT_CLINT,
-        };
-
-        let virtual_test_device: device::VirtDevice = VirtDevice {
-            start_addr: TEST_DEVICE_BASE,
-            size: TEST_DEVICE_SIZE,
-            name: "TEST",
-            device_interface: &VIRT_TEST_DEVICE,
-        };
-
-        [virtual_clint, virtual_test_device]
+    fn get_virtual_devices() -> &'static [VirtDevice] {
+        VIRT_DEVICES
     }
 
     fn get_clint() -> &'static Mutex<ClintDriver> {

--- a/src/platform/visionfive2.rs
+++ b/src/platform/visionfive2.rs
@@ -10,7 +10,7 @@ use crate::arch::{Arch, Architecture};
 use crate::config::{TARGET_FIRMWARE_ADDRESS, TARGET_START_ADDRESS};
 use crate::device::clint::{VirtClint, CLINT_SIZE};
 use crate::device::tester::{VirtTestDevice, TEST_DEVICE_SIZE};
-use crate::device::{self, VirtDevice};
+use crate::device::VirtDevice;
 use crate::driver::ClintDriver;
 use crate::Platform;
 
@@ -33,9 +33,27 @@ static CLINT_MUTEX: Mutex<ClintDriver> = unsafe { Mutex::new(ClintDriver::new(CL
 
 /// The virtual CLINT device.
 static VIRT_CLINT: VirtClint = VirtClint::new(&CLINT_MUTEX);
+
 /// The virtual test device.
 static VIRT_TEST_DEVICE: VirtTestDevice = VirtTestDevice::new();
+
 pub static WRITER: Mutex<Writer> = Mutex::new(Writer::new(SERIAL_PORT_BASE_ADDRESS));
+
+/// The list of virtual devices exposed on the platform.
+static VIRT_DEVICES: &[VirtDevice; 2] = &[
+    VirtDevice {
+        start_addr: CLINT_BASE,
+        size: CLINT_SIZE,
+        name: "CLINT",
+        device_interface: &VIRT_CLINT,
+    },
+    VirtDevice {
+        start_addr: TEST_DEVICE_BASE,
+        size: TEST_DEVICE_SIZE,
+        name: "TEST",
+        device_interface: &VIRT_TEST_DEVICE,
+    },
+];
 
 // ———————————————————————————————— Platform ———————————————————————————————— //
 
@@ -88,22 +106,8 @@ impl Platform for VisionFive2Platform {
         usize::MAX
     }
 
-    fn create_virtual_devices() -> [VirtDevice; 2] {
-        let virtual_clint: device::VirtDevice = VirtDevice {
-            start_addr: CLINT_BASE,
-            size: CLINT_SIZE,
-            name: "CLINT",
-            device_interface: &VIRT_CLINT,
-        };
-
-        let virtual_test_device: device::VirtDevice = VirtDevice {
-            start_addr: TEST_DEVICE_BASE,
-            size: TEST_DEVICE_SIZE,
-            name: "TEST",
-            device_interface: &VIRT_TEST_DEVICE,
-        };
-
-        [virtual_clint, virtual_test_device]
+    fn get_virtual_devices() -> &'static [VirtDevice] {
+        VIRT_DEVICES
     }
 
     fn get_clint() -> &'static Mutex<ClintDriver> {

--- a/src/platform/visionfive2.rs
+++ b/src/platform/visionfive2.rs
@@ -11,7 +11,7 @@ use crate::config::{TARGET_FIRMWARE_ADDRESS, TARGET_START_ADDRESS};
 use crate::device::clint::{VirtClint, CLINT_SIZE};
 use crate::device::tester::{VirtTestDevice, TEST_DEVICE_SIZE};
 use crate::device::VirtDevice;
-use crate::driver::ClintDriver;
+use crate::driver::clint::ClintDriver;
 use crate::Platform;
 
 // —————————————————————————— Platform Parameters ——————————————————————————— //
@@ -61,6 +61,7 @@ pub struct VisionFive2Platform {}
 
 impl Platform for VisionFive2Platform {
     const NB_HARTS: usize = 5;
+    const NB_VIRT_DEVICES: usize = 2;
 
     fn name() -> &'static str {
         "VisionFive 2 board"

--- a/src/virt/emulator.rs
+++ b/src/virt/emulator.rs
@@ -349,7 +349,7 @@ impl VirtContext {
             MCause::StoreAccessFault | MCause::LoadAccessFault => {
                 // PMP faults
                 if let Some(device) =
-                    device::find_matching_device(self.trap_info.mtval, &mctx.devices)
+                    device::find_matching_device(self.trap_info.mtval, mctx.devices)
                 {
                     let instr = unsafe { Arch::get_raw_faulting_instr(&self.trap_info) };
                     let instr = mctx.decode(instr);


### PR DESCRIPTION
This commit adds support for a virtual PLIC device, and refactors the virtual device code to allow for more flexibility in the per-platform number of devices.

We do not enable virtual PLIC yet, as it would required trapping S-mode accesses too (se commit message for details).