### PR TITLE
Introduce Zicntr extension

### DIFF
--- a/model_checking/src/adapters.rs
+++ b/model_checking/src/adapters.rs
@@ -282,6 +282,7 @@ pub fn sail_to_miralis(sail_ctx: SailVirtCtx) -> VirtContext {
             has_crypto_extension: true,
             has_sstc_extension: false,
             is_sstc_enabled: false,
+            has_zicntr: true,
             has_h_extension: false,
             has_s_extension: false,
             has_v_extension: true,

--- a/model_checking/src/symbolic.rs
+++ b/model_checking/src/symbolic.rs
@@ -51,6 +51,7 @@ pub fn new_ctx() -> VirtContext {
             has_crypto_extension: true,
             has_sstc_extension: false,
             is_sstc_enabled: false,
+            has_zicntr: true,
             has_h_extension: false,
             has_s_extension: false,
             has_v_extension: true,

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -369,6 +369,7 @@ impl Architecture for MetalArch {
                 is_sstc_enabled: false, // Since the virtual menvcfg is initialized with 0
                 has_v_extension: false,
                 has_crypto_extension: false,
+                has_zicntr: false,
             },
         }
     }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -158,6 +158,8 @@ pub struct ExtensionsCapability {
     pub has_v_extension: bool,
     /// Crypto extension
     pub has_crypto_extension: bool,
+    /// Zicntr - Standard Extension for Base Counters and Timers
+    pub has_zicntr: bool,
     /// If the sstc extension is supported
     pub has_sstc_extension: bool,
     /// If the sstc extension is enabled

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -26,6 +26,7 @@ static HOST_CTX: Mutex<VirtContext> = Mutex::new(VirtContext::new(
         is_sstc_enabled: false,
         has_v_extension: false,
         has_crypto_extension: false,
+        has_zicntr: true,
     },
 ));
 
@@ -115,6 +116,7 @@ impl Architecture for HostArch {
                 has_s_extension: true,
                 has_v_extension: true,
                 has_crypto_extension: false,
+                has_zicntr: true,
                 has_sstc_extension: false,
                 is_sstc_enabled: false,
             },

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -396,9 +396,27 @@ impl MiralisContext {
             0x3B0..=0x3EF => Csr::Pmpaddr(csr - 0x3B0),
             0xB00 => Csr::Mcycle,
             0xB02 => Csr::Minstret,
-            0xC00 => Csr::Cycle,
-            0xC01 => Csr::Time,
-            0xC02 => Csr::Instret,
+            0xC00 => {
+                if self.hw.extensions.has_zicntr {
+                    Csr::Cycle
+                } else {
+                    Csr::Unknown
+                }
+            }
+            0xC01 => {
+                if self.hw.extensions.has_zicntr {
+                    Csr::Time
+                } else {
+                    Csr::Unknown
+                }
+            }
+            0xC02 => {
+                if self.hw.extensions.has_zicntr {
+                    Csr::Instret
+                } else {
+                    Csr::Unknown
+                }
+            }
             0xB03..=0xB1F => Csr::Mhpmcounter(csr - 0xB03), // Mhpm counters start at 3 and end at 31 : we shift them by 3 to start at 0 and end at 29
             0x320 => Csr::Mcountinhibit,
             0x323..=0x33F => Csr::Mhpmevent(csr - 0x323),


### PR DESCRIPTION
Zinctr is a optional standard extension and is not available on the board. This commit adds the possibility to activate / deactivate the extension depending on the hardware.