### PR TITLE
Bugfix: measure cold build time in CI

### DIFF
--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -33,8 +33,6 @@ jobs:
         chmod +x spike
         echo "$PWD" >> $GITHUB_PATH
         sudo apt install device-tree-compiler
-    - name: Benchmark cycles
-      run: cargo run -- run --firmware tracing_firmware --config ./config/test/spike-latency-benchmark.toml > cycles.txt
     - name: Push stats
       shell: bash
       run: |

--- a/misc/push_stats.sh
+++ b/misc/push_stats.sh
@@ -45,6 +45,9 @@ fi
 
 file="cycles.txt"
 
+# Run the benchmarks
+Run cargo run -- run --firmware tracing_firmware --config ./config/test/spike-latency-benchmark.toml > $file
+
 # Extract the number after "firmware cost:"
 firmware_cost=$(grep -i "Firmware cost :" "$file"  | sed -E 's/.*Firmware cost : ([0-9]+).*/\1/')
 payload_cost=$(grep -i "Payload cost :" "$file" | sed -E 's/.*Payload cost : ([0-9]+).*/\1/')


### PR DESCRIPTION
This commit fixes a bug where the cold build time measured where in fact warm, as the CI was first benchmarking and then measuring build time. This commit fixes the issue by inverting the order of those two steps.