### PR TITLE
Verification: improve CSR write coverage

### DIFF
--- a/firmware/csr_ops/main.rs
+++ b/firmware/csr_ops/main.rs
@@ -342,18 +342,18 @@ fn test_mconfigptr() {
 // —————————————————— Machine Environment Config registers —————————————————— //
 
 fn test_menvcfg() {
-    const VALUE: usize = 0x42;
+    let target_val = 0x80000000000000f0;
     let mut res: usize;
     unsafe {
         asm!(
-            "li {0}, 0x42",
+            "li {0}, 0x80000000000000f0",
             "csrw menvcfg, {0}",
             "csrr {1}, menvcfg",
             out(reg) _,
             out(reg) res,
         );
     }
-    assert_eq!(res, VALUE);
+    assert_eq!(res, target_val);
 
     unsafe {
         asm!(
@@ -364,5 +364,5 @@ fn test_menvcfg() {
             out(reg) res,
         );
     }
-    assert_eq!(res, VALUE);
+    assert_eq!(res, 0x42);
 }

--- a/model_checking/sail_model/lib.rs
+++ b/model_checking/sail_model/lib.rs
@@ -1386,6 +1386,18 @@ pub fn _get_Misa_U(sail_ctx: &mut SailVirtCtx, v: Misa) -> BitVector<1> {
     v.subrange::<20, 21, 1>()
 }
 
+pub fn sys_enable_sstc(sail_ctx: &mut SailVirtCtx, unit_arg: ()) -> bool {
+    false
+}
+
+pub fn sys_has_zicbom(sail_ctx: &mut SailVirtCtx, unit_arg: ()) -> bool {
+    false
+}
+
+pub fn sys_has_zicboz(sail_ctx: &mut SailVirtCtx, unit_arg: ()) -> bool {
+    false
+}
+
 pub fn legalize_misa(sail_ctx: &mut SailVirtCtx, m: Misa, v: BitVector<64>) -> Misa {
     let v = Mk_Misa(sail_ctx, v);
     if {
@@ -1749,7 +1761,7 @@ pub fn cur_Architecture(sail_ctx: &mut SailVirtCtx, unit_arg: ()) -> Architectur
         Some(a) => a,
         None => internal_error(
             String::from("../miralis-sail-riscv/model/riscv_sys_regs.sail"),
-            323,
+            327,
             String::from("Invalid current architecture"),
         ),
         _ => {
@@ -2940,6 +2952,36 @@ pub fn Mk_MEnvcfg(sail_ctx: &mut SailVirtCtx, v: BitVector<64>) -> MEnvcfg {
     MEnvcfg { bits: v }
 }
 
+pub fn _get_MEnvcfg_CBCFE(sail_ctx: &mut SailVirtCtx, v: MEnvcfg) -> BitVector<1> {
+    v.subrange::<6, 7, 1>()
+}
+
+pub fn _update_MEnvcfg_CBCFE(sail_ctx: &mut SailVirtCtx, v: MEnvcfg, x: BitVector<1>) -> MEnvcfg {
+    BitField {
+        bits: update_subrange_bits(v.bits, 6, 6, x),
+    }
+}
+
+pub fn _get_MEnvcfg_CBIE(sail_ctx: &mut SailVirtCtx, v: MEnvcfg) -> BitVector<2> {
+    v.subrange::<4, 6, 2>()
+}
+
+pub fn _update_MEnvcfg_CBIE(sail_ctx: &mut SailVirtCtx, v: MEnvcfg, x: BitVector<2>) -> MEnvcfg {
+    BitField {
+        bits: update_subrange_bits(v.bits, 5, 4, x),
+    }
+}
+
+pub fn _get_MEnvcfg_CBZE(sail_ctx: &mut SailVirtCtx, v: MEnvcfg) -> BitVector<1> {
+    v.subrange::<7, 8, 1>()
+}
+
+pub fn _update_MEnvcfg_CBZE(sail_ctx: &mut SailVirtCtx, v: MEnvcfg, x: BitVector<1>) -> MEnvcfg {
+    BitField {
+        bits: update_subrange_bits(v.bits, 7, 7, x),
+    }
+}
+
 pub fn _get_MEnvcfg_FIOM(sail_ctx: &mut SailVirtCtx, v: MEnvcfg) -> BitVector<1> {
     v.subrange::<0, 1, 1>()
 }
@@ -2947,6 +2989,16 @@ pub fn _get_MEnvcfg_FIOM(sail_ctx: &mut SailVirtCtx, v: MEnvcfg) -> BitVector<1>
 pub fn _update_MEnvcfg_FIOM(sail_ctx: &mut SailVirtCtx, v: MEnvcfg, x: BitVector<1>) -> MEnvcfg {
     BitField {
         bits: update_subrange_bits(v.bits, 0, 0, x),
+    }
+}
+
+pub fn _get_MEnvcfg_STCE(sail_ctx: &mut SailVirtCtx, v: MEnvcfg) -> BitVector<1> {
+    v.subrange::<63, 64, 1>()
+}
+
+pub fn _update_MEnvcfg_STCE(sail_ctx: &mut SailVirtCtx, v: MEnvcfg, x: BitVector<1>) -> MEnvcfg {
+    BitField {
+        bits: update_subrange_bits(v.bits, 63, 63, x),
     }
 }
 
@@ -2967,13 +3019,49 @@ pub fn _update_SEnvcfg_FIOM(sail_ctx: &mut SailVirtCtx, v: SEnvcfg, x: BitVector
 pub fn legalize_menvcfg(sail_ctx: &mut SailVirtCtx, o: MEnvcfg, v: BitVector<64>) -> MEnvcfg {
     let v = Mk_MEnvcfg(sail_ctx, v);
     let o = {
-        let var_1 = o;
-        let var_2 = if { sys_enable_writable_fiom(()) } {
-            _get_MEnvcfg_FIOM(sail_ctx, v)
+        let var_1 = {
+            let var_3 = {
+                let var_5 = {
+                    let var_7 = {
+                        let var_9 = o;
+                        let var_10 = if { sys_enable_writable_fiom(()) } {
+                            _get_MEnvcfg_FIOM(sail_ctx, v)
+                        } else {
+                            BitVector::<1>::new(0b0)
+                        };
+                        _update_MEnvcfg_FIOM(sail_ctx, var_9, var_10)
+                    };
+                    let var_8 = if { sys_has_zicboz(sail_ctx, ()) } {
+                        _get_MEnvcfg_CBZE(sail_ctx, v)
+                    } else {
+                        BitVector::<1>::new(0b0)
+                    };
+                    _update_MEnvcfg_CBZE(sail_ctx, var_7, var_8)
+                };
+                let var_6 = if { sys_has_zicbom(sail_ctx, ()) } {
+                    _get_MEnvcfg_CBCFE(sail_ctx, v)
+                } else {
+                    BitVector::<1>::new(0b0)
+                };
+                _update_MEnvcfg_CBCFE(sail_ctx, var_5, var_6)
+            };
+            let var_4 = if { sys_has_zicbom(sail_ctx, ()) } {
+                if { (_get_MEnvcfg_CBIE(sail_ctx, v) != BitVector::<2>::new(0b10)) } {
+                    _get_MEnvcfg_CBIE(sail_ctx, v)
+                } else {
+                    BitVector::<2>::new(0b00)
+                }
+            } else {
+                BitVector::<2>::new(0b00)
+            };
+            _update_MEnvcfg_CBIE(sail_ctx, var_3, var_4)
+        };
+        let var_2 = if { sys_enable_sstc(sail_ctx, ()) } {
+            _get_MEnvcfg_STCE(sail_ctx, v)
         } else {
             BitVector::<1>::new(0b0)
         };
-        _update_MEnvcfg_FIOM(sail_ctx, var_1, var_2)
+        _update_MEnvcfg_STCE(sail_ctx, var_1, var_2)
     };
     o
 }

--- a/model_checking/src/adapters.rs
+++ b/model_checking/src/adapters.rs
@@ -321,6 +321,8 @@ pub fn sail_to_miralis(sail_ctx: SailVirtCtx) -> VirtContext {
             has_s_extension: false,
             has_v_extension: true,
             has_zihpm_extension: true,
+            has_zicboz_extension: false,
+            has_zicbom_extension: false,
             has_tee_extension: false,
         },
     );

--- a/model_checking/src/lib.rs
+++ b/model_checking/src/lib.rs
@@ -182,10 +182,9 @@ pub fn write_csr() {
     let (mut ctx, mut mctx, mut sail_ctx) = symbolic::new_symbolic_contexts();
 
     let is_mideleg = csr_register == 0b001100000011;
-    let is_menvcfg = csr_register == 0b001100001010;
 
     // TODO: Handle the last few registers
-    if is_menvcfg || is_mideleg {
+    if is_mideleg {
         csr_register = 0;
     }
 

--- a/model_checking/src/lib.rs
+++ b/model_checking/src/lib.rs
@@ -181,20 +181,11 @@ pub fn write_csr() {
 
     let (mut ctx, mut mctx, mut sail_ctx) = symbolic::new_symbolic_contexts();
 
-    let is_mstatus = csr_register == 0b001100000000;
     let is_mideleg = csr_register == 0b001100000011;
-    let is_mie = csr_register == 0b001100000100;
     let is_menvcfg = csr_register == 0b001100001010;
-    let is_mepc = csr_register == 0b001101000001;
-    let is_mip = csr_register == 0b001101000100;
-    let is_sstatus = csr_register == 0b000100000000;
-    let is_sie = csr_register == 0b000100000100;
 
-    // TODO: Adapt the last 8 registers for the symbolic verification
-    if is_mstatus || is_mideleg || is_mie || is_menvcfg {
-        csr_register = 0;
-    }
-    if is_mepc || is_mip || is_sstatus || is_sie {
+    // TODO: Handle the last few registers
+    if is_menvcfg || is_mideleg {
         csr_register = 0;
     }
 
@@ -374,11 +365,11 @@ pub fn write_csr() {
         ctx.csr.vlenb,
         "Write vlenb"
     );
-    /*assert_eq!(
+    assert_eq!(
         sail_to_miralis(sail_ctx).csr.sepc,
         ctx.csr.sepc,
         "Write sepc"
-    );*/
+    );
     assert_eq!(
         sail_to_miralis(sail_ctx).csr.misa,
         ctx.csr.misa,
@@ -399,8 +390,8 @@ pub fn write_csr() {
         ctx.csr.scounteren,
         "Write scounteren"
     );
-    // assert_eq!(sail_to_miralis(sail_ctx).csr.mip, ctx.csr.mip, "Write mip");
-    // assert_eq!(sail_to_miralis(sail_ctx).csr.mie, ctx.csr.mie, "Write mie");
+    assert_eq!(sail_to_miralis(sail_ctx).csr.mip, ctx.csr.mip, "Write mip");
+    assert_eq!(sail_to_miralis(sail_ctx).csr.mie, ctx.csr.mie, "Write mie");
     assert_eq!(
         sail_to_miralis(sail_ctx).csr.mstatus,
         ctx.csr.mstatus,

--- a/model_checking/src/symbolic.rs
+++ b/model_checking/src/symbolic.rs
@@ -4,7 +4,7 @@
 //! context. We make sure that this module can compile and be tested even without Kani installed,
 //! in which case concrete values are used in place of symbolic ones.
 
-use miralis::arch::{mie, misa, mstatus, Arch, Architecture, ExtensionsCapability, Mode};
+use miralis::arch::{menvcfg, mie, misa, mstatus, Arch, Architecture, ExtensionsCapability, Mode};
 use miralis::host::MiralisContext;
 use miralis::platform::{Plat, Platform};
 use miralis::virt::VirtContext;
@@ -69,6 +69,8 @@ pub fn new_ctx() -> VirtContext {
             has_s_extension: false,
             has_v_extension: true,
             has_zihpm_extension: true,
+            has_zicbom_extension: false,
+            has_zicboz_extension: false,
             has_tee_extension: false,
         },
     );
@@ -103,7 +105,7 @@ pub fn new_ctx() -> VirtContext {
     ctx.csr.minstret = any!();
     ctx.csr.mcountinhibit = any!();
     ctx.csr.mcounteren = any!();
-    ctx.csr.menvcfg = any!();
+    ctx.csr.menvcfg = any!(usize) & (menvcfg::FIOM_FILTER | menvcfg::STCE_FILTER);
     // ctx.csr.mseccfg = any!();
     ctx.csr.mcause = any!();
     ctx.csr.mepc = any!(usize) & (!0b11);

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -160,6 +160,10 @@ pub struct ExtensionsCapability {
     pub is_sstc_enabled: bool,
     /// Has Zihpm extension
     pub has_zihpm_extension: bool,
+    /// Has Zicbom extension
+    pub has_zicbom_extension: bool,
+    /// Has Zicboz extension
+    pub has_zicboz_extension: bool,
     /// Has Trusted Execution Environment Task Group
     pub has_tee_extension: bool,
 }
@@ -458,8 +462,31 @@ pub mod mtvec {
 }
 
 pub mod menvcfg {
+    /// Fence I/O Implies Memoru
+    pub const FIOM_OFFSET: usize = 0;
+    pub const FIOM_FILTER: usize = 0b1 << FIOM_OFFSET;
+
+    /// CBIE from Zicbom extension
+    pub const CBIE_OFFSET: usize = 4;
+    pub const CBIE_FILTER: usize = 0b11 << CBIE_OFFSET;
+
+    // CBCFE from Zicbom extension
+    pub const CBCFE_OFFSET: usize = 6;
+    pub const CBCFE_FILTER: usize = 0b1 << CBCFE_OFFSET;
+
+    // CBZE from Zicboz extension
+    pub const CBZE_OFFSET: usize = 7;
+    pub const CBZE_FILTER: usize = 0b1 << CBZE_OFFSET;
+
+    /// Supervisor Timer Extension
     pub const STCE_OFFSET: usize = 63;
     pub const STCE_FILTER: usize = 0b1 << STCE_OFFSET;
+
+    /// All valid bits in menvcfg.
+    ///
+    /// Note that not all bits might be available on a given hart, depending on the implemented
+    /// extensions.
+    pub const ALL: usize = FIOM_FILTER | CBIE_FILTER | CBCFE_FILTER | CBZE_FILTER | STCE_FILTER;
 }
 
 // ————————————————————————————— Hypervisor Status ————————————————————————————— //

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -25,6 +25,8 @@ pub static HOST_CTX: Mutex<VirtContext> = Mutex::new(VirtContext::new(
         has_crypto_extension: false,
         has_zicntr: true,
         has_zihpm_extension: true,
+        has_zicbom_extension: true,
+        has_zicboz_extension: true,
         has_tee_extension: false,
     },
 ));
@@ -89,6 +91,8 @@ impl Architecture for HostArch {
                 has_sstc_extension: false,
                 is_sstc_enabled: false,
                 has_zihpm_extension: false,
+                has_zicboz_extension: false,
+                has_zicbom_extension: false,
                 has_tee_extension: false,
             },
         }

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -417,7 +417,9 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
                         }
                     }
                 }
-                self.csr.mip = value | (self.csr.mip & mie::MIDELEG_READ_ONLY_ZERO);
+
+                // Keep all the non-writeable bits
+                self.csr.mip = value | (self.csr.mip & !mie::MIP_WRITE_FILTER);
             }
             Csr::Mtvec => {
                 match value & 0b11 {

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -483,9 +483,17 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
                 self.csr.mcounteren = (self.csr.mcounteren & !0b111) | (value & 0b111) as u32
             }
             Csr::Menvcfg => {
-                let mut mask: usize = usize::MAX;
+                let mut mask: usize = menvcfg::ALL;
+
+                // Filter valid values based on implemented extensions.
                 if !mctx.hw.extensions.has_sstc_extension {
                     mask &= !menvcfg::STCE_FILTER; // Hardwire STCE to 0 if Sstc is disabled
+                }
+                if !mctx.hw.extensions.has_zicbom_extension {
+                    mask &= !(menvcfg::CBIE_FILTER | menvcfg::CBCFE_FILTER);
+                }
+                if !mctx.hw.extensions.has_zicboz_extension {
+                    mask &= !menvcfg::CBZE_FILTER;
                 }
 
                 self.csr.menvcfg = value & mask;


### PR DESCRIPTION
This PR increases the coverage for the verification of CSR write operations. It first fixes a bug in the write mask of `mip`, update the Sail model to add support for `Sstc`, `Zicbom`, and `Zicboz` extensions, and add support for `Zicbom` and `Zicboz` in Miralis.