### PR TITLE
Split Instr in Load, Store, and Illegal instr

### DIFF
--- a/model_checking/src/adapters.rs
+++ b/model_checking/src/adapters.rs
@@ -6,7 +6,7 @@
 //! this module exposing functions to convert from one representation to the other.
 
 use miralis::arch::{Csr, Mode, Register, Width};
-use miralis::decoder::Instr;
+use miralis::decoder::{IllegalInst, LoadInstr, StoreInstr};
 use miralis::host::MiralisContext;
 use miralis::utils::bits_to_int;
 use miralis::virt::VirtContext;
@@ -507,25 +507,9 @@ fn size_to_width(size: word_width) -> Width {
     }
 }
 
-pub fn ast_to_miralis_instr(ast_entry: ast) -> Instr {
+pub fn ast_to_miralis_load(ast_entry: ast) -> LoadInstr {
     match ast_entry {
-        ast::MRET(()) => Instr::Mret,
-        ast::WFI(()) => Instr::Wfi,
-        ast::ECALL(()) => panic!("Miralis does not need to decode ecalls"),
-        ast::EBREAK(()) => panic!("Miralis does not need to decode ebreaks"),
-        ast::SFENCE_VMA((rs1, rs2)) => Instr::Sfencevma {
-            rs1: Register::from(rs1.bits as usize),
-            rs2: Register::from(rs2.bits as usize),
-        },
-        ast::HFENCE_VVMA((rs1, rs2)) => Instr::Hfencevvma {
-            rs1: Register::from(rs1.bits as usize),
-            rs2: Register::from(rs2.bits as usize),
-        },
-        ast::HFENCE_GVMA((rs1, rs2)) => Instr::Hfencegvma {
-            rs1: Register::from(rs1.bits as usize),
-            rs2: Register::from(rs2.bits as usize),
-        },
-        ast::C_LW((imm, rs1, rd)) => Instr::Load {
+        ast::C_LW((imm, rs1, rd)) => LoadInstr {
             rd: Register::from(rd.bits as usize + 8),
             rs1: Register::from(rs1.bits as usize + 8),
             imm: (imm.bits << 2) as isize,
@@ -533,7 +517,7 @@ pub fn ast_to_miralis_instr(ast_entry: ast) -> Instr {
             is_compressed: true,
             is_unsigned: false,
         },
-        ast::C_LD((imm, rs1, rd)) => Instr::Load {
+        ast::C_LD((imm, rs1, rd)) => LoadInstr {
             rd: Register::from(rd.bits as usize + 8),
             rs1: Register::from(rs1.bits as usize + 8),
             imm: (imm.bits << 3) as isize,
@@ -541,7 +525,7 @@ pub fn ast_to_miralis_instr(ast_entry: ast) -> Instr {
             is_compressed: true,
             is_unsigned: false,
         },
-        ast::LOAD((imm, rs1, rd, is_unsigned, size, ..)) => Instr::Load {
+        ast::LOAD((imm, rs1, rd, is_unsigned, size, ..)) => LoadInstr {
             rd: Register::from(rd.bits as usize),
             rs1: Register::from(rs1.bits as usize),
             imm: bits_to_int(imm.bits as usize, 0, 11),
@@ -549,14 +533,20 @@ pub fn ast_to_miralis_instr(ast_entry: ast) -> Instr {
             is_compressed: false,
             is_unsigned: is_unsigned,
         },
-        ast::C_SW((imm, rs1, rs2)) => Instr::Store {
+        _ => unreachable!(),
+    }
+}
+
+pub fn ast_to_miralis_store(ast_entry: ast) -> StoreInstr {
+    match ast_entry {
+        ast::C_SW((imm, rs1, rs2)) => StoreInstr {
             rs2: Register::from(rs2.bits as usize + 8),
             rs1: Register::from(rs1.bits as usize + 8),
             imm: (imm.bits << 2) as isize,
             len: Width::Byte4,
             is_compressed: true,
         },
-        ast::C_SD((imm, rs1, rs2)) => Instr::Store {
+        ast::C_SD((imm, rs1, rs2)) => StoreInstr {
             rs2: Register::from(rs2.bits as usize + 8),
             rs1: Register::from(rs1.bits as usize + 8),
             imm: (imm.bits << 3) as isize,
@@ -564,12 +554,34 @@ pub fn ast_to_miralis_instr(ast_entry: ast) -> Instr {
             is_compressed: true,
         },
 
-        ast::STORE((imm, rs2, rs1, size, ..)) => Instr::Store {
+        ast::STORE((imm, rs2, rs1, size, ..)) => StoreInstr {
             rs2: Register::from(rs2.bits as usize),
             rs1: Register::from(rs1.bits as usize),
             imm: bits_to_int(imm.bits as usize, 0, 11),
             len: size_to_width(size),
             is_compressed: false,
+        },
+        _ => unreachable!(),
+    }
+}
+
+pub fn ast_to_miralis_instr(ast_entry: ast) -> IllegalInst {
+    match ast_entry {
+        ast::MRET(()) => IllegalInst::Mret,
+        ast::WFI(()) => IllegalInst::Wfi,
+        ast::ECALL(()) => panic!("Miralis does not need to decode ecalls"),
+        ast::EBREAK(()) => panic!("Miralis does not need to decode ebreaks"),
+        ast::SFENCE_VMA((rs1, rs2)) => IllegalInst::Sfencevma {
+            rs1: Register::from(rs1.bits as usize),
+            rs2: Register::from(rs2.bits as usize),
+        },
+        ast::HFENCE_VVMA((rs1, rs2)) => IllegalInst::Hfencevvma {
+            rs1: Register::from(rs1.bits as usize),
+            rs2: Register::from(rs2.bits as usize),
+        },
+        ast::HFENCE_GVMA((rs1, rs2)) => IllegalInst::Hfencegvma {
+            rs1: Register::from(rs1.bits as usize),
+            rs2: Register::from(rs2.bits as usize),
         },
         ast::CSR((csrreg, rs1, rd, is_immediate, op)) => {
             let csr_register: Csr = decode_csr_register(csrreg);
@@ -578,38 +590,38 @@ pub fn ast_to_miralis_instr(ast_entry: ast) -> Instr {
             let rd_miralis = Register::from(rd.bits() as usize);
 
             match (op, is_immediate) {
-                (csrop::CSRRW, false) => Instr::Csrrw {
+                (csrop::CSRRW, false) => IllegalInst::Csrrw {
                     csr: csr_register,
                     rd: rd_miralis,
                     rs1: rs1_miralis,
                 },
-                (csrop::CSRRC, false) => Instr::Csrrc {
+                (csrop::CSRRC, false) => IllegalInst::Csrrc {
                     csr: csr_register,
                     rd: rd_miralis,
                     rs1: rs1_miralis,
                 },
-                (csrop::CSRRS, false) => Instr::Csrrs {
+                (csrop::CSRRS, false) => IllegalInst::Csrrs {
                     csr: csr_register,
                     rd: rd_miralis,
                     rs1: rs1_miralis,
                 },
-                (csrop::CSRRW, true) => Instr::Csrrwi {
+                (csrop::CSRRW, true) => IllegalInst::Csrrwi {
                     csr: csr_register,
                     rd: rd_miralis,
                     uimm: rs1.bits as usize,
                 },
-                (csrop::CSRRC, true) => Instr::Csrrci {
+                (csrop::CSRRC, true) => IllegalInst::Csrrci {
                     csr: csr_register,
                     rd: rd_miralis,
                     uimm: rs1.bits as usize,
                 },
-                (csrop::CSRRS, true) => Instr::Csrrsi {
+                (csrop::CSRRS, true) => IllegalInst::Csrrsi {
                     csr: csr_register,
                     rd: rd_miralis,
                     uimm: rs1.bits as usize,
                 },
             }
         }
-        _ => Instr::Unknown,
+        _ => IllegalInst::Unknown,
     }
 }

--- a/model_checking/src/lib.rs
+++ b/model_checking/src/lib.rs
@@ -2,7 +2,7 @@ use miralis::arch::pmp::pmplayout::VIRTUAL_PMP_OFFSET;
 use miralis::arch::pmp::PmpGroup;
 use miralis::arch::userspace::return_userspace_ctx;
 use miralis::arch::{mie, write_pmp, MCause, Register};
-use miralis::decoder::Instr;
+use miralis::decoder::IllegalInst;
 use miralis::host::MiralisContext;
 use miralis::virt::traits::{HwRegisterContextSetter, RegisterContextGetter};
 use miralis::virt::VirtContext;
@@ -10,15 +10,15 @@ use sail_decoder::decoder_illegal::sail_decoder_illegal;
 use sail_decoder::decoder_load::sail_decoder_load;
 use sail_decoder::decoder_store::sail_decoder_store;
 use sail_model::{
-    execute_HFENCE_GVMA, execute_HFENCE_VVMA, execute_MRET, execute_SFENCE_VMA, execute_SRET,
+    ast, execute_HFENCE_GVMA, execute_HFENCE_VVMA, execute_MRET, execute_SFENCE_VMA, execute_SRET,
     execute_WFI, pmpCheck, readCSR, set_next_pc, step_interrupts_only, trap_handler, writeCSR,
     AccessType, ExceptionType, Privilege,
 };
 use sail_prelude::{sys_pmp_count, BitField, BitVector};
 
 use crate::adapters::{
-    ast_to_miralis_instr, decode_csr_register, miralis_to_sail, pmpaddr_sail_to_miralis,
-    pmpcfg_sail_to_miralis, sail_to_miralis,
+    ast_to_miralis_instr, ast_to_miralis_load, ast_to_miralis_store, decode_csr_register,
+    miralis_to_sail, pmpaddr_sail_to_miralis, pmpcfg_sail_to_miralis, sail_to_miralis,
 };
 
 #[macro_use]
@@ -423,7 +423,7 @@ pub fn verify_decoder() {
     let decoded_value_miralis = mctx.decode_illegal_instruction(instr as usize);
 
     // For the moment, we ignore the values that are not decoded by the sail reference
-    if decoded_value_sail != Instr::Unknown {
+    if decoded_value_sail != IllegalInst::Unknown {
         assert_eq!(
             decoded_value_sail, decoded_value_miralis,
             "decoders are not equivalent"
@@ -469,20 +469,21 @@ pub fn verify_compressed_loads() {
     // Generate an instruction to decode
     let instr = any!(u16, 0x01073) & !0b11;
 
-    // Decode values
-    let decoded_value_sail = ast_to_miralis_instr(sail_decoder_load::encdec_compressed_backwards(
-        &mut sail_ctx,
-        BitVector::new(instr as u64),
-    ));
+    let intermediate_sail_value =
+        sail_decoder_load::encdec_compressed_backwards(&mut sail_ctx, BitVector::new(instr as u64));
 
-    let decoded_value_miralis = mctx.decode_load(instr as usize);
+    match intermediate_sail_value {
+        ast::ILLEGAL(_) => {}
+        _ => {
+            // Decode values
+            let decoded_value_sail = ast_to_miralis_load(intermediate_sail_value);
+            let decoded_value_miralis = mctx.decode_load(instr as usize);
 
-    // For the moment, we ignore the values that are not decoded by the sail reference
-    if decoded_value_sail != Instr::Unknown {
-        assert_eq!(
-            decoded_value_sail, decoded_value_miralis,
-            "decoders for compressed loads are not equivalent"
-        );
+            assert_eq!(
+                decoded_value_sail, decoded_value_miralis,
+                "decoders for compressed loads are not equivalent"
+            );
+        }
     }
 }
 
@@ -494,20 +495,21 @@ pub fn verify_load() {
     // Generate an instruction to decode
     let instr = any!(u32, 0x01073) | 0b11;
 
-    // Decode values
-    let decoded_value_sail = ast_to_miralis_instr(sail_decoder_load::encdec_backwards(
-        &mut sail_ctx,
-        BitVector::new(instr as u64),
-    ));
+    let intermediate_sail_value =
+        sail_decoder_load::encdec_backwards(&mut sail_ctx, BitVector::new(instr as u64));
 
-    let decoded_value_miralis = mctx.decode_load(instr as usize);
+    match intermediate_sail_value {
+        ast::ILLEGAL(_) => {}
+        _ => {
+            let decoded_value_sail = ast_to_miralis_load(intermediate_sail_value);
 
-    // For the moment, we ignore the values that are not decoded by the sail reference
-    if decoded_value_sail != Instr::Unknown {
-        assert_eq!(
-            decoded_value_sail, decoded_value_miralis,
-            "decoders for loads are not equivalent"
-        );
+            let decoded_value_miralis = mctx.decode_load(instr as usize);
+
+            assert_eq!(
+                decoded_value_sail, decoded_value_miralis,
+                "decoders for loads are not equivalent"
+            );
+        }
     }
 }
 
@@ -519,20 +521,27 @@ pub fn verify_compressed_stores() {
     // Generate an instruction to decode
     let instr = any!(u16, 0x01073) & !0b11;
 
-    // Decode values
-    let decoded_value_sail = ast_to_miralis_instr(sail_decoder_store::encdec_compressed_backwards(
+    let intermediate_sail_value = sail_decoder_store::encdec_compressed_backwards(
         &mut sail_ctx,
         BitVector::new(instr as u64),
-    ));
+    );
 
-    let decoded_value_miralis = mctx.decode_store(instr as usize);
+    match intermediate_sail_value {
+        ast::ILLEGAL(_) => {}
+        _ => {
+            let decoded_value_sail =
+                ast_to_miralis_store(sail_decoder_store::encdec_compressed_backwards(
+                    &mut sail_ctx,
+                    BitVector::new(instr as u64),
+                ));
 
-    // For the moment, we ignore the values that are not decoded by the sail reference
-    if decoded_value_sail != Instr::Unknown {
-        assert_eq!(
-            decoded_value_sail, decoded_value_miralis,
-            "decoders for compressed stores are not equivalent"
-        );
+            let decoded_value_miralis = mctx.decode_store(instr as usize);
+
+            assert_eq!(
+                decoded_value_sail, decoded_value_miralis,
+                "decoders for compressed stores are not equivalent"
+            );
+        }
     }
 }
 
@@ -544,19 +553,21 @@ pub fn verify_stores() {
     // Generate an instruction to decode
     let instr = any!(u32, 0x01073) | 0b11;
 
-    // Decode values
-    let decoded_value_sail = ast_to_miralis_instr(sail_decoder_store::encdec_backwards(
-        &mut sail_ctx,
-        BitVector::new(instr as u64),
-    ));
+    let intermediate_sail_value =
+        sail_decoder_store::encdec_backwards(&mut sail_ctx, BitVector::new(instr as u64));
 
-    let decoded_value_miralis = mctx.decode_store(instr as usize);
+    match intermediate_sail_value {
+        ast::ILLEGAL(_) => {}
+        _ => {
+            // Decode values
+            let decoded_value_sail = ast_to_miralis_store(intermediate_sail_value);
 
-    // For the moment, we ignore the values that are not decoded by the sail reference
-    if decoded_value_sail != Instr::Unknown {
-        assert_eq!(
-            decoded_value_sail, decoded_value_miralis,
-            "decoders for loads are not equivalent"
-        );
+            let decoded_value_miralis = mctx.decode_store(instr as usize);
+
+            assert_eq!(
+                decoded_value_sail, decoded_value_miralis,
+                "decoders for loads are not equivalent"
+            );
+        }
     }
 }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -24,7 +24,7 @@ pub use registers::{Csr, Register};
 pub use trap::{MCause, TrapInfo};
 
 use crate::arch::mstatus::{MPP_FILTER, MPP_OFFSET, SPP_FILTER, SPP_OFFSET};
-use crate::decoder::Instr;
+use crate::decoder::{LoadInstr, StoreInstr};
 use crate::utils::PhantomNotSendNotSync;
 use crate::virt::{ExecutionMode, VirtContext};
 
@@ -94,7 +94,9 @@ pub trait Architecture {
     /// It should not be assume that any of the core configuration is preserved by this function.
     unsafe fn detect_hardware() -> HardwareCapability;
 
-    unsafe fn handle_virtual_load_store(instr: Instr, ctx: &mut VirtContext);
+    unsafe fn handle_virtual_load(instr: LoadInstr, ctx: &mut VirtContext);
+
+    unsafe fn handle_virtual_store(instr: StoreInstr, ctx: &mut VirtContext);
 
     /// Copies dest.len() bytes from src to dest, using the provided mode to read from src.
     /// This function can be useful to copy bytes from the virtual address space of a lower

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -9,7 +9,7 @@ use spin::{Mutex, MutexGuard};
 
 use super::{mie, mstatus, Architecture, Csr, ExtensionsCapability, Mode};
 use crate::arch::HardwareCapability;
-use crate::decoder::Instr;
+use crate::decoder::{LoadInstr, StoreInstr};
 use crate::logger;
 use crate::virt::VirtContext;
 
@@ -302,8 +302,12 @@ impl Architecture for HostArch {
         Self::write_csr(csr, Self::read_csr(csr) | bits_mask)
     }
 
-    unsafe fn handle_virtual_load_store(_instr: Instr, _ctx: &mut VirtContext) {
-        todo!();
+    unsafe fn handle_virtual_load(_instr: LoadInstr, _ctx: &mut VirtContext) {
+        todo!()
+    }
+
+    unsafe fn handle_virtual_store(_instr: StoreInstr, _ctx: &mut VirtContext) {
+        todo!()
     }
 
     unsafe fn read_bytes_from_mode(

--- a/src/virt/emulator.rs
+++ b/src/virt/emulator.rs
@@ -12,7 +12,7 @@ use crate::arch::{
     parse_spp_return_mode, Arch, Architecture, Csr, MCause, Mode, Register,
 };
 use crate::benchmark::{Benchmark, BenchmarkModule};
-use crate::decoder::Instr;
+use crate::decoder::{IllegalInst, LoadInstr, StoreInstr};
 use crate::device::VirtDevice;
 use crate::host::MiralisContext;
 use crate::platform::{Plat, Platform};
@@ -29,31 +29,38 @@ pub enum ExitResult {
     Done,
 }
 
+/// A load or store instruction.
+#[derive(Debug)]
+enum LoadStoreInstr {
+    Load(LoadInstr),
+    Store(StoreInstr),
+}
+
 impl VirtContext {
-    fn emulate_privileged_instr(&mut self, instr: &Instr, mctx: &mut MiralisContext) {
+    fn emulate_privileged_instr(&mut self, instr: &IllegalInst, mctx: &mut MiralisContext) {
         match instr {
-            Instr::Wfi => self.emulate_wfi(mctx),
-            Instr::Csrrw { csr, .. }
-            | Instr::Csrrs { csr, .. }
-            | Instr::Csrrc { csr, .. }
-            | Instr::Csrrwi { csr, .. }
-            | Instr::Csrrsi { csr, .. }
-            | Instr::Csrrci { csr, .. }
+            IllegalInst::Wfi => self.emulate_wfi(mctx),
+            IllegalInst::Csrrw { csr, .. }
+            | IllegalInst::Csrrs { csr, .. }
+            | IllegalInst::Csrrc { csr, .. }
+            | IllegalInst::Csrrwi { csr, .. }
+            | IllegalInst::Csrrsi { csr, .. }
+            | IllegalInst::Csrrci { csr, .. }
                 if csr.is_unknown() =>
             {
                 self.emulate_jump_trap_handler();
             }
-            Instr::Csrrw { csr, rd, rs1 } => self.emulate_csrrw(mctx, *csr, *rd, *rs1),
-            Instr::Csrrs { csr, rd, rs1 } => self.emulate_csrrs(mctx, *csr, *rd, *rs1),
-            Instr::Csrrc { csr, rd, rs1 } => self.emulate_csrrc(mctx, *csr, *rd, *rs1),
-            Instr::Csrrwi { csr, rd, uimm } => self.emulate_csrrwi(mctx, *csr, *rd, *uimm),
-            Instr::Csrrsi { csr, rd, uimm } => self.emulate_csrrsi(mctx, *csr, *rd, *uimm),
-            Instr::Csrrci { csr, rd, uimm } => self.emulate_csrrci(mctx, *csr, *rd, *uimm),
-            Instr::Mret => self.emulate_mret(mctx),
-            Instr::Sret => self.emulate_sret(mctx),
-            Instr::Sfencevma { rs1, rs2 } => self.emulate_sfence_vma(mctx, rs1, rs2),
-            Instr::Hfencegvma { rs1, rs2 } => self.emulate_hfence_gvma(mctx, rs1, rs2),
-            Instr::Hfencevvma { rs1, rs2 } => self.emulate_hfence_vvma(mctx, rs1, rs2),
+            IllegalInst::Csrrw { csr, rd, rs1 } => self.emulate_csrrw(mctx, *csr, *rd, *rs1),
+            IllegalInst::Csrrs { csr, rd, rs1 } => self.emulate_csrrs(mctx, *csr, *rd, *rs1),
+            IllegalInst::Csrrc { csr, rd, rs1 } => self.emulate_csrrc(mctx, *csr, *rd, *rs1),
+            IllegalInst::Csrrwi { csr, rd, uimm } => self.emulate_csrrwi(mctx, *csr, *rd, *uimm),
+            IllegalInst::Csrrsi { csr, rd, uimm } => self.emulate_csrrsi(mctx, *csr, *rd, *uimm),
+            IllegalInst::Csrrci { csr, rd, uimm } => self.emulate_csrrci(mctx, *csr, *rd, *uimm),
+            IllegalInst::Mret => self.emulate_mret(mctx),
+            IllegalInst::Sret => self.emulate_sret(mctx),
+            IllegalInst::Sfencevma { rs1, rs2 } => self.emulate_sfence_vma(mctx, rs1, rs2),
+            IllegalInst::Hfencegvma { rs1, rs2 } => self.emulate_hfence_gvma(mctx, rs1, rs2),
+            IllegalInst::Hfencevvma { rs1, rs2 } => self.emulate_hfence_vvma(mctx, rs1, rs2),
             _ => todo!(
                 "Instruction not yet implemented: {:?} {:x} {:x}",
                 instr,
@@ -63,12 +70,12 @@ impl VirtContext {
         }
 
         // All instructions except MRET and SRET increases the pc by 4
-        if *instr != Instr::Mret && *instr != Instr::Sret {
+        if *instr != IllegalInst::Mret && *instr != IllegalInst::Sret {
             self.pc += 4;
         }
     }
 
-    /// Handles a load instruction.
+    /// Handles a devie load instruction.
     ///
     /// Calculates the memory address, reads the value from the device,
     /// sign-extends (normal load) or zero-extends (unsigned load) it to 64 bits if necessary,
@@ -78,89 +85,73 @@ impl VirtContext {
     /// - The immediate (`imm`) value can be positive or negative.
     /// - Compressed load&store instructions are 2 bytes long.
     /// - The immediate (`imm`) value is always positive.
-    fn handle_load(&mut self, device: &VirtDevice, instr: &Instr) {
-        match instr {
-            Instr::Load {
-                rd,
-                rs1,
-                imm,
-                len,
-                is_compressed,
-                is_unsigned,
-            } => {
-                let address = utils::calculate_addr(self.get(*rs1), *imm);
-                let offset = address - device.start_addr;
+    fn handle_device_load(&mut self, device: &VirtDevice, instr: &LoadInstr) {
+        let LoadInstr {
+            rd,
+            rs1,
+            imm,
+            len,
+            is_compressed,
+            is_unsigned,
+        } = instr;
+        let address = utils::calculate_addr(self.get(*rs1), *imm);
+        let offset = address - device.start_addr;
 
-                match device.device_interface.read_device(offset, *len, self) {
-                    Ok(value) => {
-                        let value = if !is_unsigned {
-                            sign_extend(value, *len)
-                        } else {
-                            value
-                        };
+        match device.device_interface.read_device(offset, *len, self) {
+            Ok(value) => {
+                let value = if !is_unsigned {
+                    sign_extend(value, *len)
+                } else {
+                    value
+                };
 
-                        self.set(*rd, value);
-                        self.pc += if *is_compressed { 2 } else { 4 };
-                    }
-                    Err(err) => panic!("Error reading {}: {}", device.name, err),
-                }
+                self.set(*rd, value);
+                self.pc += if *is_compressed { 2 } else { 4 };
             }
-            _ => panic!("Not a load instruction in a load handler"),
+            Err(err) => panic!("Error reading {}: {}", device.name, err),
         }
     }
 
-    /// Handles a store instruction.
+    /// Handles a device store instruction.
     ///
     /// Calculates the memory address and writes the value
     /// to the device (after applying a mask to prevent overflow).
-    fn handle_store(&mut self, device: &VirtDevice, instr: &Instr) {
-        match instr {
-            Instr::Store {
-                rs2,
-                rs1,
-                imm,
-                len,
-                is_compressed,
-            } => {
-                let address = utils::calculate_addr(self.get(*rs1), *imm);
-                let offset = address - device.start_addr;
+    fn handle_device_store(&mut self, device: &VirtDevice, instr: &StoreInstr) {
+        let StoreInstr {
+            rs2,
+            rs1,
+            imm,
+            len,
+            is_compressed,
+        } = instr;
+        let address = utils::calculate_addr(self.get(*rs1), *imm);
+        let offset = address - device.start_addr;
 
-                let value = self.get(*rs2);
+        let value = self.get(*rs2);
 
-                let mask = if len.to_bits() < usize::BITS as usize {
-                    (1 << len.to_bits()) - 1
-                } else {
-                    usize::MAX
-                };
+        let mask = if len.to_bits() < usize::BITS as usize {
+            (1 << len.to_bits()) - 1
+        } else {
+            usize::MAX
+        };
 
-                if value > mask {
-                    debug::warn_once!(
-                        "Value {} exceeds allowed length {}. Trimming to fit.",
-                        value,
-                        len.to_bits()
-                    );
-                }
-
-                match device
-                    .device_interface
-                    .write_device(offset, *len, value & mask, self)
-                {
-                    Ok(()) => {
-                        // Update the program counter (pc) based on compression
-                        self.pc += if *is_compressed { 2 } else { 4 };
-                    }
-                    Err(err) => panic!("Error writing {}: {}", device.name, err),
-                }
-            }
-            _ => panic!("Not a store instruction in a store handler"),
+        if value > mask {
+            debug::warn_once!(
+                "Value {} exceeds allowed length {}. Trimming to fit.",
+                value,
+                len.to_bits()
+            );
         }
-    }
 
-    pub fn handle_device_access_fault(&mut self, instr: &Instr, device: &VirtDevice) {
-        match instr {
-            Instr::Load { .. } => self.handle_load(device, instr),
-            Instr::Store { .. } => self.handle_store(device, instr),
-            _ => todo!("Instruction not yet implemented: {:?}", instr),
+        match device
+            .device_interface
+            .write_device(offset, *len, value & mask, self)
+        {
+            Ok(()) => {
+                // Update the program counter (pc) based on compression
+                self.pc += if *is_compressed { 2 } else { 4 };
+            }
+            Err(err) => panic!("Error writing {}: {}", device.name, err),
         }
     }
 
@@ -170,23 +161,43 @@ impl VirtContext {
     /// - An emulated MMIO access, that is a device is being accessed.
     /// - A load/store with MPRV set to 1
     /// - A normal access fault, which should be forwarded.
-    fn handle_pmp_fault(&mut self, mctx: &mut MiralisContext, instr: Instr) {
+    fn handle_pmp_fault(&mut self, mctx: &mut MiralisContext, instr: LoadStoreInstr) {
         if let Some(device) = device::find_matching_device(self.trap_info.mtval, mctx.devices) {
+            // The fault is due to an access to a virtual device
             logger::trace!(
                 "Accessed devices: {} | With instr: {:?}",
                 device.name,
                 instr
             );
-            self.handle_device_access_fault(&instr, device);
+            match instr {
+                LoadStoreInstr::Load(instr) => self.handle_device_load(device, &instr),
+                LoadStoreInstr::Store(instr) => self.handle_device_store(device, &instr),
+            }
         } else if (self.csr.mstatus & mstatus::MPRV_FILTER) >> mstatus::MPRV_OFFSET == 1 {
+            // The fault is due to an access with MPRV = 1.
+            //
+            // Miralis need to emulate all such accesses. When the virtual firmware sets MPRV = 1
+            // Miralis configures the PMP to traps on all loads and stores, catch the traps and
+            // emulate the load/stores one by one.
+            //
+            // Sadly this is necessary as MPRV = 1 changes the access rights for load & stores, but
+            // not for instruction fetches, thus it is not possible to emulate the MPRV = 1
+            // behavior using page tables. Of course the current emulation strategy comes with a
+            // performance overhead.
+            //
             // TODO: make sure virtual address does not get around PMP protection
             logger::trace!(
                 "Access fault {:x?} with a virtual address: 0x{:x}",
                 &instr,
                 self.trap_info.mtval
             );
-            unsafe {
-                Arch::handle_virtual_load_store(instr, self);
+            match instr {
+                LoadStoreInstr::Load(instr) => unsafe {
+                    Arch::handle_virtual_load(instr, self);
+                },
+                LoadStoreInstr::Store(instr) => unsafe {
+                    Arch::handle_virtual_store(instr, self);
+                },
             }
         } else {
             logger::trace!(
@@ -408,12 +419,12 @@ impl VirtContext {
             MCause::StoreAccessFault => {
                 let instr = unsafe { get_raw_faulting_instr(&self.trap_info) };
                 let instr = mctx.decode_store(instr);
-                self.handle_pmp_fault(mctx, instr);
+                self.handle_pmp_fault(mctx, LoadStoreInstr::Store(instr));
             }
             MCause::LoadAccessFault => {
                 let instr = unsafe { get_raw_faulting_instr(&self.trap_info) };
                 let instr = mctx.decode_load(instr);
-                self.handle_pmp_fault(mctx, instr);
+                self.handle_pmp_fault(mctx, LoadStoreInstr::Load(instr));
             }
             MCause::InstrAccessFault => {
                 logger::trace!("Instruction access fault: {:x?}", self.trap_info);


### PR DESCRIPTION
This commit splits the generic Instr enum in three components: IllegalInstr, LoadInstr, and StoreInstr. The instruction decoder is also split accordingly.

Such a decomposition makes sense as the `mcause` CSR indicates the kind of instruction that caused a trap, therefore the right decoded can be called based on the error code. This saves works in the decoder itself, and makes the overall trap handling faster.

As a downside this Miralis no longer has a generic instruction decoder, and must therefore always rely on the `mcause` code to determine which kind of instruction caused a fault.

This PR is a refactor of #417