### PR TITLE
Deduplicate set_mpp and get_raw_faulting_instr

### DIFF
--- a/model_checking/src/lib.rs
+++ b/model_checking/src/lib.rs
@@ -1,7 +1,7 @@
 use miralis::arch::pmp::pmplayout::VIRTUAL_PMP_OFFSET;
 use miralis::arch::pmp::PmpGroup;
 use miralis::arch::userspace::return_userspace_ctx;
-use miralis::arch::{mie, Arch, Architecture};
+use miralis::arch::{mie, write_pmp};
 use miralis::virt::traits::{HwRegisterContextSetter, RegisterContextGetter};
 use sail_model::{
     execute_MRET, execute_WFI, pmpCheck, readCSR, step_interrupts_only, writeCSR, AccessType,
@@ -382,7 +382,7 @@ pub fn pmp_equivalence() {
             sail_prelude::sys_pmp_count(()),
         );
         unsafe {
-            Arch::write_pmp(&pmp_group).flush();
+            write_pmp(&pmp_group).flush();
         }
 
         // Retrieve hardware context

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -4,10 +4,7 @@ use core::marker::PhantomData;
 use core::usize;
 
 use super::{menvcfg, Arch, Architecture, Csr, ExtensionsCapability, Mode, RegistersCapability};
-use crate::arch::pmp::PmpFlush;
-use crate::arch::{
-    mie, misa, mstatus, parse_mpp_return_mode, set_mpp, HardwareCapability, PmpGroup, Width,
-};
+use crate::arch::{mie, misa, mstatus, parse_mpp_return_mode, set_mpp, HardwareCapability, Width};
 use crate::decoder::Instr;
 use crate::virt::VirtContext;
 use crate::{utils, RegisterContextGetter, RegisterContextSetter};
@@ -44,6 +41,110 @@ impl Architecture for MetalArch {
         unsafe { asm!("wfi") };
     }
 
+    unsafe fn write_pmpaddr(index: usize, pmpaddr: usize) {
+        macro_rules! asm_write_pmpaddr {
+        ($idx:literal, $addr:expr) => {
+            asm!(
+                concat!("csrw pmpaddr", $idx, ", {addr}"),
+                addr = in(reg) pmpaddr,
+                options(nomem)
+            )
+        };
+    }
+
+        match index {
+            0 => asm_write_pmpaddr!(0, pmpaddr),
+            1 => asm_write_pmpaddr!(1, pmpaddr),
+            2 => asm_write_pmpaddr!(2, pmpaddr),
+            3 => asm_write_pmpaddr!(3, pmpaddr),
+            4 => asm_write_pmpaddr!(4, pmpaddr),
+            5 => asm_write_pmpaddr!(5, pmpaddr),
+            6 => asm_write_pmpaddr!(6, pmpaddr),
+            7 => asm_write_pmpaddr!(7, pmpaddr),
+            8 => asm_write_pmpaddr!(8, pmpaddr),
+            9 => asm_write_pmpaddr!(9, pmpaddr),
+            10 => asm_write_pmpaddr!(10, pmpaddr),
+            11 => asm_write_pmpaddr!(11, pmpaddr),
+            12 => asm_write_pmpaddr!(12, pmpaddr),
+            13 => asm_write_pmpaddr!(13, pmpaddr),
+            14 => asm_write_pmpaddr!(14, pmpaddr),
+            15 => asm_write_pmpaddr!(15, pmpaddr),
+            16 => asm_write_pmpaddr!(16, pmpaddr),
+            17 => asm_write_pmpaddr!(17, pmpaddr),
+            18 => asm_write_pmpaddr!(18, pmpaddr),
+            19 => asm_write_pmpaddr!(19, pmpaddr),
+            20 => asm_write_pmpaddr!(20, pmpaddr),
+            21 => asm_write_pmpaddr!(21, pmpaddr),
+            22 => asm_write_pmpaddr!(22, pmpaddr),
+            23 => asm_write_pmpaddr!(23, pmpaddr),
+            24 => asm_write_pmpaddr!(24, pmpaddr),
+            25 => asm_write_pmpaddr!(25, pmpaddr),
+            26 => asm_write_pmpaddr!(26, pmpaddr),
+            27 => asm_write_pmpaddr!(27, pmpaddr),
+            28 => asm_write_pmpaddr!(28, pmpaddr),
+            29 => asm_write_pmpaddr!(29, pmpaddr),
+            30 => asm_write_pmpaddr!(30, pmpaddr),
+            31 => asm_write_pmpaddr!(31, pmpaddr),
+            32 => asm_write_pmpaddr!(32, pmpaddr),
+            33 => asm_write_pmpaddr!(33, pmpaddr),
+            34 => asm_write_pmpaddr!(34, pmpaddr),
+            35 => asm_write_pmpaddr!(35, pmpaddr),
+            36 => asm_write_pmpaddr!(36, pmpaddr),
+            37 => asm_write_pmpaddr!(37, pmpaddr),
+            38 => asm_write_pmpaddr!(38, pmpaddr),
+            39 => asm_write_pmpaddr!(39, pmpaddr),
+            40 => asm_write_pmpaddr!(40, pmpaddr),
+            41 => asm_write_pmpaddr!(41, pmpaddr),
+            42 => asm_write_pmpaddr!(42, pmpaddr),
+            43 => asm_write_pmpaddr!(43, pmpaddr),
+            44 => asm_write_pmpaddr!(44, pmpaddr),
+            45 => asm_write_pmpaddr!(45, pmpaddr),
+            46 => asm_write_pmpaddr!(46, pmpaddr),
+            47 => asm_write_pmpaddr!(47, pmpaddr),
+            48 => asm_write_pmpaddr!(48, pmpaddr),
+            49 => asm_write_pmpaddr!(49, pmpaddr),
+            50 => asm_write_pmpaddr!(50, pmpaddr),
+            51 => asm_write_pmpaddr!(51, pmpaddr),
+            52 => asm_write_pmpaddr!(52, pmpaddr),
+            53 => asm_write_pmpaddr!(53, pmpaddr),
+            54 => asm_write_pmpaddr!(54, pmpaddr),
+            55 => asm_write_pmpaddr!(55, pmpaddr),
+            56 => asm_write_pmpaddr!(56, pmpaddr),
+            57 => asm_write_pmpaddr!(57, pmpaddr),
+            58 => asm_write_pmpaddr!(58, pmpaddr),
+            59 => asm_write_pmpaddr!(59, pmpaddr),
+            60 => asm_write_pmpaddr!(60, pmpaddr),
+            61 => asm_write_pmpaddr!(61, pmpaddr),
+            62 => asm_write_pmpaddr!(62, pmpaddr),
+            63 => asm_write_pmpaddr!(63, pmpaddr),
+            _ => panic!("Invalid pmpaddr register"),
+        }
+    }
+
+    unsafe fn write_pmpcfg(index: usize, pmpcfg: usize) {
+        macro_rules! asm_write_pmpcfg {
+        ($idx:literal, $cfg:expr) => {
+            asm!(
+                concat!("csrw pmpcfg", $idx, ", {cfg}"),
+                cfg = in(reg) $cfg,
+                options(nomem)
+            )
+        };
+    }
+
+        match index {
+            0 => asm_write_pmpcfg!(0, pmpcfg),
+            2 => asm_write_pmpcfg!(2, pmpcfg),
+            4 => asm_write_pmpcfg!(4, pmpcfg),
+            6 => asm_write_pmpcfg!(6, pmpcfg),
+            8 => asm_write_pmpcfg!(8, pmpcfg),
+            10 => asm_write_pmpcfg!(10, pmpcfg),
+            12 => asm_write_pmpcfg!(12, pmpcfg),
+            14 => asm_write_pmpcfg!(14, pmpcfg),
+            _ => panic!("Invalid pmpcfg register"),
+        }
+    }
+
     unsafe fn write_csr(csr: Csr, value: usize) -> usize {
         let mut prev_value: usize = 0;
 
@@ -70,7 +171,7 @@ impl Architecture for MetalArch {
             Csr::Marchid => asm_write_csr!("marchid"),
             Csr::Mimpid => asm_write_csr!("mimpid"),
             Csr::Pmpcfg(_) => todo!(),
-            Csr::Pmpaddr(index) => write_pmpaddr(index, value),
+            Csr::Pmpaddr(index) => Arch::write_pmpaddr(index, value),
             Csr::Mcycle => asm_write_csr!("mcycle"),
             Csr::Minstret => asm_write_csr!("minstret"),
             Csr::Cycle => todo!(),
@@ -372,27 +473,6 @@ impl Architecture for MetalArch {
                 has_zihpm_extension: true,
             },
         }
-    }
-
-    unsafe fn write_pmp(pmp: &PmpGroup) -> PmpFlush {
-        let pmpaddr = pmp.pmpaddr();
-        let pmpcfg = pmp.pmpcfg();
-        let nb_pmp = pmp.nb_pmp as usize;
-
-        assert!(
-            nb_pmp as usize <= pmpaddr.len() && nb_pmp as usize <= pmpcfg.len() * 8,
-            "Invalid number of PMP registers"
-        );
-
-        for idx in 0..nb_pmp {
-            write_pmpaddr(idx, pmpaddr[idx]);
-        }
-        for idx in 0..(nb_pmp / 8) {
-            let cfg = pmpcfg[idx];
-            write_pmpcfg(idx * 2, cfg);
-        }
-
-        PmpFlush()
     }
 
     unsafe fn run_vcpu(ctx: &mut VirtContext) {
@@ -1098,110 +1178,6 @@ unsafe fn find_nb_of_non_zero_pmp(nb_implemented: usize) -> usize {
     test_pmp!(63);
 
     return 64;
-}
-
-unsafe fn write_pmpaddr(index: usize, pmpaddr: usize) {
-    macro_rules! asm_write_pmpaddr {
-        ($idx:literal, $addr:expr) => {
-            asm!(
-                concat!("csrw pmpaddr", $idx, ", {addr}"),
-                addr = in(reg) pmpaddr,
-                options(nomem)
-            )
-        };
-    }
-
-    match index {
-        0 => asm_write_pmpaddr!(0, pmpaddr),
-        1 => asm_write_pmpaddr!(1, pmpaddr),
-        2 => asm_write_pmpaddr!(2, pmpaddr),
-        3 => asm_write_pmpaddr!(3, pmpaddr),
-        4 => asm_write_pmpaddr!(4, pmpaddr),
-        5 => asm_write_pmpaddr!(5, pmpaddr),
-        6 => asm_write_pmpaddr!(6, pmpaddr),
-        7 => asm_write_pmpaddr!(7, pmpaddr),
-        8 => asm_write_pmpaddr!(8, pmpaddr),
-        9 => asm_write_pmpaddr!(9, pmpaddr),
-        10 => asm_write_pmpaddr!(10, pmpaddr),
-        11 => asm_write_pmpaddr!(11, pmpaddr),
-        12 => asm_write_pmpaddr!(12, pmpaddr),
-        13 => asm_write_pmpaddr!(13, pmpaddr),
-        14 => asm_write_pmpaddr!(14, pmpaddr),
-        15 => asm_write_pmpaddr!(15, pmpaddr),
-        16 => asm_write_pmpaddr!(16, pmpaddr),
-        17 => asm_write_pmpaddr!(17, pmpaddr),
-        18 => asm_write_pmpaddr!(18, pmpaddr),
-        19 => asm_write_pmpaddr!(19, pmpaddr),
-        20 => asm_write_pmpaddr!(20, pmpaddr),
-        21 => asm_write_pmpaddr!(21, pmpaddr),
-        22 => asm_write_pmpaddr!(22, pmpaddr),
-        23 => asm_write_pmpaddr!(23, pmpaddr),
-        24 => asm_write_pmpaddr!(24, pmpaddr),
-        25 => asm_write_pmpaddr!(25, pmpaddr),
-        26 => asm_write_pmpaddr!(26, pmpaddr),
-        27 => asm_write_pmpaddr!(27, pmpaddr),
-        28 => asm_write_pmpaddr!(28, pmpaddr),
-        29 => asm_write_pmpaddr!(29, pmpaddr),
-        30 => asm_write_pmpaddr!(30, pmpaddr),
-        31 => asm_write_pmpaddr!(31, pmpaddr),
-        32 => asm_write_pmpaddr!(32, pmpaddr),
-        33 => asm_write_pmpaddr!(33, pmpaddr),
-        34 => asm_write_pmpaddr!(34, pmpaddr),
-        35 => asm_write_pmpaddr!(35, pmpaddr),
-        36 => asm_write_pmpaddr!(36, pmpaddr),
-        37 => asm_write_pmpaddr!(37, pmpaddr),
-        38 => asm_write_pmpaddr!(38, pmpaddr),
-        39 => asm_write_pmpaddr!(39, pmpaddr),
-        40 => asm_write_pmpaddr!(40, pmpaddr),
-        41 => asm_write_pmpaddr!(41, pmpaddr),
-        42 => asm_write_pmpaddr!(42, pmpaddr),
-        43 => asm_write_pmpaddr!(43, pmpaddr),
-        44 => asm_write_pmpaddr!(44, pmpaddr),
-        45 => asm_write_pmpaddr!(45, pmpaddr),
-        46 => asm_write_pmpaddr!(46, pmpaddr),
-        47 => asm_write_pmpaddr!(47, pmpaddr),
-        48 => asm_write_pmpaddr!(48, pmpaddr),
-        49 => asm_write_pmpaddr!(49, pmpaddr),
-        50 => asm_write_pmpaddr!(50, pmpaddr),
-        51 => asm_write_pmpaddr!(51, pmpaddr),
-        52 => asm_write_pmpaddr!(52, pmpaddr),
-        53 => asm_write_pmpaddr!(53, pmpaddr),
-        54 => asm_write_pmpaddr!(54, pmpaddr),
-        55 => asm_write_pmpaddr!(55, pmpaddr),
-        56 => asm_write_pmpaddr!(56, pmpaddr),
-        57 => asm_write_pmpaddr!(57, pmpaddr),
-        58 => asm_write_pmpaddr!(58, pmpaddr),
-        59 => asm_write_pmpaddr!(59, pmpaddr),
-        60 => asm_write_pmpaddr!(60, pmpaddr),
-        61 => asm_write_pmpaddr!(61, pmpaddr),
-        62 => asm_write_pmpaddr!(62, pmpaddr),
-        63 => asm_write_pmpaddr!(63, pmpaddr),
-        _ => panic!("Invalid pmpaddr register"),
-    }
-}
-
-unsafe fn write_pmpcfg(index: usize, pmpcfg: usize) {
-    macro_rules! asm_write_pmpcfg {
-        ($idx:literal, $cfg:expr) => {
-            asm!(
-                concat!("csrw pmpcfg", $idx, ", {cfg}"),
-                cfg = in(reg) $cfg,
-                options(nomem)
-            )
-        };
-    }
-
-    match index {
-        0 => asm_write_pmpcfg!(0, pmpcfg),
-        2 => asm_write_pmpcfg!(2, pmpcfg),
-        4 => asm_write_pmpcfg!(4, pmpcfg),
-        6 => asm_write_pmpcfg!(6, pmpcfg),
-        8 => asm_write_pmpcfg!(8, pmpcfg),
-        10 => asm_write_pmpcfg!(10, pmpcfg),
-        12 => asm_write_pmpcfg!(12, pmpcfg),
-        14 => asm_write_pmpcfg!(14, pmpcfg),
-        _ => panic!("Invalid pmpcfg register"),
-    }
 }
 
 // ————————————————————————————— Context Switch ————————————————————————————— //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ use policy::{Policy, PolicyModule};
 use virt::traits::*;
 use virt::{ExecutionMode, ExitResult, VirtContext};
 
+use crate::arch::write_pmp;
+
 /// The virtuam firmware monitor main loop.
 ///
 /// Runs the firmware and payload in a loop, handling the traps and interrupts and switching world
@@ -110,7 +112,7 @@ fn handle_trap(
 
             unsafe {
                 // Commit the PMP to hardware
-                Arch::write_pmp(&mctx.pmp).flush();
+                write_pmp(&mctx.pmp).flush();
             }
         }
         (ExecutionMode::Payload, ExecutionMode::Firmware) => {
@@ -123,7 +125,7 @@ fn handle_trap(
 
             unsafe {
                 // Commit the PMP to hardware
-                Arch::write_pmp(&mctx.pmp).flush();
+                write_pmp(&mctx.pmp).flush();
             }
         }
         _ => {} // No execution mode transition

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@
 
 use core::arch::global_asm;
 
-use miralis::arch::{misa, Arch, Architecture, Csr, Mode, Register};
+use miralis::arch::{misa, set_mpp, Arch, Architecture, Csr, Mode, Register};
 use miralis::config::{
     DELEGATE_PERF_COUNTER, PLATFORM_BOOT_HART_ID, PLATFORM_NAME, PLATFORM_NB_HARTS,
     TARGET_STACK_SIZE,
@@ -66,7 +66,7 @@ pub(crate) extern "C" fn main(_hart_id: usize, device_tree_blob_addr: usize) -> 
     let mut ctx = VirtContext::new(hart_id, mctx.pmp.nb_virt_pmp, mctx.hw.extensions.clone());
     unsafe {
         // Set return address, mode and PMP permissions
-        Arch::set_mpp(Mode::U);
+        set_mpp(Mode::U);
         // Update the PMPs prior to first entry
         Arch::write_pmp(&mctx.pmp).flush();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@
 
 use core::arch::global_asm;
 
-use miralis::arch::{misa, set_mpp, Arch, Architecture, Csr, Mode, Register};
+use miralis::arch::{misa, set_mpp, write_pmp, Arch, Architecture, Csr, Mode, Register};
 use miralis::config::{
     DELEGATE_PERF_COUNTER, PLATFORM_BOOT_HART_ID, PLATFORM_NAME, PLATFORM_NB_HARTS,
     TARGET_STACK_SIZE,
@@ -68,7 +68,7 @@ pub(crate) extern "C" fn main(_hart_id: usize, device_tree_blob_addr: usize) -> 
         // Set return address, mode and PMP permissions
         set_mpp(Mode::U);
         // Update the PMPs prior to first entry
-        Arch::write_pmp(&mctx.pmp).flush();
+        write_pmp(&mctx.pmp).flush();
 
         // Configure the firmware context
         ctx.set(Register::X10, hart_id);

--- a/src/policy/keystone.rs
+++ b/src/policy/keystone.rs
@@ -9,7 +9,9 @@ use core::ptr;
 
 use crate::arch::pmp::pmplayout::POLICY_OFFSET;
 use crate::arch::pmp::{pmpcfg, Segment};
-use crate::arch::{parse_mpp_return_mode, Arch, Architecture, Csr, MCause, Mode, Register};
+use crate::arch::{
+    parse_mpp_return_mode, set_mpp, Arch, Architecture, Csr, MCause, Mode, Register,
+};
 use crate::host::MiralisContext;
 use crate::policy::{PolicyHookResult, PolicyModule};
 use crate::virt::traits::*;
@@ -135,7 +137,7 @@ impl EnclaveCtx {
 
             // Swap M-mode registers
             self.mideleg = Arch::write_csr(Csr::Mideleg, self.mideleg);
-            self.mpp = Arch::set_mpp(self.mpp);
+            self.mpp = set_mpp(self.mpp);
         }
     }
 }

--- a/src/policy/keystone.rs
+++ b/src/policy/keystone.rs
@@ -10,7 +10,7 @@ use core::ptr;
 use crate::arch::pmp::pmplayout::POLICY_OFFSET;
 use crate::arch::pmp::{pmpcfg, Segment};
 use crate::arch::{
-    parse_mpp_return_mode, set_mpp, Arch, Architecture, Csr, MCause, Mode, Register,
+    parse_mpp_return_mode, set_mpp, write_pmp, Arch, Architecture, Csr, MCause, Mode, Register,
 };
 use crate::host::MiralisContext;
 use crate::policy::{PolicyHookResult, PolicyModule};
@@ -192,7 +192,7 @@ impl KeystonePolicy {
         );
 
         unsafe {
-            Arch::write_pmp(&mctx.pmp).flush();
+            write_pmp(&mctx.pmp).flush();
         }
     }
 
@@ -212,7 +212,7 @@ impl KeystonePolicy {
         // shouldn't. This is a temporary compromise due to limitations in the number of available
         // PMPs (8 or fewer). Properly securing the payload would require additional PMPs.
         unsafe {
-            Arch::write_pmp(&mctx.pmp).flush();
+            write_pmp(&mctx.pmp).flush();
         }
     }
 
@@ -328,7 +328,7 @@ impl KeystonePolicy {
         mctx.pmp.set_inactive(pmp_id, 0);
         mctx.pmp.set_inactive(pmp_id + 1, 0);
         unsafe {
-            Arch::write_pmp(&mctx.pmp).flush();
+            write_pmp(&mctx.pmp).flush();
         }
 
         ReturnCode::Success

--- a/src/virt/emulator.rs
+++ b/src/virt/emulator.rs
@@ -8,8 +8,8 @@ use crate::arch::mie::{
     MEIE_OFFSET, MSIE_OFFSET, MTIE_OFFSET, SEIE_OFFSET, SSIE_OFFSET, STIE_OFFSET,
 };
 use crate::arch::{
-    mie, misa, mstatus, mtvec, parse_mpp_return_mode, Arch, Architecture, Csr, MCause, Mode,
-    Register,
+    get_raw_faulting_instr, mie, misa, mstatus, mtvec, parse_mpp_return_mode, Arch, Architecture,
+    Csr, MCause, Mode, Register,
 };
 use crate::benchmark::Benchmark;
 use crate::decoder::Instr;
@@ -357,7 +357,7 @@ impl VirtContext {
                 panic!("Firmware should not be able to come from S-mode");
             }
             MCause::IllegalInstr => {
-                let instr = unsafe { Arch::get_raw_faulting_instr(&self.trap_info) };
+                let instr = unsafe { get_raw_faulting_instr(&self.trap_info) };
                 let instr = mctx.decode(instr);
                 if logger::trace_enabled!() {
                     log::trace!("Faulting instruction: {:?}", instr);
@@ -372,7 +372,7 @@ impl VirtContext {
                 if let Some(device) =
                     device::find_matching_device(self.trap_info.mtval, mctx.devices)
                 {
-                    let instr = unsafe { Arch::get_raw_faulting_instr(&self.trap_info) };
+                    let instr = unsafe { get_raw_faulting_instr(&self.trap_info) };
                     let instr = mctx.decode(instr);
                     log::trace!(
                         "Accessed devices: {} | With instr: {:?}",
@@ -382,7 +382,7 @@ impl VirtContext {
                     self.handle_device_access_fault(&instr, device);
                 } else if (self.csr.mstatus & mstatus::MPRV_FILTER) >> mstatus::MPRV_OFFSET == 1 {
                     // TODO: make sure virtual address does not get around PMP protection
-                    let instr = unsafe { Arch::get_raw_faulting_instr(&self.trap_info) };
+                    let instr = unsafe { get_raw_faulting_instr(&self.trap_info) };
                     let instr = mctx.decode(instr);
                     log::trace!(
                         "Access fault {:x?} with a virtual address: 0x{:x}",

--- a/src/virt/world_switch.rs
+++ b/src/virt/world_switch.rs
@@ -5,7 +5,7 @@
 use super::{VirtContext, VirtCsr};
 use crate::arch::pmp::pmpcfg;
 use crate::arch::pmp::pmpcfg::NO_PERMISSIONS;
-use crate::arch::{mie, mstatus, Arch, Architecture, Csr, Mode};
+use crate::arch::{mie, mstatus, set_mpp, Arch, Architecture, Csr, Mode};
 use crate::config::DELEGATE_PERF_COUNTER;
 use crate::host::MiralisContext;
 
@@ -120,7 +120,7 @@ impl VirtContext {
 
         self.csr.mstatus = self.csr.mstatus & !mstatus::SSTATUS_FILTER
             | Arch::read_csr(Csr::Mstatus) & mstatus::SSTATUS_FILTER;
-        Arch::set_mpp(Mode::U);
+        set_mpp(Mode::U);
         Arch::write_csr(Csr::Mideleg, 0); // Do not delegate any interrupts
         Arch::write_csr(Csr::Medeleg, 0); // Do not delegate any exceptions
 


### PR DESCRIPTION
Both instructions performs exactly the same logic in userspace.rs and metal.rs and are not architecture dependent. This commit removes the smell