### PR TITLE
Introduce TEE extension in hardware context

### DIFF
--- a/model_checking/src/adapters.rs
+++ b/model_checking/src/adapters.rs
@@ -288,6 +288,7 @@ pub fn sail_to_miralis(sail_ctx: SailVirtCtx) -> VirtContext {
             has_s_extension: false,
             has_v_extension: true,
             has_zihpm_extension: true,
+            has_tee_extension: false,
         },
     );
 

--- a/model_checking/src/symbolic.rs
+++ b/model_checking/src/symbolic.rs
@@ -56,6 +56,7 @@ pub fn new_ctx() -> VirtContext {
             has_s_extension: false,
             has_v_extension: true,
             has_zihpm_extension: true,
+            has_tee_extension: false,
         },
     );
 

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -471,6 +471,7 @@ impl Architecture for MetalArch {
                 has_crypto_extension: false,
                 has_zicntr: false,
                 has_zihpm_extension: true,
+                has_tee_extension: true,
             },
         }
     }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -160,6 +160,8 @@ pub struct ExtensionsCapability {
     pub is_sstc_enabled: bool,
     /// Has Zihpm extension
     pub has_zihpm_extension: bool,
+    /// Has Trusted Execution Environment Task Group
+    pub has_tee_extension: bool,
 }
 
 // ———————————————————————————— Privilege Modes ————————————————————————————— //

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -25,6 +25,7 @@ pub static HOST_CTX: Mutex<VirtContext> = Mutex::new(VirtContext::new(
         has_crypto_extension: false,
         has_zicntr: true,
         has_zihpm_extension: true,
+        has_tee_extension: false,
     },
 ));
 
@@ -88,6 +89,7 @@ impl Architecture for HostArch {
                 has_sstc_extension: false,
                 is_sstc_enabled: false,
                 has_zihpm_extension: false,
+                has_tee_extension: false,
             },
         }
     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -422,7 +422,13 @@ impl MiralisContext {
             }
             0x306 => Csr::Mcounteren,
             0x30a => Csr::Menvcfg,
-            0x747 => Csr::Mseccfg,
+            0x747 => {
+                if !self.hw.extensions.has_tee_extension {
+                    Csr::Unknown
+                } else {
+                    Csr::Mseccfg
+                }
+            }
             0xF15 => Csr::Mconfigptr,
             0x302 => {
                 if !self.hw.extensions.has_s_extension {


### PR DESCRIPTION
The sail model doesn't have the TEE extension. This commit introduces a feature to enable disable this extension depending on the configuration context.