### PR TITLE
Offload IPI and remote fences

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -47,6 +47,8 @@ pub mod sbi_codes {
     // SBI return codes used in Miralis
     pub const SBI_ERR_DENIED: usize = (-4_i64) as usize;
 
+    pub const SBI_SUCCESS: usize = 0x0;
+
     // SBI EIDs and FIDs
     /// The debug console extension defines a generic mechanism for boot-time early prints.
     pub const SBI_DEBUG_CONSOLE_EXTENSION_EID: usize = 0x4442434E;
@@ -56,5 +58,24 @@ pub mod sbi_codes {
 
     /// Programs the clock for next event after stime_value time. stime_value is in absolute time. This function must clear the pending timer interrupt bit as well.
     /// If the supervisor wishes to clear the timer interrupt without scheduling the next timer event, it can either request a timer interrupt infinitely far into the future (i.e., (uint64_t)-1), or it can instead mask the timer interrupt by clearing sie.STIE CSR bit.
-    pub const SBI_TIMER_FID: usize = 0;
+    pub const SBI_TIMER_FID: usize = 0x0;
+
+    /// This extension replaces the legacy extension (EID #0x04). The other IPI related legacy extension(0x3)
+    /// is deprecated now. All the functions in this extension follow the hart_mask as defined in the binary
+    /// encoding section.
+    pub const IPI_EXTENSION_EID: usize = 0x735049;
+    /// Send an inter-processor interrupt to all the harts defined in hart_mask. Interprocessor interrupts
+    // manifest at the receiving harts as the supervisor software interrupts.
+    pub const SEND_IPI_FID: usize = 0x0;
+
+    /// This extension defines all remote fence related functions and replaces the legacy extensions (EIDs
+    /// #0x05 - #0x07). All the functions follow the hart_mask as defined in binary encoding section. Any
+    /// function wishes to use range of addresses (i.e. start_addr and size), have to abide by the below
+    /// constraints on range parameters.
+    pub const RFENCE_EXTENSION_EID: usize = 0x52464E43;
+    /// Instructs remote harts to execute FENCE.I instruction.
+    pub const REMOTE_FENCE_I_FID: usize = 0x0;
+    /// Instructs the remote harts to execute one or more SFENCE.VMA instructions, covering the range of
+    /// virtual addresses between start and size.
+    pub const REMOTE_FENCE_VMA_FID: usize = 0x01;
 }

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -662,6 +662,10 @@ impl Architecture for MetalArch {
         }
     }
 
+    unsafe fn ifence() {
+        asm!("fence.i");
+    }
+
     unsafe fn clear_csr_bits(csr: Csr, bits_mask: usize) -> usize {
         let mut prev_value: usize = 0;
         macro_rules! asm_clear_csr_bits {

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -74,6 +74,7 @@ pub trait Architecture {
     unsafe fn sfencevma(vaddr: Option<usize>, asid: Option<usize>);
     unsafe fn hfencegvma(vaddr: Option<usize>, asid: Option<usize>);
     unsafe fn hfencevvma(vaddr: Option<usize>, asid: Option<usize>);
+    unsafe fn ifence();
     unsafe fn run_vcpu(ctx: &mut VirtContext);
 
     /// Wait for interrupt

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -72,6 +72,10 @@ impl Architecture for HostArch {
         logger::debug!("Userspace hfencevvma")
     }
 
+    unsafe fn ifence() {
+        logger::debug!("Userspace ifence");
+    }
+
     unsafe fn detect_hardware() -> HardwareCapability {
         HardwareCapability {
             interrupts: mie::ALL_INT,

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,9 @@ pub const PLATFORM_NB_HARTS: usize = {
     }
 };
 
+/// A mask containing all harts
+pub const ALL_HARTS_MASK: usize = (1 << PLATFORM_NB_HARTS) - 1;
+
 /// Delegate performance counters
 pub const DELEGATE_PERF_COUNTER: bool = is_enabled_default_false!("MIRALIS_DELEGATE_PERF_COUNTER");
 

--- a/src/device/clint.rs
+++ b/src/device/clint.rs
@@ -331,10 +331,12 @@ impl VirtClint {
         self.vmsi[hart].load(Ordering::SeqCst)
     }
 
-    /// Mark the policy MSI as pending for each hart.
-    pub fn set_all_policy_msi(&self) {
+    /// Mark the policy MSI as pending for the harts given by the mask (bit 0 represents hart 0, bit 1 hart 1,....)
+    pub fn set_all_policy_msi(&self, mask: usize) {
         for hart_idx in 0..PLATFORM_NB_HARTS {
-            self.policy_msi[hart_idx].store(true, Ordering::SeqCst);
+            if mask & (1 << hart_idx) != 0 {
+                self.policy_msi[hart_idx].store(true, Ordering::SeqCst);
+            }
         }
     }
 

--- a/src/driver/clint.rs
+++ b/src/driver/clint.rs
@@ -6,7 +6,7 @@
 
 use core::ptr;
 
-use crate::arch::{Arch, Architecture, Csr, Width};
+use crate::arch::Width;
 use crate::config::{self, PLATFORM_NB_HARTS};
 use crate::logger;
 
@@ -145,20 +145,10 @@ impl ClintDriver {
         Ok(())
     }
 
-    /// Create a pending MSI interrupts for each harts of the platform, including the current one.
-    pub fn trigger_msi_on_all_harts(&mut self) {
+    /// Create a pending MSI interrupts for each harts of the platform given in the mask (bit 0 = hart 0, bit 1 = hart 1,...)
+    pub fn trigger_msi_on_all_harts(&mut self, mask: usize) {
         for i in 0..PLATFORM_NB_HARTS {
-            self.write_msip(i, 1).unwrap();
-        }
-    }
-
-    /// Create a pending MSI interrupts for each harts of the platform, except the current one.
-    #[allow(dead_code)]
-    pub fn trigger_msi_on_all_other_harts(&mut self) {
-        let current_hart: usize = Arch::read_csr(Csr::Marchid);
-
-        for i in 0..PLATFORM_NB_HARTS {
-            if i != current_hart {
+            if mask & (1 << i) != 0 {
                 self.write_msip(i, 1).unwrap();
             }
         }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -40,12 +40,12 @@ pub trait Platform {
     /// Signal a pending policy interrupt on all cores and trigger an MSI.
     ///
     /// As a result the policy interrupt callback will be called into on each cores.
-    fn broadcast_policy_interrupt() {
+    fn broadcast_policy_interrupt(mask: usize) {
         // Mark values in virtual clint
-        Self::get_vclint().set_all_policy_msi();
+        Self::get_vclint().set_all_policy_msi(mask);
 
         // Fire physical clint
-        Self::get_clint().lock().trigger_msi_on_all_harts();
+        Self::get_clint().lock().trigger_msi_on_all_harts(mask);
     }
 
     /// Load the firmware (virtual M-mode software) and return its address.

--- a/src/policy/offload.rs
+++ b/src/policy/offload.rs
@@ -1,15 +1,28 @@
 //! The offload policy is a special policy used to reduce the number of world switches
 //! It emulates the misaligned loads and stores, the read of the "time" register and offlaods the timer extension handling in Miralis
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use miralis_core::sbi_codes;
 
-use crate::arch::{get_raw_faulting_instr, Arch, Architecture, Csr, MCause, Register};
+use crate::arch::{get_raw_faulting_instr, mie, Arch, Architecture, Csr, MCause, Mode, Register};
+use crate::config::PLATFORM_NB_HARTS;
 use crate::host::MiralisContext;
 use crate::platform::{Plat, Platform};
 use crate::policy::{PolicyHookResult, PolicyModule};
 use crate::virt::memory::{emulate_misaligned_read, emulate_misaligned_write};
 use crate::virt::traits::{RegisterContextGetter, RegisterContextSetter};
 use crate::virt::VirtContext;
+
+/// Policy Supervisor Software Interrupt (MSI) map
+static POLICY_SSI_ARRAY: [AtomicBool; PLATFORM_NB_HARTS] =
+    [const { AtomicBool::new(false) }; PLATFORM_NB_HARTS];
+/// Remote instruction fence map
+static FENCE_I_ARRAY: [AtomicBool; PLATFORM_NB_HARTS] =
+    [const { AtomicBool::new(false) }; PLATFORM_NB_HARTS];
+/// Remote vma fence map
+static FENCE_VMA_ARRAY: [AtomicBool; PLATFORM_NB_HARTS] =
+    [const { AtomicBool::new(false) }; PLATFORM_NB_HARTS];
 
 pub struct OffloadPolicy {}
 
@@ -33,17 +46,7 @@ impl PolicyModule for OffloadPolicy {
             MCause::LoadAddrMisaligned => emulate_misaligned_read(ctx, mctx),
             MCause::StoreAddrMisaligned => emulate_misaligned_write(ctx, mctx),
             MCause::EcallFromSMode => {
-                let timer_eid: bool = ctx.get(Register::X17) == sbi_codes::SBI_TIMER_EID;
-                let timer_fid: bool = ctx.get(Register::X16) == sbi_codes::SBI_TIMER_FID;
-
-                if timer_eid && timer_fid {
-                    let v_clint = Plat::get_vclint();
-                    v_clint.set_payload_deadline(ctx, mctx, ctx.regs[Register::X10 as usize]);
-                    ctx.pc += 4;
-                    PolicyHookResult::Overwrite
-                } else {
-                    PolicyHookResult::Ignore
-                }
+                Self::check_ecall(ctx, mctx, ctx.get(Register::X16), ctx.get(Register::X17))
             }
             MCause::IllegalInstr => {
                 let instr = unsafe { get_raw_faulting_instr(ctx) };
@@ -75,5 +78,112 @@ impl PolicyModule for OffloadPolicy {
         }
     }
 
+    fn on_interrupt(&mut self, ctx: &mut VirtContext, mctx: &mut MiralisContext) {
+        if POLICY_SSI_ARRAY[mctx.hw.hart]
+            .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            if ctx.mode != Mode::M {
+                unsafe { self.set_physical_ssip() };
+            } else {
+                ctx.csr.mip |= mie::SSIE_FILTER;
+            }
+        }
+
+        if FENCE_I_ARRAY[mctx.hw.hart]
+            .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            unsafe {
+                Arch::ifence();
+            }
+        }
+
+        if FENCE_VMA_ARRAY[mctx.hw.hart]
+            .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            unsafe {
+                Arch::sfencevma(None, None);
+            }
+        }
+    }
+
     const NUMBER_PMPS: usize = 0;
+}
+
+impl OffloadPolicy {
+    fn check_ecall(
+        ctx: &mut VirtContext,
+        mctx: &mut MiralisContext,
+        fid: usize,
+        eid: usize,
+    ) -> PolicyHookResult {
+        match (fid, eid) {
+            (sbi_codes::SBI_TIMER_FID, sbi_codes::SBI_TIMER_EID) => {
+                let v_clint = Plat::get_vclint();
+                v_clint.set_payload_deadline(ctx, mctx, ctx.regs[Register::X10 as usize]);
+                ctx.pc += 4;
+                PolicyHookResult::Overwrite
+            }
+            (sbi_codes::SEND_IPI_FID, sbi_codes::IPI_EXTENSION_EID) => {
+                Self::broadcast_ssi(ctx.get(Register::X10) << ctx.get(Register::X11));
+                ctx.pc += 4;
+                ctx.set(Register::X10, sbi_codes::SBI_SUCCESS);
+                PolicyHookResult::Overwrite
+            }
+            (sbi_codes::REMOTE_FENCE_I_FID, sbi_codes::RFENCE_EXTENSION_EID) => {
+                Self::broadcast_i_fence(ctx.get(Register::X10));
+                ctx.pc += 4;
+                ctx.set(Register::X10, sbi_codes::SBI_SUCCESS);
+                PolicyHookResult::Overwrite
+            }
+            (sbi_codes::REMOTE_FENCE_VMA_FID, sbi_codes::RFENCE_EXTENSION_EID) => {
+                Self::broadcast_vma_fence(ctx.get(Register::X10));
+                ctx.pc += 4;
+                ctx.set(Register::X10, sbi_codes::SBI_SUCCESS);
+                PolicyHookResult::Overwrite
+            }
+            _ => PolicyHookResult::Ignore,
+        }
+    }
+
+    fn broadcast_ssi(mask: usize) {
+        #[allow(clippy::needless_range_loop)]
+        for idx in 0..PLATFORM_NB_HARTS {
+            if mask & (1 << idx) != 0 {
+                POLICY_SSI_ARRAY[idx].store(true, Ordering::SeqCst);
+            }
+        }
+
+        Plat::broadcast_policy_interrupt(mask);
+    }
+
+    fn broadcast_i_fence(mask: usize) {
+        #[allow(clippy::needless_range_loop)]
+        for idx in 0..PLATFORM_NB_HARTS {
+            if mask & (1 << idx) != 0 {
+                FENCE_I_ARRAY[idx].store(true, Ordering::SeqCst);
+            }
+        }
+
+        let mut clint = Plat::get_clint().lock();
+        clint.trigger_msi_on_all_harts(mask);
+    }
+
+    fn broadcast_vma_fence(mask: usize) {
+        #[allow(clippy::needless_range_loop)]
+        for idx in 0..PLATFORM_NB_HARTS {
+            if mask & (1 << idx) != 0 {
+                FENCE_VMA_ARRAY[idx].store(true, Ordering::SeqCst);
+            }
+        }
+
+        let mut clint = Plat::get_clint().lock();
+        clint.trigger_msi_on_all_harts(mask);
+    }
+
+    unsafe fn set_physical_ssip(&self) {
+        Arch::set_csr_bits(Csr::Mip, mie::SSIE_FILTER);
+    }
 }

--- a/src/policy/protect_payload.rs
+++ b/src/policy/protect_payload.rs
@@ -9,7 +9,7 @@ use tiny_keccak::{Hasher, Sha3};
 use crate::arch::pmp::pmpcfg;
 use crate::arch::pmp::pmplayout::POLICY_OFFSET;
 use crate::arch::{get_raw_faulting_instr, mie, mstatus, MCause, Register};
-use crate::config::{PAYLOAD_HASH_SIZE, TARGET_PAYLOAD_ADDRESS};
+use crate::config::{ALL_HARTS_MASK, PAYLOAD_HASH_SIZE, TARGET_PAYLOAD_ADDRESS};
 use crate::host::MiralisContext;
 use crate::logger;
 use crate::platform::{Plat, Platform};
@@ -148,7 +148,7 @@ impl PolicyModule for ProtectPayloadPolicy {
         {
             // Lock memory from all cores
             // TODO: add a proper barrier to ensure synchronization
-            Plat::broadcast_policy_interrupt();
+            Plat::broadcast_policy_interrupt(ALL_HARTS_MASK);
 
             let hashed_value = hash_payload(PAYLOAD_HASH_SIZE, ctx.pc);
 


### PR DESCRIPTION
This commit introduces support for offloading IPI and remote fences in the offload policy. In the Memcached and Redis, we found the presence of a significant amount of requests for IPI and remote fences and this lead to some overhead. This commit closes the gap.