### PR TITLE
Replace log calls by logger calls in the miralis critical path

### DIFF
--- a/src/arch/pmp.rs
+++ b/src/arch/pmp.rs
@@ -13,8 +13,8 @@ use crate::arch::pmp::pmplayout::{
     POLICY_OFFSET, POLICY_SIZE, VIRTUAL_PMP_OFFSET,
 };
 use crate::arch::Arch;
-use crate::config;
 use crate::platform::{Plat, Platform};
+use crate::{config, logger};
 
 // ——————————————————————————— PMP Configuration ———————————————————————————— //
 
@@ -223,7 +223,7 @@ impl PmpGroup {
 
             // Protect virtual devices
             for (i, device) in virtual_devices.iter().enumerate() {
-                log::debug!(
+                logger::debug!(
                     "PMP protect device {} at [0x{:x}, 0x{:x}]",
                     device.name,
                     device.start_addr,

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -10,6 +10,7 @@ use spin::{Mutex, MutexGuard};
 use super::{mie, mstatus, Architecture, Csr, ExtensionsCapability, Mode};
 use crate::arch::HardwareCapability;
 use crate::decoder::Instr;
+use crate::logger;
 use crate::virt::VirtContext;
 
 pub static HOST_CTX: Mutex<VirtContext> = Mutex::new(VirtContext::new(
@@ -40,7 +41,7 @@ impl Architecture for HostArch {
     }
 
     fn wfi() {
-        log::debug!("Userspace wfi");
+        logger::debug!("Userspace wfi");
     }
 
     unsafe fn write_pmpaddr(idx: usize, value: usize) {
@@ -57,15 +58,15 @@ impl Architecture for HostArch {
     }
 
     unsafe fn sfencevma(_vaddr: Option<usize>, _asid: Option<usize>) {
-        log::debug!("Userspace sfencevma");
+        logger::debug!("Userspace sfencevma");
     }
 
     unsafe fn hfencegvma(_: Option<usize>, _: Option<usize>) {
-        log::debug!("Userspace hfencegvma")
+        logger::debug!("Userspace hfencegvma")
     }
 
     unsafe fn hfencevvma(_: Option<usize>, _: Option<usize>) {
-        log::debug!("Userspace hfencevvma")
+        logger::debug!("Userspace hfencevvma")
     }
 
     unsafe fn detect_hardware() -> HardwareCapability {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,6 +1,7 @@
 //! RISC-V instruction decoder
 use crate::arch::{Csr, Register, Width};
 use crate::host::MiralisContext;
+use crate::logger;
 
 const OPCODE_MASK: usize = 0b1111111;
 
@@ -857,7 +858,7 @@ impl MiralisContext {
             }
 
             _ => {
-                log::debug!("Unknown CSR: 0x{:x}", csr);
+                logger::debug!("Unknown CSR: 0x{:x}", csr);
                 Csr::Unknown
             }
         }

--- a/src/device/clint.rs
+++ b/src/device/clint.rs
@@ -4,12 +4,12 @@ use spin::Mutex;
 
 use crate::arch::mie;
 use crate::config::PLATFORM_NB_HARTS;
-use crate::debug;
 use crate::device::{DeviceAccess, Width};
 use crate::driver::clint::{
     ClintDriver, MSIP_OFFSET, MSIP_WIDTH, MTIMECMP_OFFSET, MTIMECMP_WIDTH, MTIME_OFFSET,
 };
 use crate::virt::VirtContext;
+use crate::{debug, logger};
 
 // ————————————————————————————— Virtual CLINT —————————————————————————————— //
 
@@ -67,7 +67,7 @@ impl VirtClint {
     }
 
     pub fn read_clint(&self, offset: usize, r_width: Width) -> Result<usize, &'static str> {
-        log::trace!("Read from CLINT at offset 0x{:x}", offset);
+        logger::trace!("Read from CLINT at offset 0x{:x}", offset);
         self.validate_offset(offset)?;
         let driver = self.driver.lock();
 
@@ -92,7 +92,7 @@ impl VirtClint {
         value: usize,
         ctx: &mut VirtContext,
     ) -> Result<(), &'static str> {
-        log::trace!(
+        logger::trace!(
             "Write to CLINT at offset 0x{:x} with a value 0x{:x}",
             offset,
             value

--- a/src/device/plic.rs
+++ b/src/device/plic.rs
@@ -8,10 +8,10 @@
 
 use spin::Mutex;
 
-use crate::debug;
 use crate::device::{DeviceAccess, Width};
 use crate::driver::plic::PlicDriver;
 use crate::virt::VirtContext;
+use crate::{debug, logger};
 
 // —————————————————————————————— Virtual PLIC —————————————————————————————— //
 
@@ -32,7 +32,7 @@ impl DeviceAccess for VirtPlic {
         r_width: Width,
         _ctx: &mut VirtContext,
     ) -> Result<usize, &'static str> {
-        log::trace!("read PLIC at offset 0x{:x}", offset);
+        logger::trace!("read PLIC at offset 0x{:x}", offset);
         let plic = self.driver.lock();
 
         // TODO: for now we don't virtualize the PLIC, but simply implement a pass-through
@@ -72,12 +72,12 @@ impl DeviceAccess for VirtPlic {
         // Log some information, for debugging purpose
         match offset {
             0x000000..0x001000 => {
-                log::trace!("Setting interrupt {} to priority 0x{:x}", offset / 4, value)
+                logger::trace!("Setting interrupt {} to priority 0x{:x}", offset / 4, value)
             }
             0x002000..0x200000 => {
                 let context = (offset - 0x002000) / 0x80;
                 let source_group = ((offset - 0x002000) % 0x80) * 8;
-                log::trace!(
+                logger::trace!(
                     "Setting enable bits for sources {}-{} to 0x{:x} on context {}",
                     source_group,
                     source_group + 31,
@@ -88,16 +88,16 @@ impl DeviceAccess for VirtPlic {
             0x200000..0x400000 => {
                 let context = (offset - 0x200000) % 0x1000;
                 match offset % 0x1000 {
-                    0 => log::trace!(
+                    0 => logger::trace!(
                         "Set priority threshold for context {} to 0x{:x}",
                         context,
                         value
                     ),
-                    4 => log::trace!("Complete interrupt {} on context {}", value, context),
-                    _ => log::trace!("Write to reserved area at offset 0x{:x}", offset),
+                    4 => logger::trace!("Complete interrupt {} on context {}", value, context),
+                    _ => logger::trace!("Write to reserved area at offset 0x{:x}", offset),
                 }
             }
-            _ => log::debug!("Writting to unknon PLIC region at offset 0x{:x}", offset),
+            _ => logger::debug!("Writting to unknon PLIC region at offset 0x{:x}", offset),
         }
         let plic = self.driver.lock();
 

--- a/src/driver/clint.rs
+++ b/src/driver/clint.rs
@@ -8,6 +8,7 @@ use core::ptr;
 
 use crate::arch::{Arch, Architecture, Csr, Width};
 use crate::config::{self, PLATFORM_NB_HARTS};
+use crate::logger;
 
 pub const MSIP_OFFSET: usize = 0x0;
 pub const MTIMECMP_OFFSET: usize = 0x4000;
@@ -47,7 +48,7 @@ impl ClintDriver {
         // SAFETY: We derive a valid memory address assuming the base points to a valid CLINT
         // device.
         let time = unsafe { ptr::read_volatile(pointer as *const usize) };
-        log::trace!("MTIME value: 0x{:x}", time);
+        logger::trace!("MTIME value: 0x{:x}", time);
 
         time
     }
@@ -59,7 +60,7 @@ impl ClintDriver {
         // SAFETY: We derive a valid memory address assuming the base points to a valid CLINT
         // device. Moreover, we take `self` with &mut reference to enforce aliasing rules.
         unsafe { ptr::write_volatile(pointer as *mut usize, time) };
-        log::trace!("MTIME value written: 0x{:x}", time);
+        logger::trace!("MTIME value written: 0x{:x}", time);
     }
 
     ///  Read the value of the machine timer compare (mtimecmp) for a specific hart
@@ -77,7 +78,7 @@ impl ClintDriver {
         // SAFETY: We checked that the number of hart is within the platform limit, which ensures
         // the read is contained within the MTIMECMP area of the CLINT.
         let deadline = unsafe { ptr::read_volatile(pointer as *const usize) };
-        log::trace!("MTIMECMP value: 0x{:x}", deadline);
+        logger::trace!("MTIMECMP value: 0x{:x}", deadline);
         Ok(deadline)
     }
 
@@ -97,7 +98,7 @@ impl ClintDriver {
         // the read is contained within the MTIMECMP area of the CLINT. Moreover, we take `self`
         // with a &mut reference to enforce aliasing rules.
         unsafe { ptr::write_volatile(pointer as *mut usize, deadline) };
-        log::trace!("MTIMECMP value written: 0x{:x}", deadline);
+        logger::trace!("MTIMECMP value written: 0x{:x}", deadline);
         Ok(())
     }
 
@@ -116,7 +117,7 @@ impl ClintDriver {
         // SAFETY: We checked that the number of hart is within the platform limit, which ensures
         // the read is contained within the MSIP area of the CLINT.
         let msip = unsafe { ptr::read_volatile((pointer) as *const u32) };
-        log::trace!("MSIP value: 0x{:x}", msip);
+        logger::trace!("MSIP value: 0x{:x}", msip);
         if (msip >> 1) != 0 {
             log::warn!("Upper 31 bits of MSIP value are not zero!");
         }
@@ -140,7 +141,7 @@ impl ClintDriver {
         // the read is contained within the MSIP area of the CLINT. Moreover, we take `self`
         // with a &mut reference to enforce aliasing rules.
         unsafe { ptr::write_volatile((pointer) as *mut u32, msip_value) };
-        log::trace!("MSIP value written: 0x{:x} for hart {hart}", msip_value);
+        logger::trace!("MSIP value written: 0x{:x} for hart {hart}", msip_value);
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,83 +152,83 @@ fn handle_miralis_trap(ctx: &mut VirtContext) {
 /// Log the current context using the trace log level.
 fn log_ctx(ctx: &VirtContext) {
     let trap_info = &ctx.trap_info;
-    log::trace!(
+    logger::trace!(
         "Trapped on hart {}:  {:?}",
         ctx.hart_id,
         ctx.trap_info.get_cause()
     );
-    log::trace!(
+    logger::trace!(
         "  mstatus: 0x{:<16x} mepc: 0x{:x}",
         trap_info.mstatus,
         trap_info.mepc
     );
-    log::trace!(
+    logger::trace!(
         "  mtval:   0x{:<16x} exits: {}  {:?}-mode",
         ctx.trap_info.mtval,
         ctx.nb_exits,
         ctx.mode
     );
-    log::trace!(
+    logger::trace!(
         "  x1  {:<16x}  x2  {:<16x}  x3  {:<16x}",
         ctx.get(Register::X1),
         ctx.get(Register::X2),
         ctx.get(Register::X3)
     );
-    log::trace!(
+    logger::trace!(
         "  x4  {:<16x}  x5  {:<16x}  x6  {:<16x}",
         ctx.get(Register::X4),
         ctx.get(Register::X5),
         ctx.get(Register::X6)
     );
-    log::trace!(
+    logger::trace!(
         "  x7  {:<16x}  x8  {:<16x}  x9  {:<16x}",
         ctx.get(Register::X7),
         ctx.get(Register::X8),
         ctx.get(Register::X9)
     );
-    log::trace!(
+    logger::trace!(
         "  x10 {:<16x}  x11 {:<16x}  x12 {:<16x}",
         ctx.get(Register::X10),
         ctx.get(Register::X11),
         ctx.get(Register::X12)
     );
-    log::trace!(
+    logger::trace!(
         "  x13 {:<16x}  x14 {:<16x}  x15 {:<16x}",
         ctx.get(Register::X13),
         ctx.get(Register::X14),
         ctx.get(Register::X15)
     );
-    log::trace!(
+    logger::trace!(
         "  x16 {:<16x}  x17 {:<16x}  x18 {:<16x}",
         ctx.get(Register::X16),
         ctx.get(Register::X17),
         ctx.get(Register::X18)
     );
-    log::trace!(
+    logger::trace!(
         "  x19 {:<16x}  x20 {:<16x}  x21 {:<16x}",
         ctx.get(Register::X19),
         ctx.get(Register::X20),
         ctx.get(Register::X21)
     );
-    log::trace!(
+    logger::trace!(
         "  x22 {:<16x}  x23 {:<16x}  x24 {:<16x}",
         ctx.get(Register::X22),
         ctx.get(Register::X23),
         ctx.get(Register::X24)
     );
-    log::trace!(
+    logger::trace!(
         "  x25 {:<16x}  x26 {:<16x}  x27 {:<16x}",
         ctx.get(Register::X25),
         ctx.get(Register::X26),
         ctx.get(Register::X27)
     );
-    log::trace!(
+    logger::trace!(
         "  x28 {:<16x}  x29 {:<16x}  x30 {:<16x}",
         ctx.get(Register::X28),
         ctx.get(Register::X29),
         ctx.get(Register::X30)
     );
-    log::trace!(
+    logger::trace!(
         "  x31 {:<16x}  mie {:<16x}  mip {:<16x}",
         ctx.get(Register::X31),
         ctx.get(Csr::Mie),

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -177,6 +177,7 @@ macro_rules! trace {
 /// This macro call is guaranteed to be optimized-out at compile time if the corresponding log
 /// level is not enabled. Therefore it is free even in the critical path, whereas the [log::debug]
 /// macro might not be (it performs run-time checks).
+#[macro_export]
 macro_rules! debug {
     ($($args:tt)*) => {
         if logger::debug_enabled!() {

--- a/src/policy/keystone.rs
+++ b/src/policy/keystone.rs
@@ -15,7 +15,7 @@ use crate::arch::{
 use crate::host::MiralisContext;
 use crate::policy::{PolicyHookResult, PolicyModule};
 use crate::virt::traits::*;
-use crate::{RegisterContextGetter, VirtContext};
+use crate::{logger, RegisterContextGetter, VirtContext};
 
 /// Keystone parameters
 ///
@@ -240,7 +240,7 @@ impl KeystonePolicy {
     }
 
     fn create_enclave(&mut self, mctx: &mut MiralisContext, ctx: &mut VirtContext) -> ReturnCode {
-        log::debug!("Keystone: Create enclave");
+        logger::debug!("Keystone: Create enclave");
         #[repr(C)]
         struct CreateArgs {
             epm_paddr: usize, // Enclave region
@@ -299,7 +299,7 @@ impl KeystonePolicy {
     }
 
     fn run_enclave(&mut self, mctx: &mut MiralisContext, ctx: &mut VirtContext) -> ReturnCode {
-        log::debug!("Keystone: Run enclave");
+        logger::debug!("Keystone: Run enclave");
 
         let eid = ctx.get(Register::X10);
         if eid >= ENCL_MAX || self.enclaves[eid].state != EnclaveState::Fresh {
@@ -311,7 +311,7 @@ impl KeystonePolicy {
     }
 
     fn destroy_enclave(&mut self, mctx: &mut MiralisContext, ctx: &mut VirtContext) -> ReturnCode {
-        log::debug!("Keystone: Destroy enclave");
+        logger::debug!("Keystone: Destroy enclave");
         let eid = ctx.get(Register::X10);
         if eid >= ENCL_MAX
             || self.enclaves[eid].state == EnclaveState::Running
@@ -335,7 +335,7 @@ impl KeystonePolicy {
     }
 
     fn resume_enclave(&mut self, mctx: &mut MiralisContext, ctx: &mut VirtContext) -> ReturnCode {
-        log::debug!("Keystone: Resume enclave");
+        logger::debug!("Keystone: Resume enclave");
 
         let eid = ctx.get(Register::X10);
         if eid >= ENCL_MAX || self.enclaves[eid].state != EnclaveState::Stopped {
@@ -347,14 +347,14 @@ impl KeystonePolicy {
     }
 
     fn random(&mut self, ctx: &mut VirtContext) -> ReturnCode {
-        log::debug!("Keystone: Random");
+        logger::debug!("Keystone: Random");
         ctx.set(Register::X11, self.nonce);
         self.nonce += 1;
         ReturnCode::Success
     }
 
     fn stop_enclave(&mut self, mctx: &mut MiralisContext, ctx: &mut VirtContext) -> ReturnCode {
-        log::debug!("Keystone: Stop enclave");
+        logger::debug!("Keystone: Stop enclave");
         let stop_reason = match MCause::new(ctx.trap_info.mcause) {
             MCause::MachineTimerInt | MCause::MachineSoftInt => StoppedReason::Interrupt,
             _ => StoppedReason::from(ctx.get(Register::X10)),
@@ -371,7 +371,7 @@ impl KeystonePolicy {
     }
 
     fn exit_enclave(&mut self, mctx: &mut MiralisContext, ctx: &mut VirtContext) -> ReturnCode {
-        log::debug!("Keystone: Exit enclave");
+        logger::debug!("Keystone: Exit enclave");
         let enclave = self.get_active_enclave(ctx).unwrap();
         let exit_code = ctx.get(Register::X10);
         Self::context_switch_to_host(mctx, ctx, enclave);

--- a/src/policy/protect_payload.rs
+++ b/src/policy/protect_payload.rs
@@ -14,6 +14,7 @@ use crate::arch::{parse_mpp_return_mode, Arch, Architecture, Csr, MCause, Regist
 use crate::config::{PAYLOAD_HASH_SIZE, TARGET_PAYLOAD_ADDRESS};
 use crate::decoder::Instr;
 use crate::host::MiralisContext;
+use crate::logger;
 use crate::platform::{Plat, Platform};
 use crate::policy::{PolicyHookResult, PolicyModule};
 use crate::virt::traits::*;
@@ -168,7 +169,7 @@ impl ProtectPayloadPolicy {
             MCause::EcallFromSMode
                 if ctx.get(Register::X17) == sbi_codes::SBI_DEBUG_CONSOLE_EXTENSION_EID =>
             {
-                log::debug!("Ignoring console ecall to the debug_console_extension");
+                logger::debug!("Ignoring console ecall to the debug_console_extension");
                 // Explicitly tell the payload this feature is not available
                 ctx.set(Register::X10, SBI_ERR_DENIED);
                 ctx.pc += 4;

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -7,7 +7,7 @@ use super::{VirtContext, VirtCsr};
 use crate::arch::mstatus::{MBE_FILTER, SBE_FILTER, UBE_FILTER};
 use crate::arch::pmp::pmpcfg;
 use crate::arch::{hstatus, menvcfg, mie, misa, mstatus, Arch, Architecture, Csr, Register};
-use crate::{debug, MiralisContext, Plat, Platform};
+use crate::{debug, logger, MiralisContext, Plat, Platform};
 
 /// A module exposing the traits to manipulate registers of a virtual context.
 ///
@@ -285,7 +285,7 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
                 // When vMPRV transitions back to 0, remove the protection.
                 // pMPRV is never set to 1 outside of a virtual access handler.
                 if mprv != previous_mprv {
-                    log::trace!("vMPRV set to {:b}", mprv);
+                    logger::trace!("vMPRV set to {:b}", mprv);
                     if mprv != 0 {
                         pmp.set_tor(0, usize::MAX, pmpcfg::X);
                     } else {

--- a/src/virt/emulator.rs
+++ b/src/virt/emulator.rs
@@ -224,7 +224,7 @@ impl VirtContext {
 
     pub fn emulate_jump_trap_handler(&mut self) {
         // We are now emulating a trap, registers need to be updated
-        log::trace!("Emulating jump to trap handler");
+        logger::trace!("Emulating jump to trap handler");
         self.csr.mcause = self.trap_info.mcause;
         self.csr.mstatus = self.trap_info.mstatus;
         self.csr.mtval = self.trap_info.mtval;
@@ -337,7 +337,7 @@ impl VirtContext {
         policy: &mut Policy,
     ) -> ExitResult {
         if policy.trap_from_firmware(mctx, self).overwrites() {
-            log::trace!("Catching trap in the policy module");
+            logger::trace!("Catching trap in the policy module");
             return ExitResult::Continue;
         }
 
@@ -655,11 +655,11 @@ impl VirtContext {
     pub fn emulate_mret(&mut self, mctx: &mut MiralisContext) {
         match parse_mpp_return_mode(self.csr.mstatus) {
             Mode::M => {
-                log::trace!("mret to m-mode to {:x}", self.trap_info.mepc);
+                logger::trace!("mret to m-mode to {:x}", self.trap_info.mepc);
                 // Mret is jumping back to machine mode, do nothing
             }
             Mode::S if mctx.hw.extensions.has_s_extension => {
-                log::trace!("mret to s-mode with MPP to {:x}", self.trap_info.mepc);
+                logger::trace!("mret to s-mode with MPP to {:x}", self.trap_info.mepc);
                 // Mret is jumping to supervisor mode, the runner is the guest OS
                 self.mode = Mode::S;
 
@@ -671,7 +671,7 @@ impl VirtContext {
                 );
             }
             Mode::U => {
-                log::trace!("mret to u-mode with MPP");
+                logger::trace!("mret to u-mode with MPP");
                 // Mret is jumping to user mode, the runner is the guest OS
                 self.mode = Mode::U;
 


### PR DESCRIPTION
Currently most of the logs still use the native log api and are checked at compile time if they should be enabled or not. This commit removes the logs at compile time if they are not used.