### PR TITLE
Average number of world switches and firmware exits by the number of …

### DIFF
--- a/src/benchmark/counter.rs
+++ b/src/benchmark/counter.rs
@@ -5,6 +5,8 @@ use crate::benchmark::default::IntervalCounter;
 use crate::benchmark::Counter::{FirmwareExits, WorldSwitches};
 use crate::benchmark::{BenchmarkModule, Counter, Scope};
 use crate::config::PLATFORM_NB_HARTS;
+use crate::platform::visionfive2::VISION_FIVE_2_NAME;
+use crate::platform::{Plat, Platform};
 use crate::virt::traits::*;
 use crate::virt::VirtContext;
 
@@ -88,8 +90,15 @@ impl BenchmarkModule for CounterBenchmark {
             ),
         }
 
-        ctx.set(Register::X10, nb_firmware_exits);
-        ctx.set(Register::X11, nb_world_switch);
+        // Edge case: one core is never used on the visionfive2 board
+        let nb_running_harts: usize = if Plat::name() == VISION_FIVE_2_NAME {
+            4
+        } else {
+            PLATFORM_NB_HARTS
+        };
+
+        ctx.set(Register::X10, nb_firmware_exits / nb_running_harts);
+        ctx.set(Register::X11, nb_world_switch / nb_running_harts);
     }
 
     fn display_counters() {

--- a/src/platform/visionfive2.rs
+++ b/src/platform/visionfive2.rs
@@ -25,6 +25,8 @@ const FIRMWARE_START_ADDR: usize = TARGET_FIRMWARE_ADDRESS;
 const CLINT_BASE: usize = 0x2000000;
 const TEST_DEVICE_BASE: usize = 0x3000000;
 
+pub const VISION_FIVE_2_NAME: &str = "VisionFive 2 board";
+
 // ———————————————————————————— Platform Devices ———————————————————————————— //
 
 /// The physical CLINT driver.
@@ -69,7 +71,7 @@ impl Platform for VisionFive2Platform {
     const NB_VIRT_DEVICES: usize = 2;
 
     fn name() -> &'static str {
-        "VisionFive 2 board"
+        VISION_FIVE_2_NAME
     }
 
     fn init() {


### PR DESCRIPTION
…cores

We are interested in the average number of world switches and firmware exits. Therefore we must average by the number of cores. On the visionfive 2 board, there is an edge case. One core doesn't boot linux and must therefore be excluded.