### PR TITLE
Introduce script to measure the duration of the formal verification

### DIFF
--- a/.github/workflows/duration-formal.yaml
+++ b/.github/workflows/duration-formal.yaml
@@ -1,0 +1,26 @@
+name: Duration formal verification
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  Miralis:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 500
+    env:
+      RUSTFLAGS: --deny warnings
+      MIRALIS_RUNNER_STRICT: 1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # We fetch the whole git tree to be able to run tests on previous commits
+          ref: ${{ github.event.pull_request.head.sha }} # Ignore automatic merge commit
+      - uses: extractions/setup-just@v2 # Install `just`
+      - name: Setup Toolchain
+        run: just install-toolchain
+      - name: DurationVerification
+        shell: bash
+        run: python3 misc/formal_verification_time.py

--- a/misc/formal_verification_time.py
+++ b/misc/formal_verification_time.py
@@ -1,0 +1,41 @@
+import re
+import subprocess
+import time
+
+def extract_kani_names(file_path):
+    pattern = re.compile(
+        r"#\[cfg_attr\(kani, kani::proof\)\]\s*"
+        r"#\[cfg_attr\(test, test\)\]\s*"
+        r"pub fn (\w+)\s*\("
+    )
+
+    with open(file_path, 'r') as file:
+        content = file.read()
+
+    return pattern.findall(content)
+
+def time_cargo_run(subcommand):
+    command = ["cargo", "run", "--", "verify", subcommand]
+
+    start_time = time.time()
+
+    try:
+        with open('/dev/null', 'w') as devnull:
+            subprocess.run(command, check=True, stdout=devnull, stderr=devnull)
+    except subprocess.CalledProcessError as e:
+        print(f"Command failed with return code {e.returncode}")
+
+    duration = time.time() - start_time
+
+    print(f"{subcommand} verification completed in {duration:.2f} seconds.")
+
+    return duration
+
+if __name__ == "__main__":
+    print("Please run the script from the miralis folder, otherwise it won't work.")
+
+    file_path = "model_checking/src/lib.rs"
+    functions = extract_kani_names(file_path)
+
+    for func in functions:
+        time_cargo_run(func)


### PR DESCRIPTION
This commit introduces a python file that measure the required time for the formal verification. It also introduces the possibility to manually run it on the github workflow