### PR TITLE
Parametrize Benchmark Type at Compile Time

### DIFF
--- a/config/example.config.toml
+++ b/config/example.config.toml
@@ -69,8 +69,8 @@ disk = "ubuntu"
 # Enable benchmark code and logs. Logs can then be collected to 
 # analyze a run of the program.
 [benchmark]
-# Enable all benchmark
-enable = false
+# Runs the default benchmark type
+benchmark_type = "default"
 
 # Print in csv_format, useful for analysis
 csv_format = true

--- a/config/qemu-keystone.toml
+++ b/config/qemu-keystone.toml
@@ -10,9 +10,6 @@ max_pmp = 0
 [platform]
 nb_harts = 1
 
-[benchmark]
-enable = false
-
 [target.miralis]
 profile = "dev"
 start_address = 0x80000000

--- a/config/qemu-virt-benchmark.toml
+++ b/config/qemu-virt-benchmark.toml
@@ -15,7 +15,7 @@ nb_harts = 1
 boot_hart_id = 0
 
 [benchmark]
-enable = true
+benchmark_type = "default"
 csv_format = true
 time = true
 instruction = true

--- a/config/qemu-virt.toml
+++ b/config/qemu-virt.toml
@@ -13,6 +13,3 @@ max_pmp = 8
 [platform]
 nb_harts = 1
 boot_hart_id = 0
-
-[benchmark]
-enable = false

--- a/config/test/qemu-rustsbi-test-kernel-spike.toml
+++ b/config/test/qemu-rustsbi-test-kernel-spike.toml
@@ -15,7 +15,8 @@ nb_harts = 1
 name = "spike"
 
 [benchmark]
-enable = false
+# You can choose between default and empty - empty implies no benchmark
+benchmark_type = "default"
 
 [target.miralis]
 # Build profile for Miralis (dev profile is set by default)

--- a/config/test/qemu-virt-2harts.toml
+++ b/config/test/qemu-virt-2harts.toml
@@ -13,5 +13,3 @@ max_pmp = 8
 [platform]
 nb_harts = 2
 
-[benchmark]
-enable = false

--- a/config/test/qemu-virt-benchmark.toml
+++ b/config/test/qemu-virt-benchmark.toml
@@ -14,7 +14,7 @@ max_pmp = 8
 nb_harts = 1
 
 [benchmark]
-enable = true
+benchmark_type = "default"
 time = true
 instruction = true
 nb_exits = true

--- a/config/test/qemu-virt-hello-world-payload-spike.toml
+++ b/config/test/qemu-virt-hello-world-payload-spike.toml
@@ -14,8 +14,6 @@ max_pmp = 8
 nb_harts = 1
 name = "spike"
 
-[benchmark]
-enable = false
 
 [target.miralis]
 # Build profile for Miralis (dev profile is set by default)

--- a/config/test/qemu-virt-keystone.toml
+++ b/config/test/qemu-virt-keystone.toml
@@ -11,8 +11,5 @@ max_pmp = 0
 [platform]
 nb_harts = 1
 
-[benchmark]
-enable = false
-
 [policy]
 name = "keystone"

--- a/config/test/qemu-virt-protect-payload.toml
+++ b/config/test/qemu-virt-protect-payload.toml
@@ -14,8 +14,5 @@ max_pmp = 8
 nb_harts = 1
 boot_hart_id = 0
 
-[benchmark]
-enable = false
-
 [policy]
 name = "protect_payload"

--- a/config/test/qemu-virt-release.toml
+++ b/config/test/qemu-virt-release.toml
@@ -13,9 +13,6 @@ max_pmp = 8
 [platform]
 nb_harts = 1
 
-[benchmark]
-enable = false
-
 [target.miralis]
 profile = "release"
 stack_size = 0x8000

--- a/config/test/qemu-virt-sifive-u54-spike.toml
+++ b/config/test/qemu-virt-sifive-u54-spike.toml
@@ -15,9 +15,6 @@ nb_harts = 1
 boot_hart_id = 0
 name = "spike"
 
-[benchmark]
-enable = false
-
 [qemu]
 machine = "virt"
 cpu = "sifive-u54"

--- a/config/test/qemu-virt-sifive-u54.toml
+++ b/config/test/qemu-virt-sifive-u54.toml
@@ -14,9 +14,6 @@ max_pmp = 8
 nb_harts = 1
 boot_hart_id = 0
 
-[benchmark]
-enable = false
-
 [qemu]
 machine = "virt"
 cpu = "sifive-u54"

--- a/config/test/qemu-virt.toml
+++ b/config/test/qemu-virt.toml
@@ -13,5 +13,3 @@ max_pmp = 8
 [platform]
 nb_harts = 1
 
-[benchmark]
-enable = false

--- a/config/test/spike-virt-benchmark.toml
+++ b/config/test/spike-virt-benchmark.toml
@@ -15,7 +15,7 @@ nb_harts = 1
 name = "spike"
 
 [benchmark]
-enable = true
+benchmark_type = "default"
 time = true
 instruction = true
 nb_exits = true

--- a/config/visionfive2-release-protect-payload.toml
+++ b/config/visionfive2-release-protect-payload.toml
@@ -12,9 +12,6 @@ name = "visionfive2"
 nb_harts = 5
 boot_hart_id = 1
 
-[benchmark]
-enable = false
-
 [target.miralis]
 start_address = 0x43000000
 stack_size = 0x8000

--- a/config/visionfive2-release.toml
+++ b/config/visionfive2-release.toml
@@ -12,9 +12,6 @@ name = "visionfive2"
 nb_harts = 5
 boot_hart_id = 1
 
-[benchmark]
-enable = false
-
 [target.miralis]
 start_address = 0x43000000
 stack_size = 0x8000

--- a/config/visionfive2.toml
+++ b/config/visionfive2.toml
@@ -15,9 +15,6 @@ name = "visionfive2"
 nb_harts = 5
 boot_hart_id = 1
 
-[benchmark]
-enable = false
-
 [target.miralis]
 start_address = 0x43000000
 stack_size = 0x8000

--- a/runner/src/config.rs
+++ b/runner/src/config.rs
@@ -102,7 +102,7 @@ impl fmt::Display for Platforms {
 #[derive(Deserialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Benchmark {
-    pub enable: Option<bool>,
+    pub benchmark_type: Option<String>,
     pub csv_format: Option<bool>,
     pub time: Option<bool>,
     pub instruction: Option<bool>,
@@ -269,7 +269,7 @@ impl Platform {
 impl Benchmark {
     pub fn build_envs(&self) -> HashMap<String, String> {
         let mut envs = EnvVars::new();
-        envs.insert("MIRALIS_BENCHMARK", &self.enable);
+        envs.insert("MIRALIS_BENCHMARK_TYPE", &self.benchmark_type);
         envs.insert("MIRALIS_BENCHMARK_CSV_FORMAT", &self.csv_format);
         envs.insert("MIRALIS_BENCHMARK_TIME", &self.time);
         envs.insert("MIRALIS_BENCHMARK_INSTRUCTION", &self.instruction);

--- a/src/benchmark/empty.rs
+++ b/src/benchmark/empty.rs
@@ -1,0 +1,34 @@
+use crate::benchmark::default::IntervalCounter;
+use crate::benchmark::{BenchmarkModule, Counter, Scope};
+
+pub struct EmptyBenchmark {}
+
+impl BenchmarkModule for EmptyBenchmark {
+    fn init() -> Self {
+        EmptyBenchmark {}
+    }
+
+    fn name() -> &'static str {
+        "Empty Benchmark"
+    }
+
+    fn start_interval_counters(_scope: Scope) {}
+
+    fn stop_interval_counters(_scope: Scope) {}
+
+    fn increment_counter(_counter: Counter) {}
+
+    fn update_inteval_counter_stats(
+        &mut self,
+        _counter: &IntervalCounter,
+        _scope: &Scope,
+        _value: usize,
+    ) {
+    }
+
+    fn display_counters() {}
+
+    fn get_counter_value(_counter: Counter) -> usize {
+        0
+    }
+}

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -1,0 +1,65 @@
+//! Benchmark Modules
+//!
+//! This modules holds the different values for the benchmarks
+
+mod default;
+mod empty;
+
+use config_select::select_env;
+
+use crate::benchmark::default::IntervalCounter;
+
+pub type Benchmark = select_env!["MIRALIS_BENCHMARK_TYPE":
+    "default"      => default::DefaultBenchmark
+    _ => empty::EmptyBenchmark
+];
+
+pub trait BenchmarkModule {
+    fn init() -> Self;
+    fn name() -> &'static str;
+
+    fn start_interval_counters(scope: Scope);
+    fn stop_interval_counters(scope: Scope);
+    fn increment_counter(counter: Counter);
+
+    fn update_inteval_counter_stats(
+        &mut self,
+        counter: &IntervalCounter,
+        scope: &Scope,
+        value: usize,
+    );
+    /// Print formated string with value of the counters
+    fn display_counters();
+
+    fn get_counter_value(counter: Counter) -> usize;
+}
+
+pub enum Scope {
+    HandleTrap,
+    RunVCPU,
+}
+
+impl Scope {
+    fn base(&self) -> usize {
+        match self {
+            Self::HandleTrap => 0,
+            Self::RunVCPU => 1,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::HandleTrap => "handle_trap",
+            Self::RunVCPU => "run_vcpu",
+        }
+    }
+}
+
+/// Benchmark counters.
+/// This kind of counter aims to be incremented to count occurences of an event.
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub enum Counter {
+    TotalExits = 0,
+    FirmwareExits = 1,
+    WorldSwitches = 2,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,8 +66,8 @@ pub const DELEGATE_PERF_COUNTER: bool = is_enabled_default_false!("MIRALIS_DELEG
 pub const PLATFORM_BOOT_HART_ID: usize =
     parse_usize_or(option_env!("MIRALIS_PLATFORM_BOOT_HART_ID"), 0);
 
-/// Whether any benchmark is enabled
-pub const BENCHMARK: bool = is_enabled_default_false!("MIRALIS_BENCHMARK");
+/// What kind of benchmark we want to have in Miralis
+pub const BENCHMARK_TYPE: &str = parse_str_or(option_env!("MIRALIS_BENCHMARK_TYPE"), "empty");
 
 /// Whether print in csv format or not
 pub const BENCHMARK_CSV_FORMAT: bool = is_enabled!("MIRALIS_BENCHMARK_CSV_FORMAT");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(not(test), no_main)]
 
 pub mod arch;
-mod benchmark;
+pub mod benchmark;
 pub mod config;
 pub mod debug;
 pub mod decoder;
@@ -23,7 +23,6 @@ pub mod utils;
 pub mod virt;
 
 use arch::{Arch, Architecture, Csr, Register};
-use benchmark::{Benchmark, Counter, Scope};
 use host::MiralisContext;
 pub use platform::init;
 use platform::{Plat, Platform};
@@ -32,6 +31,7 @@ use virt::traits::*;
 use virt::{ExecutionMode, ExitResult, VirtContext};
 
 use crate::arch::write_pmp;
+use crate::benchmark::{Benchmark, BenchmarkModule, Counter, Scope};
 
 /// The virtuam firmware monitor main loop.
 ///

--- a/src/virt/emulator.rs
+++ b/src/virt/emulator.rs
@@ -11,7 +11,7 @@ use crate::arch::{
     get_raw_faulting_instr, mie, misa, mstatus, mtvec, parse_mpp_return_mode, Arch, Architecture,
     Csr, MCause, Mode, Register,
 };
-use crate::benchmark::Benchmark;
+use crate::benchmark::{Benchmark, BenchmarkModule};
 use crate::decoder::Instr;
 use crate::device::VirtDevice;
 use crate::host::MiralisContext;
@@ -523,7 +523,7 @@ impl VirtContext {
                 self.pc += 4;
             }
             abi::MIRALIS_BENCHMARK_FID => {
-                Benchmark::record_counters();
+                Benchmark::display_counters();
                 Plat::exit_success();
             }
             _ => panic!("Invalid Miralis FID: 0x{:x}", fid),


### PR DESCRIPTION
Currently, we only support a single type of benchmark. However, we are planning to introduce lightweight benchmarks with a smaller CPU footprint. This commit adds functionality to parametrize the benchmark type, similar to how architecture, platform, and policies are handled. This change lays the foundation for future extensions to support additional benchmark types.