### PR TITLE
SailBugfix: Fix emulate_csrrwi and emulate_csrrci

### DIFF
--- a/src/virt/emulator.rs
+++ b/src/virt/emulator.rs
@@ -640,7 +640,12 @@ impl VirtContext {
         uimm: usize,
     ) {
         let tmp = self.get(csr);
-        self.set_csr(csr, tmp | uimm, mctx);
+
+        // In the Sail specification writes with 0 as immediate are ignored
+        if uimm != 0 {
+            self.set_csr(csr, tmp | uimm, mctx);
+        }
+
         self.set(rd, tmp);
     }
 
@@ -672,7 +677,12 @@ impl VirtContext {
         uimm: usize,
     ) {
         let tmp = self.get(csr);
-        self.set_csr(csr, tmp & !uimm, mctx);
+
+        // In the Sail specification writes with 0 as immediate are ignored
+        if uimm != 0 {
+            self.set_csr(csr, tmp & !uimm, mctx);
+        }
+
         self.set(rd, tmp);
     }
 


### PR DESCRIPTION
In the sail specification, when the write value is 0, we don't do the csr write. This commit fixes the divergence.