### PR TITLE
Remove space between two logs on the visionfive2 board

### DIFF
--- a/src/platform/visionfive2.rs
+++ b/src/platform/visionfive2.rs
@@ -78,7 +78,7 @@ impl Platform for VisionFive2Platform {
     fn debug_print(_level: Level, args: fmt::Arguments) {
         let mut writer = WRITER.lock();
         writer.write_fmt(args).unwrap();
-        writer.write_str("\r\n").unwrap();
+        writer.write_str("\r").unwrap();
     }
 
     fn exit_success() -> ! {


### PR DESCRIPTION
Currently, there is a space between two logs, this commit removes the extra line to match with the vert platform.