### PR TITLE
Disable support for machine external interrupts (MEI)

### DIFF
--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -37,7 +37,7 @@ impl Architecture for MetalArch {
         // Wouldn't try to read physical address as virtual (with jump, for example)
         unsafe { Arch::write_csr(Csr::Satp, 0) };
         // Ensure that virtualized interrupts are enabled
-        unsafe { Arch::set_csr_bits(Csr::Mie, mie::MIDELEG_READ_ONLY_ZERO) };
+        unsafe { Arch::set_csr_bits(Csr::Mie, mie::MSIE_FILTER | mie::MTIE_FILTER) };
     }
 
     #[inline]

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -367,6 +367,10 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
             }
             Csr::Misa => {} // Read only register, we don't support deactivating extensions in Miralis
             Csr::Mie => {
+                if value & mie::MEIE_FILTER != 0 {
+                    debug::warn_once!("MEIE bit in 'mie' is not yet supported");
+                }
+
                 self.csr.mie = hw.interrupts
                     & ((value & mie::MIE_WRITE_FILTER) | (self.csr.mie & !mie::MIE_WRITE_FILTER))
             }


### PR DESCRIPTION
This commit disables support for machine-mode external interrupt. As we currently don't emulate the PLIC (which would require trapping on M-mode accesses too) we don't have a proper solution to handle MEI (which would require claiming the interrupt, hence interacting with the physical PLIC an potentially racing with the OS/firmware).
So instead we simply decide to disable MEI as OpenSBI doesn't use them. In the future we could re-enable them selectively if the PLIC is virtualized, to support firmwares such as Zephyr with MEI enabled.