### PR TITLE
ROUND2 SailBugfix: Filter with mideleg before reading sie.

### DIFF
--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -142,7 +142,7 @@ impl RegisterContextGetter<Csr> for VirtContext {
             Csr::Mtval => self.csr.mtval,
             //Supervisor-level CSRs
             Csr::Sstatus => self.get(Csr::Mstatus) & mstatus::SSTATUS_FILTER,
-            Csr::Sie => self.get(Csr::Mie) & mie::SIE_FILTER,
+            Csr::Sie => self.get(Csr::Mie) & mie::SIE_FILTER & self.get(Csr::Mideleg),
             Csr::Stvec => self.csr.stvec,
             Csr::Scounteren => self.csr.scounteren as usize,
             Csr::Senvcfg => self.csr.senvcfg,


### PR DESCRIPTION
Reading the sie field in the official risc-v specification implies a filtering step with the mideleg register.