### PR TITLE
Formally verify the trap virtualization process

### DIFF
--- a/src/virt/emulator.rs
+++ b/src/virt/emulator.rs
@@ -257,6 +257,13 @@ impl VirtContext {
     }
 
     pub fn emulate_jump_trap_handler(&mut self) {
+        // Precondition to emulate a jump, we must be in a trap
+        assert_eq!(
+            self.trap_info.mcause & (1 << 63),
+            0,
+            "Mcause should represent a trap, not an interrupt"
+        );
+
         // We are now emulating a trap, registers need to be updated
         logger::trace!("Emulating jump to trap handler");
         self.csr.mcause = self.trap_info.mcause;


### PR DESCRIPTION
Currently, we only verify formally the virtualization process of interrupt. This commit extends the logic to the traps.

@CharlyCst I am completely aware you are not a fan of this #cfg kani. It is true that it make the codebase a bit more complex but make the entire process of formal verification way easier. I lost a lot of time because in one test you have a precondition that you don't have in another and so on. **I really need** to put the #cfg kani to this place and a few csr registers in write CSR (like 3) such that I can merge everything and we remove this in the next commits. 