### PR TITLE
SailBugfix: Illegal instruction decoder decodes too many instructions

### DIFF
--- a/model_checking/src/lib.rs
+++ b/model_checking/src/lib.rs
@@ -525,7 +525,7 @@ pub fn verify_decoder() {
     let (_, mctx, mut sail_ctx) = symbolic::new_symbolic_contexts();
 
     // Generate an instruction to decode
-    let instr = any!(u32);
+    let instr = any!(u32, 0x30001073);
 
     // Decode values
     let decoded_value_sail = ast_to_miralis_instr(encdec_backwards(

--- a/model_checking/src/symbolic.rs
+++ b/model_checking/src/symbolic.rs
@@ -15,10 +15,12 @@ use crate::adapters;
 /// Generates an arbitrary value.
 ///
 /// A type can be provided as argument, otherwise it will be inferred if possible.
+/// A default value can be provided in addition to the type, it will be used during concrete
+/// execution.
 ///
-/// This macro either generate the default value of a type, or an arbitrary Kani value during model
-/// checking. We use this macro to make our Kani proofs runnable as simple tests, which ensures
-/// that we don't break the Kani verification harnesses.
+/// This macro either generate a value of a type, or an arbitrary Kani value during model checking.
+/// We use this macro to make our Kani proofs runnable as simple tests, which ensures that we don't
+/// break the Kani verification harnesses.
 macro_rules! any {
     () => {{
         #[cfg(kani)]
@@ -38,6 +40,17 @@ macro_rules! any {
         #[cfg(not(kani))]
         {
             <$t>::default()
+        }
+    }};
+    ($t:ty, $value:tt) => {{
+        #[cfg(kani)]
+        {
+            kani::any::<$t>()
+        }
+        #[cfg(not(kani))]
+        {
+            let val: $t = $value;
+            val
         }
     }};
 }


### PR DESCRIPTION
Currently, the illegal instruction decoder decodes too many instructions instead of returning an unknown instructions. This commit fixes the issues and produces a formally verified decoder.