### PR TITLE
Runner: enable filtering verification harnesses

### DIFF
--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -96,6 +96,8 @@ struct TestArgs {
 
 #[derive(Args)]
 struct VerifyArgs {
+    /// Pattern of harnesses to verify, all if none
+    pattern: Option<String>,
     /// The command will succeed only if all checks can be run successfully
     ///
     /// This flag can also be configured with the environment variable `MIRALIS_RUNNER_STRICT=1`

--- a/runner/src/verify.rs
+++ b/runner/src/verify.rs
@@ -30,6 +30,11 @@ pub fn verify(args: &mut VerifyArgs) -> ExitCode {
         .args(["--output-format", "terse"])
         .args(["-p", "model_checking"]);
 
+    // Filter by pattern, if any
+    if let Some(pattern) = &args.pattern {
+        kani_cmd.arg("--harness").arg(pattern);
+    }
+
     let exit_status = kani_cmd.status().expect("Failed to run Kani");
     if exit_status.success() {
         log::info!("Successfully passed verification");


### PR DESCRIPTION
As verification is taking longer, this commit adds an option to only verify a subset of harnesses. Now `runner verify <pattern>` will only verify the harnesses matching the provided pattern.