### PR TITLE
PerformanceFix: Compile in release mode

### DIFF
--- a/config/test/spike-latency-benchmark.toml
+++ b/config/test/spike-latency-benchmark.toml
@@ -8,7 +8,13 @@ color = true
 max_pmp = 8
 delegate_perf_counters=true
 
-
 [platform]
 name = "spike"
 
+[target.miralis]
+# Build profile for Miralis (dev profile is set by default)
+profile = "release"
+
+[target.firmware]
+# Build profile for the firmware (dev profile is set by default)
+profile = "release"


### PR DESCRIPTION
We want to benchmark in release mode, because it is faster