### PR TITLE
Make mepc/sepc pass model checking

### DIFF
--- a/model_checking/src/lib.rs
+++ b/model_checking/src/lib.rs
@@ -77,12 +77,10 @@ pub fn read_csr() {
 
     let mut csr_register = generate_csr_register();
 
-    let is_mepc = csr_register == 0b001101000001;
-    let is_sepc = csr_register == 0b000101000001;
     let is_seed = csr_register == 0b000000010101;
 
-    // TODO: Adapt the last 4 registers for the symbolic verification
-    if is_mepc || is_sepc || is_seed {
+    // TODO: Adapt the last registers for the symbolic verification
+    if is_seed {
         csr_register = 0;
     }
 

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -250,15 +250,7 @@ pub mod misa {
     pub const MXL: usize = 0b10 << (core::mem::size_of::<usize>() * 8 - 2);
 
     /// Architecture extensions disabled by the current configuration
-    pub const DISABLED: usize = {
-        // By default we disable compressed instructions for now, because emulation and the
-        // decoded assume 4 bytes instructions.
-        // We also disable H mode, because we don't provide support for it right now.
-        // In addition, we disable floating points because we encountered some issues with those
-        // and they will require special handling when context switching from the OS (checking the
-        // mstatus.FS bits).
-        C | D | F | Q
-    };
+    pub const DISABLED: usize = N | F | D | Q;
 
     /// Constant to filter out non-writable fields of the misa csr
     pub const MISA_CHANGE_FILTER: usize = 0x0000000003FFFFFF;

--- a/src/virt/mod.rs
+++ b/src/virt/mod.rs
@@ -148,7 +148,7 @@ impl VirtContext {
 
     /// Expected PC alignment, depending on the C extension.
     pub fn pc_alignment_mask(&self) -> usize {
-        if (self.csr.misa & misa::C != 0) || (misa::DISABLED & misa::C != 0) {
+        if self.csr.misa & misa::C != 0 {
             !0b00
         } else {
             !0b10


### PR DESCRIPTION
We had some issues around the handling of the C (compressed) extension. This commit fixes those, and also enables the C extension by default (as we now supports the extension in all of Miralis).