### PR TITLE
SailBugfix: Filter with mideleg before reading sip.

### DIFF
--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -150,7 +150,7 @@ impl RegisterContextGetter<Csr> for VirtContext {
             Csr::Sepc => self.csr.sepc & self.pc_alignment_mask(),
             Csr::Scause => self.csr.scause,
             Csr::Stval => self.csr.stval,
-            Csr::Sip => self.get(Csr::Mip) & mie::SIE_FILTER,
+            Csr::Sip => self.get(Csr::Mip) & mie::SIE_FILTER & self.get(Csr::Mideleg),
             Csr::Satp => self.csr.satp,
             Csr::Scontext => self.csr.scontext,
             Csr::Stimecmp => self.csr.stimecmp,


### PR DESCRIPTION
Reading the sip field in the official risc-v specification implies a filtering step with the mideleg register.