### PR TITLE
Bugfix: Fallback to load instructions with MPRV

### DIFF
--- a/src/policy/offload.rs
+++ b/src/policy/offload.rs
@@ -46,7 +46,7 @@ impl PolicyModule for OffloadPolicy {
                 }
             }
             MCause::IllegalInstr => {
-                let instr = unsafe { get_raw_faulting_instr(&ctx.trap_info) };
+                let instr = unsafe { get_raw_faulting_instr(ctx) };
 
                 let is_privileged_op: bool = instr & 0x7f == 0b111_0011;
                 let is_time_register: bool = (instr >> 20) == 0b1100_0000_0001;

--- a/src/policy/protect_payload.rs
+++ b/src/policy/protect_payload.rs
@@ -8,7 +8,7 @@ use tiny_keccak::{Hasher, Sha3};
 
 use crate::arch::pmp::pmpcfg;
 use crate::arch::pmp::pmplayout::POLICY_OFFSET;
-use crate::arch::{get_raw_faulting_instr, mie, mstatus, MCause, Register, TrapInfo};
+use crate::arch::{get_raw_faulting_instr, mie, mstatus, MCause, Register};
 use crate::config::{PAYLOAD_HASH_SIZE, TARGET_PAYLOAD_ADDRESS};
 use crate::host::MiralisContext;
 use crate::logger;
@@ -98,7 +98,7 @@ impl PolicyModule for ProtectPayloadPolicy {
 
         // If the illegal instruction is whitelisted, we allow every register to be modified
         if ctx.trap_info.get_cause() == MCause::IllegalInstr {
-            self.check_illegal_instruction(&mut ctx.trap_info);
+            self.check_illegal_instruction(ctx);
         }
 
         // The code becomes harder to read with the linter suggestion
@@ -196,8 +196,8 @@ impl ProtectPayloadPolicy {
         }
     }
 
-    fn check_illegal_instruction(&mut self, trap_info: &mut TrapInfo) {
-        let instr = unsafe { get_raw_faulting_instr(trap_info) };
+    fn check_illegal_instruction(&mut self, ctx: &VirtContext) {
+        let instr = unsafe { get_raw_faulting_instr(ctx) };
 
         let is_privileged_op: bool = instr & 0x7f == 0b111_0011;
         let is_time_register: bool = (instr >> 20) == 0b1100_0000_0001;

--- a/src/virt/emulator.rs
+++ b/src/virt/emulator.rs
@@ -404,7 +404,7 @@ impl VirtContext {
                 panic!("Firmware should not be able to come from S-mode");
             }
             MCause::IllegalInstr => {
-                let instr = unsafe { get_raw_faulting_instr(&self.trap_info) };
+                let instr = unsafe { get_raw_faulting_instr(self) };
 
                 // Illegal instruction can have two causes:
                 // - privileged (system) instructions excepts ebreak and ecall
@@ -417,12 +417,12 @@ impl VirtContext {
                 self.emulate_jump_trap_handler();
             }
             MCause::StoreAccessFault => {
-                let instr = unsafe { get_raw_faulting_instr(&self.trap_info) };
+                let instr = unsafe { get_raw_faulting_instr(self) };
                 let instr = mctx.decode_store(instr);
                 self.handle_pmp_fault(mctx, LoadStoreInstr::Store(instr));
             }
             MCause::LoadAccessFault => {
-                let instr = unsafe { get_raw_faulting_instr(&self.trap_info) };
+                let instr = unsafe { get_raw_faulting_instr(self) };
                 let instr = mctx.decode_load(instr);
                 self.handle_pmp_fault(mctx, LoadStoreInstr::Load(instr));
             }

--- a/src/virt/memory.rs
+++ b/src/virt/memory.rs
@@ -10,7 +10,7 @@ pub fn emulate_misaligned_read(
     ctx: &mut VirtContext,
     mctx: &mut MiralisContext,
 ) -> PolicyHookResult {
-    let raw_instruction = unsafe { get_raw_faulting_instr(&ctx.trap_info) };
+    let raw_instruction = unsafe { get_raw_faulting_instr(ctx) };
 
     let LoadInstr {
         rd,
@@ -59,7 +59,7 @@ pub fn emulate_misaligned_write(
     ctx: &mut VirtContext,
     mctx: &mut MiralisContext,
 ) -> PolicyHookResult {
-    let raw_instruction = unsafe { get_raw_faulting_instr(&ctx.trap_info) };
+    let raw_instruction = unsafe { get_raw_faulting_instr(ctx) };
 
     let StoreInstr {
         rs2,


### PR DESCRIPTION
Commit ee6279391358bccf39999600e09694498db067fb introduces a new bug. When we emulate the misaligned load and stores, we don't copy anymore from the previous mode. If the given address is virtual, we loose the mapping and therefore the code will be wrong. This commit patches the bug.

This commit fixes changes the fallback case of `get_raw_faulting_instr` to use MPRV to load the instruction. In other words, it will copy the instruction using the previous mode privileges.