### PR TITLE
Introduce Zihpm extension

### DIFF
--- a/model_checking/src/adapters.rs
+++ b/model_checking/src/adapters.rs
@@ -286,6 +286,7 @@ pub fn sail_to_miralis(sail_ctx: SailVirtCtx) -> VirtContext {
             has_h_extension: false,
             has_s_extension: false,
             has_v_extension: true,
+            has_zihpm_extension: true,
         },
     );
 

--- a/model_checking/src/symbolic.rs
+++ b/model_checking/src/symbolic.rs
@@ -55,6 +55,7 @@ pub fn new_ctx() -> VirtContext {
             has_h_extension: false,
             has_s_extension: false,
             has_v_extension: true,
+            has_zihpm_extension: true,
         },
     );
 

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -370,6 +370,7 @@ impl Architecture for MetalArch {
                 has_v_extension: false,
                 has_crypto_extension: false,
                 has_zicntr: false,
+                has_zihpm_extension: true,
             },
         }
     }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -164,6 +164,8 @@ pub struct ExtensionsCapability {
     pub has_sstc_extension: bool,
     /// If the sstc extension is enabled
     pub is_sstc_enabled: bool,
+    /// Has Zihpm extension
+    pub has_zihpm_extension: bool,
 }
 
 // ———————————————————————————— Privilege Modes ————————————————————————————— //

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -27,6 +27,7 @@ static HOST_CTX: Mutex<VirtContext> = Mutex::new(VirtContext::new(
         has_v_extension: false,
         has_crypto_extension: false,
         has_zicntr: true,
+        has_zihpm_extension: true,
     },
 ));
 
@@ -119,6 +120,7 @@ impl Architecture for HostArch {
                 has_zicntr: true,
                 has_sstc_extension: false,
                 is_sstc_enabled: false,
+                has_zihpm_extension: true,
             },
         }
     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -417,9 +417,22 @@ impl MiralisContext {
                     Csr::Unknown
                 }
             }
-            0xB03..=0xB1F => Csr::Mhpmcounter(csr - 0xB03), // Mhpm counters start at 3 and end at 31 : we shift them by 3 to start at 0 and end at 29
+            0xB03..=0xB1F => {
+                // Mhpm counters start at 3 and end at 31 : we shift them by 3 to start at 0 and end at 29
+                if self.hw.extensions.has_zihpm_extension {
+                    Csr::Mhpmcounter(csr - 0xB03)
+                } else {
+                    Csr::Unknown
+                }
+            }
             0x320 => Csr::Mcountinhibit,
-            0x323..=0x33F => Csr::Mhpmevent(csr - 0x323),
+            0x323..=0x33F => {
+                if self.hw.extensions.has_zihpm_extension {
+                    Csr::Mhpmevent(csr - 0x323)
+                } else {
+                    Csr::Unknown
+                }
+            }
             0x306 => Csr::Mcounteren,
             0x30a => Csr::Menvcfg,
             0x747 => Csr::Mseccfg,


### PR DESCRIPTION
Zihpm is a optional standard extension and is not available on the board. This commit adds the possibility to activate / deactivate the extension depending on the hardware.