### PR TITLE
Measure the Cost of Traps, World Switches, and Misaligned Operat…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
 name = "tracing_firmware"
 version = "0.1.0"
 dependencies = [
+ "config_helpers",
  "miralis_abi",
 ]
 

--- a/config/test/spike-latency-benchmark-protect-payload.toml
+++ b/config/test/spike-latency-benchmark-protect-payload.toml
@@ -1,0 +1,23 @@
+# A simple configuration to run on the Spike platform
+
+[log]
+level = "info"
+color = true
+
+[vcpu]
+max_pmp = 8
+delegate_perf_counters=true
+
+[platform]
+name = "spike"
+
+[target.miralis]
+# Build profile for Miralis (dev profile is set by default)
+profile = "release"
+
+[target.firmware]
+# Build profile for the firmware (dev profile is set by default)
+profile = "release"
+
+[policy]
+name = "protect_payload"

--- a/firmware/tracing_firmware/Cargo.toml
+++ b/firmware/tracing_firmware/Cargo.toml
@@ -11,3 +11,4 @@ path = "main.rs"
 
 [dependencies]
 miralis_abi = { path = "../../crates/abi" }
+config_helpers = { path = "../../crates/config_helpers" }

--- a/miralis.toml
+++ b/miralis.toml
@@ -32,6 +32,9 @@ path = "config/test/spike-protect-payload.toml"
 [config.spike-benchmark]
 path = "./config/test/spike-latency-benchmark.toml"
 
+[config.spike-benchmark-protect-payload]
+path = "./config/test/spike-latency-benchmark-protect-payload.toml"
+
 ## ——————————————————————————— Integration Tests ———————————————————————————— ##
 
 [test.ecall]
@@ -226,3 +229,8 @@ description = "The most basic test, which directly exit with an ecall to Miralis
 firmware = "tracing_firmware"
 config = "spike-benchmark"
 description = "The firmware and configuration we use to measure cycles in the CI"
+
+[test.spike-benchmark-protect-payload]
+firmware = "tracing_firmware"
+config = "spike-benchmark-protect-payload"
+description = "The firmware and configuration we use to measure cycles in the CI using the protect payload policy"

--- a/misc/push_stats.sh
+++ b/misc/push_stats.sh
@@ -49,8 +49,11 @@ file="cycles.txt"
 cargo run -- run --firmware tracing_firmware --config ./config/test/spike-latency-benchmark.toml > $file
 
 # Extract the number after "firmware cost:"
-firmware_cost=$(grep -i "Firmware cost :" "$file"  | sed -E 's/.*Firmware cost : ([0-9]+).*/\1/')
-payload_cost=$(grep -i "Payload cost :" "$file" | sed -E 's/.*Payload cost : ([0-9]+).*/\1/')
+firmware_cost=$(grep -i "Firmware cost default_policy :" "$file"  | sed -E 's/.*Firmware cost default_policy : ([0-9]+).*/\1/')
+payload_cost=$(grep -i "Payload cost default_policy :" "$file" | sed -E 's/.*Payload cost default_policy : ([0-9]+).*/\1/')
+firmware_cost_protect=$(grep -i "Firmware cost protect_payload:" "$file"  | sed -E 's/.*Firmware cost protect_payload : ([0-9]+).*/\1/')
+payload_cost_protect=$(grep -i "Payload cost protect_payload :" "$file" | sed -E 's/.*Payload cost protect_payload : ([0-9]+).*/\1/')
+misaligned_cost_protect=$(grep -i "Misaligned cost protect_payload :" "$file" | sed -E 's/.*Misaligned cost protect_payload : ([0-9]+).*/\1/')
 
 # Check if a number was found
 if [ -n "$firmware_cost" ]; then
@@ -66,17 +69,42 @@ else
     echo "No firmware cost found in the file."
 fi
 
+# Check if a number was found
+if [ -n "$firmware_cost_protect" ]; then
+    echo "Firmware cost: $firmware_cost_protect"
+else
+    echo "No firmware cost found in the file."
+fi
+
+# Check if a number was found
+if [ -n "$payload_cost_protect" ]; then
+    echo "Payload cost: $payload_cost_protect"
+else
+    echo "No firmware cost found in the file."
+fi
+
+# Check if a number was found
+if [ -n "$misaligned_cost_protect" ]; then
+    echo "Payload cost: $misaligned_cost_protect"
+else
+    echo "No firmware cost found in the file."
+fi
+
+
 # ———————————————————————————————— Push stats ———————————————————————————————— #
 
 echo "Commit: $git_commit"
 echo "Current date: $current_date"
 echo "Miralis size: $miralis_size bytes"
 echo "Build time: $build_time"
-echo "Miralis <--> Firmware latency in cycles: " firmware_cost
+echo "Miralis <--> Firmware latency in cycles: " $firmware_cost
 echo "Payload <--> Firmware latency in cycles: " $payload_cost
+echo "[PROTECT PAYLOAD] Miralis <--> Firmware latency in cycles: " $firmware_cost_protect
+echo "[PROTECT PAYLOAD] Payload <--> Firmware latency in cycles: " $payload_cost_protect
+echo "[PROTECT PAYLOAD] Cost of a misaligned emulation: " $misaligned_cost_protect
 
 if [ "$1" = "--commit" ]; then
-    csv_entry="$git_commit, $current_date, $miralis_size, $build_time, $firmware_cost, $payload_cost"
+    csv_entry="$git_commit, $current_date, $miralis_size, $build_time, $firmware_cost, $payload_cost,$firmware_cost_protect,$payload_cost_protect,$misaligned_cost_protect"
     echo $csv_entry >> "$miralis_stats_csv_path"
     echo "Added CSV entry to $miralis_stats_csv_path"
 fi

--- a/runner/src/artifacts.rs
+++ b/runner/src/artifacts.rs
@@ -347,7 +347,7 @@ pub fn build_target(target: Target, cfg: &Config) -> PathBuf {
             let linker_args = format!("-C link-arg=-Tmisc/linker-script.x -C link-arg=--defsym=_start_address={firmware_address}");
             build_cmd.env("RUSTFLAGS", linker_args);
             build_cmd.env("IS_TARGET_FIRMWARE", "true");
-            build_cmd.envs(cfg.benchmark.build_envs());
+            build_cmd.envs(cfg.build_envs());
             build_cmd.arg("--package").arg(firmware);
 
             if firmware == "miralis" {
@@ -365,7 +365,7 @@ pub fn build_target(target: Target, cfg: &Config) -> PathBuf {
             let linker_args = format!("-C link-arg=-Tmisc/linker-script.x -C link-arg=--defsym=_start_address={payload_address}");
             build_cmd.env("RUSTFLAGS", linker_args);
             build_cmd.env("IS_TARGET_FIRMWARE", "false");
-            build_cmd.envs(cfg.benchmark.build_envs());
+            build_cmd.envs(cfg.build_envs());
             build_cmd.arg("--package").arg(payload_name);
         }
     }


### PR DESCRIPTION
…ions with the Protect Payload Policy

This commit extends the tracing firmware with three new latency measurements in the Protect Payload policy and ensures that no additional performance losses are introduced.