### PR TITLE
Introduce single and multicore performance counter reading

### DIFF
--- a/config/benchmark.toml
+++ b/config/benchmark.toml
@@ -1,0 +1,4 @@
+# A configuration to test the benchmark module used for the benchmark on the boards
+
+[benchmark]
+benchmark_type = "counter"

--- a/config/visionfive2-release-protect-payload.toml
+++ b/config/visionfive2-release-protect-payload.toml
@@ -23,3 +23,6 @@ profile = "release"
 
 [policy]
 name = "protect_payload"
+
+[benchmark]
+benchmark_type = "counter"

--- a/config/visionfive2-release.toml
+++ b/config/visionfive2-release.toml
@@ -21,3 +21,5 @@ profile = "release"
 start_address = 0x40000000
 profile = "release"
 
+[benchmark]
+benchmark_type = "counter"

--- a/config/visionfive2.toml
+++ b/config/visionfive2.toml
@@ -21,3 +21,6 @@ stack_size = 0x8000
 
 [target.firmware]
 start_address = 0x40000000
+
+[benchmark]
+benchmark_type = "counter"

--- a/src/benchmark/counter.rs
+++ b/src/benchmark/counter.rs
@@ -76,8 +76,9 @@ impl BenchmarkModule for CounterBenchmark {
 
         match ctx.get(Register::X10) {
             SINGLE_CORE_BENCHMARK => {
-                nb_firmware_exits = get_nb_firmware_exits(0) as usize;
-                nb_world_switch = get_nb_world_switch(0) as usize;
+                let hart = hard_id();
+                nb_firmware_exits = get_nb_firmware_exits(hart) as usize;
+                nb_world_switch = get_nb_world_switch(hart) as usize;
             }
             ALL_CORES_BENCHMARK => {
                 for current_hart in 0..PLATFORM_NB_HARTS {
@@ -85,7 +86,10 @@ impl BenchmarkModule for CounterBenchmark {
                     nb_world_switch += get_nb_world_switch(current_hart) as usize;
                 }
             }
-            _ => unreachable!(),
+            _ => log::error!(
+                "Invalid argument for register a0 [0 ==> Core 0 | 1 ==> All cores] {}",
+                ctx.get(Register::X10)
+            ),
         }
 
         ctx.set(Register::X10, nb_firmware_exits);

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -13,6 +13,7 @@ use crate::virt::VirtContext;
 
 pub type Benchmark = select_env!["MIRALIS_BENCHMARK_TYPE":
     "default"      => default::DefaultBenchmark
+    "counter"      => counter::CounterBenchmark
     _ => empty::EmptyBenchmark
 ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@
 use core::arch::global_asm;
 
 use miralis::arch::{misa, set_mpp, write_pmp, Arch, Architecture, Csr, Mode, Register};
+use miralis::benchmark::{Benchmark, BenchmarkModule};
 use miralis::config::{
     DELEGATE_PERF_COUNTER, PLATFORM_BOOT_HART_ID, PLATFORM_NAME, PLATFORM_NB_HARTS,
     TARGET_STACK_SIZE,
@@ -41,6 +42,7 @@ pub(crate) extern "C" fn main(_hart_id: usize, device_tree_blob_addr: usize) -> 
     log::info!("Hello, world!");
     log::info!("Platform name: {}", Plat::name());
     log::info!("Policy module: {}", Policy::name());
+    log::info!("Benchmark module: {}", Benchmark::name());
     log::info!("Hart ID: {}", hart_id);
     log::debug!("misa:    0x{:x}", Arch::read_csr(Csr::Misa));
     log::debug!(


### PR DESCRIPTION
Currently, we can only read the performance counters on a per-core basis, which is insufficient for our multicore benchmarks. This commit extend the counter benchmark to enable reading all the cores at once.