### PR TITLE
Bugfix: sbi filtering rules doesn't take into account the legacy exte…

### DIFF
--- a/misc/generate_sbi_filtering_rules.py
+++ b/misc/generate_sbi_filtering_rules.py
@@ -28,11 +28,15 @@ def read_file_line_by_line(file_path):
         header = file.readline()
 
         if header.startswith("== ") and "EID " in header:
-            fid = header.split("#")[1].split(" ")[0].split(")")[0]
+            eid = header.split("#")[1].split(" ")[0].split(")")[0]
+
+        is_legacy = False
+        if header.strip() == "== Legacy Extensions (EIDs #0x00 - #0x0F)":
+            is_legacy = True
 
         for line in file:
-            if line.startswith("=== ") and "FID " in line:
-                eid = line.split("#")[1].split(" ")[0].split(")")[0]
+            if line.startswith("=== ") and ("FID " in line or "EID " in line) :
+                fid = line.split("#")[1].split(" ")[0].split(")")[0]
                 # Consume the next two lines
                 file.readline()
                 file.readline()
@@ -49,7 +53,12 @@ def read_file_line_by_line(file_path):
                 if "void" in curr:
                     malus += 1
 
-                output.append((fid, eid, curr.count(",") + 1 - malus))
+                if is_legacy:
+                    output.append((fid, "0", curr.count(",") + 1 - malus))
+                else:
+                    output.append((eid, fid, curr.count(",") + 1 - malus))
+
+
     return output
 
 def generate_function(values):

--- a/src/policy/protect_payload.rs
+++ b/src/policy/protect_payload.rs
@@ -493,9 +493,17 @@ fn hash_payload(size_to_hash: usize, pc_start: usize) -> [u8; 32] {
 
 // ———————————————————————————————— Filtering rules for ecall - automatically generated ———————————————————————————————— //
 
-#[allow(unused)]
 fn check_nb_registers_to_forward_per_eid_fid(eid: usize, fid: usize) -> usize {
     match (eid, fid) {
+        (0x00, 0) => 1,
+        (0x01, 0) => 1,
+        (0x02, 0) => 0,
+        (0x03, 0) => 0,
+        (0x04, 0) => 1,
+        (0x05, 0) => 1,
+        (0x06, 0) => 3,
+        (0x07, 0) => 4,
+        (0x08, 0) => 0,
         (0x10, 0) => 0,
         (0x10, 1) => 0,
         (0x10, 2) => 0,
@@ -524,13 +532,14 @@ fn check_nb_registers_to_forward_per_eid_fid(eid: usize, fid: usize) -> usize {
         (0x48534D, 1) => 0,
         (0x48534D, 2) => 1,
         (0x48534D, 3) => 3,
-        (0x4D505859, 0) => 4,
-        (0x4D505859, 1) => 1,
-        (0x4D505859, 2) => 3,
+        (0x4D505859, 0) => 0,
+        (0x4D505859, 1) => 3,
+        (0x4D505859, 2) => 1,
         (0x4D505859, 3) => 3,
         (0x4D505859, 4) => 3,
         (0x4D505859, 5) => 3,
-        (0x4D505859, 6) => 1,
+        (0x4D505859, 6) => 3,
+        (0x4D505859, 7) => 1,
         (0x4E41434C, 0) => 1,
         (0x4E41434C, 1) => 3,
         (0x4E41434C, 2) => 1,


### PR DESCRIPTION
…nsion

The script we have to filter out the registers used by the SBI didn't parse the legacy extension correctly. This update fixes the issues. One may notice that some filtering rules changes in the middle. This is simply due to the fact that we used a newer version of the SBI and is not a bug.