### PR TITLE
Bugfix: run tracing firmware with protect payload policy

### DIFF
--- a/misc/push_stats.sh
+++ b/misc/push_stats.sh
@@ -47,6 +47,7 @@ file="cycles.txt"
 
 # Run the benchmarks
 cargo run -- run --firmware tracing_firmware --config ./config/test/spike-latency-benchmark.toml > $file
+cargo run -- run --firmware tracing_firmware --config ./config/test/spike-latency-benchmark-protect-payload.toml >> $file
 
 # Extract the number after "firmware cost:"
 firmware_cost=$(grep -i "Firmware cost default_policy :" "$file"  | sed -E 's/.*Firmware cost default_policy : ([0-9]+).*/\1/')


### PR DESCRIPTION
Currently, we forgot to run the tracing firmware with the protect payload policy and therefore we have no numbers.