### PR TITLE
Remove undefined symbol in main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ extern "C" {
     static _stack_start: u8;
     static _bss_start: u8;
     static _bss_stop: u8;
-    static _stack_top: u8;
     static _start_address: u8;
 }
 


### PR DESCRIPTION
The _stack_top symbol is undefined and is initialised nowhere. This commit removes it from main.