### PR TITLE
Measure offload latency for timer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,7 @@ version = "0.1.0"
 dependencies = [
  "config_helpers",
  "miralis_abi",
+ "miralis_core",
 ]
 
 [[package]]

--- a/config/test/spike-latency-benchmark-offload.toml
+++ b/config/test/spike-latency-benchmark-offload.toml
@@ -1,0 +1,23 @@
+# A simple configuration to run on the Spike platform
+
+[log]
+level = "info"
+color = true
+
+[vcpu]
+max_pmp = 8
+delegate_perf_counters=true
+
+[platform]
+name = "spike"
+
+[target.miralis]
+# Build profile for Miralis (dev profile is set by default)
+profile = "release"
+
+[target.firmware]
+# Build profile for the firmware (dev profile is set by default)
+profile = "release"
+
+[policy]
+name = "offload"

--- a/firmware/tracing_firmware/Cargo.toml
+++ b/firmware/tracing_firmware/Cargo.toml
@@ -11,4 +11,5 @@ path = "main.rs"
 
 [dependencies]
 miralis_abi = { path = "../../crates/abi" }
+miralis_core =  { path = "../../crates/core" }
 config_helpers = { path = "../../crates/config_helpers" }

--- a/miralis.toml
+++ b/miralis.toml
@@ -38,6 +38,9 @@ path = "./config/test/spike-latency-benchmark.toml"
 [config.spike-benchmark-protect-payload]
 path = "./config/test/spike-latency-benchmark-protect-payload.toml"
 
+[config.spike-benchmark-offload]
+path = "./config/test/spike-latency-benchmark-offload.toml"
+
 ## ——————————————————————————— Integration Tests ———————————————————————————— ##
 
 [test.ecall]
@@ -242,3 +245,8 @@ description = "The firmware and configuration we use to measure cycles in the CI
 firmware = "tracing_firmware"
 config = "spike-benchmark-protect-payload"
 description = "The firmware and configuration we use to measure cycles in the CI using the protect payload policy"
+
+[test.spike-benchmark-offload]
+firmware = "tracing_firmware"
+config = "spike-benchmark-offload"
+description = "The firmware and configuration we use to measure the latency of the offloaded timer"


### PR DESCRIPTION
The most two frequents operations that the payload requests from the firmware is to set the next supervisor timer interrupt and read the current time using the time register. This commit introduces a new benchmark to measure the latency of the operations in the offload policy.

@CharlyCst Feel free to review, I will create a second commit to insert in the ci / cd pipeline