### PR TITLE
Remote the test device from the visionfive2 board

### DIFF
--- a/src/platform/visionfive2.rs
+++ b/src/platform/visionfive2.rs
@@ -9,7 +9,6 @@ use spin::Mutex;
 use crate::arch::{Arch, Architecture};
 use crate::config::{TARGET_FIRMWARE_ADDRESS, TARGET_START_ADDRESS};
 use crate::device::clint::{VirtClint, CLINT_SIZE};
-use crate::device::tester::{VirtTestDevice, TEST_DEVICE_SIZE};
 use crate::device::VirtDevice;
 use crate::driver::clint::ClintDriver;
 use crate::driver::uart::UartDriver;
@@ -23,7 +22,6 @@ const MIRALIS_START_ADDR: usize = TARGET_START_ADDRESS;
 const FIRMWARE_START_ADDR: usize = TARGET_FIRMWARE_ADDRESS;
 
 const CLINT_BASE: usize = 0x2000000;
-const TEST_DEVICE_BASE: usize = 0x3000000;
 
 // ———————————————————————————— Platform Devices ———————————————————————————— //
 
@@ -36,29 +34,18 @@ static CLINT_MUTEX: Mutex<ClintDriver> = unsafe { Mutex::new(ClintDriver::new(CL
 /// The virtual CLINT device.
 static VIRT_CLINT: VirtClint = VirtClint::new(&CLINT_MUTEX);
 
-/// The virtual test device.
-static VIRT_TEST_DEVICE: VirtTestDevice = VirtTestDevice::new();
-
 pub static WRITER: Mutex<UartDriver> = Mutex::new(UartDriver::new(
     UART_SERIAL_PORT_BASE_ADDRESS,
     UART_SIZE_PER_REGISTER,
 ));
 
 /// The list of virtual devices exposed on the platform.
-static VIRT_DEVICES: &[VirtDevice; 2] = &[
-    VirtDevice {
-        start_addr: CLINT_BASE,
-        size: CLINT_SIZE,
-        name: "CLINT",
-        device_interface: &VIRT_CLINT,
-    },
-    VirtDevice {
-        start_addr: TEST_DEVICE_BASE,
-        size: TEST_DEVICE_SIZE,
-        name: "TEST",
-        device_interface: &VIRT_TEST_DEVICE,
-    },
-];
+static VIRT_DEVICES: &[VirtDevice; 1] = &[VirtDevice {
+    start_addr: CLINT_BASE,
+    size: CLINT_SIZE,
+    name: "CLINT",
+    device_interface: &VIRT_CLINT,
+}];
 
 // ———————————————————————————————— Platform ———————————————————————————————— //
 


### PR DESCRIPTION
The test device is used for testing the interface and is a device that is therefore useful only for the ci/cd pipeline. Therefore, it makes no sense to have it in the visionfive2 board.