### PR TITLE
Add default functions in BenchmarkModule trait

### DIFF
--- a/src/benchmark/counter.rs
+++ b/src/benchmark/counter.rs
@@ -46,10 +46,6 @@ impl BenchmarkModule for CounterBenchmark {
         "Counter benchmark"
     }
 
-    fn start_interval_counters(_scope: Scope) {}
-
-    fn stop_interval_counters(_scope: Scope) {}
-
     fn increment_counter(counter: Counter) {
         if counter == FirmwareExits {
             NB_FIRMWARE_EXIT[hard_id()]

--- a/src/benchmark/empty.rs
+++ b/src/benchmark/empty.rs
@@ -1,6 +1,4 @@
-use crate::benchmark::default::IntervalCounter;
-use crate::benchmark::{BenchmarkModule, Counter, Scope};
-use crate::virt::VirtContext;
+use crate::benchmark::BenchmarkModule;
 
 pub struct EmptyBenchmark {}
 
@@ -11,27 +9,5 @@ impl BenchmarkModule for EmptyBenchmark {
 
     fn name() -> &'static str {
         "Empty Benchmark"
-    }
-
-    fn start_interval_counters(_scope: Scope) {}
-
-    fn stop_interval_counters(_scope: Scope) {}
-
-    fn increment_counter(_counter: Counter) {}
-
-    fn update_inteval_counter_stats(
-        &mut self,
-        _counter: &IntervalCounter,
-        _scope: &Scope,
-        _value: usize,
-    ) {
-    }
-
-    fn read_counters(_ctx: &mut VirtContext) {}
-
-    fn display_counters() {}
-
-    fn get_counter_value(_core_id: usize, _counter: Counter) -> usize {
-        0
     }
 }

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -21,26 +21,29 @@ pub trait BenchmarkModule {
     fn init() -> Self;
     fn name() -> &'static str;
 
-    fn start_interval_counters(scope: Scope);
-    fn stop_interval_counters(scope: Scope);
-    fn increment_counter(counter: Counter);
+    fn start_interval_counters(_scope: Scope) {}
+    fn stop_interval_counters(_scope: Scope) {}
+    fn increment_counter(_counter: Counter) {}
 
     fn update_inteval_counter_stats(
         &mut self,
-        counter: &IntervalCounter,
-        scope: &Scope,
-        value: usize,
-    );
+        _counter: &IntervalCounter,
+        _scope: &Scope,
+        _value: usize,
+    ) {
+    }
 
     /// Print formated string with value of the counters
-    fn display_counters();
+    fn display_counters() {}
 
     /// Read the performance counters into the virtual registers.
     ///
     /// Note: the specific ABI is depends on the benchmark back-end.
-    fn read_counters(ctx: &mut VirtContext);
+    fn read_counters(_ctx: &mut VirtContext) {}
 
-    fn get_counter_value(core_id: usize, counter: Counter) -> usize;
+    fn get_counter_value(_core_id: usize, _counter: Counter) -> usize {
+        0
+    }
 }
 
 pub enum Scope {


### PR DESCRIPTION
This refactoring reduces a bit the number of lines of LoC by deduplicating the empty functions in the trait directly