### PR TITLE
SailBugfix: Modifies only mie in write Sie when the interrupt is dele…

### DIFF
--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -541,10 +541,9 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
                 );
             }
             Csr::Sie => {
-                // Clear S bits
-                let mie = self.get(Csr::Mie) & !mie::SIE_FILTER;
-                // Set S bits to new value
-                self.set_csr(Csr::Mie, mie | (value & mie::SIE_FILTER), mctx);
+                // Only delegated interrupts can be enabled through `sie`
+                let mideleg = self.get(Csr::Mideleg);
+                self.csr.mie = (self.csr.mie & !mideleg) | (mideleg & value);
             }
             Csr::Stvec => {
                 match value & 0b11 {


### PR DESCRIPTION
…gated

Before modifying each specific interrupt enable bit (e.g., SEIE, STIE, or SSIE), the code checks whether the corresponding bit in Mideleg is set. Mideleg determines whether a specific interrupt is delegated to the supervisor level, so this ensures that only interrupts managed by the supervisor are updated.