### PR TITLE
Formal verification of interrupt virtualization

### DIFF
--- a/model_checking/src/lib.rs
+++ b/model_checking/src/lib.rs
@@ -1,4 +1,5 @@
-use sail_model::{execute_MRET, execute_WFI};
+use sail_model::{execute_MRET, execute_WFI, trap_handler};
+use sail_prelude::BitVector;
 
 #[macro_use]
 mod symbolic;
@@ -36,5 +37,42 @@ pub fn wfi() {
         ctx,
         adapters::sail_to_miralis(sail_ctx),
         "wfi instruction emulation is not correct"
+    );
+}
+
+#[cfg_attr(kani, kani::proof)]
+#[cfg_attr(test, test)]
+pub fn interrupt_virtualization() {
+    let (mut ctx, _, mut sail_ctx) = symbolic::new_symbolic_contexts();
+
+    // Generation of an interrupt
+    let current_interrupt = any!(usize) % 64;
+
+    ctx.inject_interrupt(current_interrupt);
+
+    // Intr field is always true because we formally check the interrupt virtualization and therefore traps are out of scope
+    {
+        // Makes the borrow checker happy
+        let cur_privilege = sail_ctx.cur_privilege;
+        let pc = sail_ctx.PC;
+        let ret_pc = trap_handler(
+            &mut sail_ctx,
+            cur_privilege,
+            true,
+            BitVector::new(current_interrupt as u64),
+            pc,
+            Some(BitVector::new(0)),
+            None,
+        );
+
+        // Now we can set the return pc
+        sail_ctx.nextPC = ret_pc;
+    }
+
+    // Finally, we can check that both virtual contexts are equivalent
+    assert_eq!(
+        ctx,
+        adapters::sail_to_miralis(sail_ctx),
+        "Interrupt injection is not correct"
     );
 }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -428,7 +428,7 @@ pub mod mtvec {
     pub const MODE_FILTER: usize = 0b11;
 
     /// Constant to filter out BASE bits of mtvec
-    pub const BASE_FILTER: usize = usize::MAX & !MODE_FILTER;
+    pub const BASE_FILTER: usize = !MODE_FILTER;
 
     /// Privilege modes
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
This commit extends model checking to the virtualization of the interrupts. It builds-up on the previous model checking infrastructure.