### PR TITLE
Inject access trap into payload on misaligned load/store emulation up…

### DIFF
--- a/model_checking/src/lib.rs
+++ b/model_checking/src/lib.rs
@@ -255,7 +255,7 @@ pub fn exception_virtualization() {
     fill_trap_info_structure(&mut ctx, &mctx, MCause::new(trap_cause as usize));
 
     // Emulate jump to trap handler in Miralis
-    ctx.emulate_jump_trap_handler();
+    ctx.emulate_firmware_trap();
 
     // Emulate jump to trap handler in Sail
     let pc = sail_ctx.PC;

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -928,12 +928,7 @@ impl Architecture for MetalArch {
         // In that case we need to update the trap info and inject the trap back.
         let cause = Self::read_csr(Csr::Mcause);
         if cause != 0 {
-            ctx.trap_info.mcause = cause;
-            ctx.trap_info.mstatus = Self::read_csr(Csr::Mstatus);
-            ctx.trap_info.mtval = Self::read_csr(Csr::Mtval);
-            ctx.trap_info.mip = Self::read_csr(Csr::Mip);
-
-            ctx.emulate_jump_trap_handler();
+            ctx.emulate_firmware_trap();
         } else {
             ctx.set(instr.rd, value);
             ctx.pc += if instr.is_compressed { 2 } else { 4 };
@@ -981,12 +976,7 @@ impl Architecture for MetalArch {
         // In that case we need to update the trap info and inject the trap back.
         let cause = Self::read_csr(Csr::Mcause);
         if cause != 0 {
-            ctx.trap_info.mcause = cause;
-            ctx.trap_info.mstatus = Self::read_csr(Csr::Mstatus);
-            ctx.trap_info.mtval = Self::read_csr(Csr::Mtval);
-            ctx.trap_info.mip = Self::read_csr(Csr::Mip);
-
-            ctx.emulate_jump_trap_handler();
+            ctx.emulate_firmware_trap();
         } else {
             ctx.pc += if instr.is_compressed { 2 } else { 4 };
         }

--- a/src/policy/offload.rs
+++ b/src/policy/offload.rs
@@ -5,14 +5,8 @@ use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use miralis_core::sbi_codes;
 
-use crate::arch::hstatus::{GVA_FILTER, SPVP_FILTER, SPV_FILTER};
-use crate::arch::mie::{SIE_FILTER, SSIE_FILTER};
-use crate::arch::mstatus::{
-    MPP_FILTER, MPP_OFFSET, MPV_FILTER, SPIE_FILTER, SPIE_OFFSET, SPP_FILTER, SPP_OFFSET,
-};
 use crate::arch::{
-    get_raw_faulting_instr, mie, mstatus, parse_mpp_return_mode, Arch, Architecture, Csr, MCause,
-    Mode, Register, PAGE_SIZE,
+    get_raw_faulting_instr, mie, Arch, Architecture, Csr, MCause, Mode, Register, PAGE_SIZE,
 };
 use crate::config::PLATFORM_NB_HARTS;
 use crate::host::MiralisContext;
@@ -59,10 +53,21 @@ impl PolicyModule for OffloadPolicy {
         let trap_info = ctx.trap_info.clone();
 
         match trap_info.get_cause() {
-            MCause::LoadAddrMisaligned => emulate_misaligned_read(ctx, mctx),
-            MCause::StoreAddrMisaligned => emulate_misaligned_write(ctx, mctx),
+            MCause::LoadAddrMisaligned => {
+                if emulate_misaligned_read(ctx, mctx).is_err() {
+                    ctx.emulate_payload_trap();
+                }
+                PolicyHookResult::Overwrite
+            }
+            MCause::StoreAddrMisaligned => {
+                if emulate_misaligned_write(ctx, mctx).is_err() {
+                    ctx.emulate_payload_trap();
+                }
+                PolicyHookResult::Overwrite
+            }
             MCause::LoadPageFault | MCause::StorePageFault | MCause::InstrPageFault => {
-                Self::redirect_trap_to_s_mode(ctx)
+                ctx.emulate_payload_trap();
+                PolicyHookResult::Overwrite
             }
             MCause::EcallFromSMode => {
                 Self::check_ecall(ctx, mctx, ctx.get(Register::X16), ctx.get(Register::X17))
@@ -220,134 +225,5 @@ impl OffloadPolicy {
 
     unsafe fn set_physical_ssip(&self) {
         Arch::set_csr_bits(Csr::Mip, mie::SSIE_FILTER);
-    }
-
-    /// This function is a rust implementation of the function "sbi_trap_redirect" in the sbi_trap.c from the OpenSBI codebase
-    /// This function corresponds to a payload to payload transition. Therefore, we don't modify the virtual context but the physical registers
-    /// The only exception is ctx.pc because in the trap handler we write mepc with ctx.pc value.
-    #[allow(unused)]
-    fn redirect_trap_to_s_mode(ctx: &mut VirtContext) -> PolicyHookResult {
-        let mut mstatus = ctx.trap_info.mstatus;
-
-        // The previous virtualisation mode
-        let prev_is_virt: bool = mstatus & MPV_FILTER != 0;
-
-        assert!(
-            !prev_is_virt,
-            "Currently, we never tested this code when virtualisation is active, the feature might be unstable"
-        );
-
-        // Sanity check on previous mode
-        let prev_mode = parse_mpp_return_mode(mstatus);
-        assert!(
-            prev_mode != Mode::S && prev_mode != Mode::U,
-            "Trying to redirect a trap from the firmware to the payload"
-        );
-
-        // If exceptions came from VS/VU-mode, redirect to VS-mode if delegated in hedeleg
-        let next_is_virt = ctx.extensions.has_h_extension
-            && prev_is_virt
-            && MCause::is_trap(MCause::try_from(ctx.trap_info.mcause).unwrap());
-
-        // Update MSTATUS MPV bits
-        mstatus &= !MPV_FILTER;
-        mstatus |= if next_is_virt { MPV_FILTER } else { 0 };
-
-        // Update hypervisor CSRs if going to HS-mode
-        if ctx.extensions.has_h_extension && !next_is_virt {
-            let mut hstatus = Arch::read_csr(Csr::Hstatus);
-
-            if prev_is_virt {
-                // hstatus.SPVP is only updated if coming from VS/VU-mode
-                hstatus &= !SPVP_FILTER;
-                hstatus |= if prev_mode == Mode::S { SPVP_FILTER } else { 0 };
-
-                hstatus &= !SPV_FILTER;
-                hstatus |= if prev_is_virt { SPV_FILTER } else { 0 };
-                hstatus &= !GVA_FILTER;
-                hstatus |= if ctx.trap_info.gva { GVA_FILTER } else { 0 };
-
-                unsafe {
-                    Arch::write_csr(Csr::Hstatus, hstatus);
-                    Arch::write_csr(Csr::Htval, ctx.trap_info.mtval2);
-                    Arch::write_csr(Csr::Htinst, ctx.trap_info.mtinst);
-                }
-            }
-        }
-
-        // Update exception related CSRs
-        if (next_is_virt) {
-            // Update VS-mode exception info
-            unsafe {
-                Arch::write_csr(Csr::Vstval, ctx.trap_info.mtval);
-                Arch::write_csr(Csr::Vsepc, ctx.trap_info.mepc);
-                Arch::write_csr(Csr::Vscause, ctx.trap_info.mcause);
-            }
-
-            // Set MEPC to VS-mode exception vector base
-            ctx.pc = Arch::read_csr(Csr::Vstvec);
-
-            // Set MPP to VS-mode
-            mstatus &= !MPP_FILTER;
-            mstatus |= (Mode::S as usize) << MPP_OFFSET;
-
-            // Get VS-mode SSTATUS CSR
-            let mut vsstatus = Arch::read_csr(Csr::Vsstatus);
-
-            // Set SPP for VS-mode
-            vsstatus &= !SPP_FILTER;
-            if prev_mode == Mode::S {
-                vsstatus |= 1 << SPP_OFFSET;
-            }
-
-            // Set SPIE for VS-mode
-            vsstatus &= !SPIE_FILTER;
-            if vsstatus & SSIE_FILTER != 0 {
-                vsstatus |= 1 << SPIE_OFFSET;
-            }
-
-            // Clear SIE for VS-mode
-            vsstatus &= !SIE_FILTER;
-
-            // Update VS-mode SSTATUS CSR
-            unsafe {
-                Arch::write_csr(Csr::Vsstatus, vsstatus);
-            }
-        } else {
-            // Update S-mode exception info
-            unsafe {
-                Arch::write_csr(Csr::Stval, ctx.trap_info.mtval);
-                Arch::write_csr(Csr::Sepc, ctx.trap_info.mepc);
-                Arch::write_csr(Csr::Scause, ctx.trap_info.mcause);
-            }
-
-            // Jump to the Payload trap handler
-            ctx.pc = Arch::read_csr(Csr::Stvec);
-
-            // Set MPP to S-mode
-            mstatus &= !MPP_FILTER;
-            mstatus |= (Mode::S as usize) << MPP_OFFSET;
-
-            // Set SPP for S-mode
-            mstatus &= !SPP_FILTER;
-            if prev_mode == Mode::S {
-                mstatus |= 1 << SPP_OFFSET;
-            }
-
-            // Set SPIE for S-mode
-            mstatus &= !SPIE_FILTER;
-            if mstatus & SIE_FILTER != 0 {
-                mstatus |= SPIE_FILTER
-            }
-
-            // Clear SIE for S-mode
-            mstatus &= !mstatus::SIE_FILTER;
-
-            unsafe {
-                Arch::write_csr(Csr::Mstatus, mstatus);
-            }
-        }
-
-        PolicyHookResult::Overwrite
     }
 }

--- a/src/virt/memory.rs
+++ b/src/virt/memory.rs
@@ -1,16 +1,14 @@
 //! Emulation logic for misaligned loads and stores
 
-use crate::arch::{get_raw_faulting_instr, parse_mpp_return_mode, Arch, Architecture, Csr};
+use crate::arch::{get_raw_faulting_instr, parse_mpp_return_mode, Arch, Architecture};
 use crate::decoder::{LoadInstr, StoreInstr};
 use crate::host::MiralisContext;
-use crate::policy::PolicyHookResult;
 use crate::virt::VirtContext;
 
-pub fn emulate_misaligned_read(
-    ctx: &mut VirtContext,
-    mctx: &mut MiralisContext,
-) -> PolicyHookResult {
+pub fn emulate_misaligned_read(ctx: &mut VirtContext, mctx: &mut MiralisContext) -> Result<(), ()> {
     let raw_instruction = unsafe { get_raw_faulting_instr(ctx) };
+    let mode = parse_mpp_return_mode(ctx.trap_info.mstatus);
+    let success;
 
     let LoadInstr {
         rd,
@@ -32,17 +30,17 @@ pub fn emulate_misaligned_read(
     ctx.regs[rd as usize] = match len.to_bytes() {
         8 => {
             let mut value_to_read: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
-            copy_from_previous_mode(start_addr, &mut value_to_read);
+            success = unsafe { Arch::read_bytes_from_mode(start_addr, &mut value_to_read, mode) };
             u64::from_le_bytes(value_to_read) as usize
         }
         4 => {
             let mut value_to_read: [u8; 4] = [0, 0, 0, 0];
-            copy_from_previous_mode(start_addr, &mut value_to_read);
+            success = unsafe { Arch::read_bytes_from_mode(start_addr, &mut value_to_read, mode) };
             u32::from_le_bytes(value_to_read) as usize
         }
         2 => {
             let mut value_to_read: [u8; 2] = [0, 0];
-            copy_from_previous_mode(start_addr, &mut value_to_read);
+            success = unsafe { Arch::read_bytes_from_mode(start_addr, &mut value_to_read, mode) };
             u16::from_le_bytes(value_to_read) as usize
         }
         _ => {
@@ -50,16 +48,22 @@ pub fn emulate_misaligned_read(
         }
     };
 
-    ctx.pc += if is_compressed { 2 } else { 4 };
-
-    PolicyHookResult::Overwrite
+    match success {
+        Ok(_) => {
+            ctx.pc += if is_compressed { 2 } else { 4 };
+            Ok(())
+        }
+        Err(_) => Err(()),
+    }
 }
 
 pub fn emulate_misaligned_write(
     ctx: &mut VirtContext,
     mctx: &mut MiralisContext,
-) -> PolicyHookResult {
+) -> Result<(), ()> {
     let raw_instruction = unsafe { get_raw_faulting_instr(ctx) };
+    let mode = parse_mpp_return_mode(ctx.trap_info.mstatus);
+    let success;
 
     let StoreInstr {
         rs2,
@@ -81,39 +85,28 @@ pub fn emulate_misaligned_write(
         8 => {
             let val = ctx.regs[rs2 as usize] as u64;
             let mut value_to_store: [u8; 8] = val.to_le_bytes();
-
-            copy_from_previous_mode_store(&mut value_to_store, start_addr);
+            success = unsafe { Arch::store_bytes_from_mode(&mut value_to_store, start_addr, mode) };
         }
         4 => {
             let val = ctx.regs[rs2 as usize] as u32;
             let mut value_to_store: [u8; 4] = val.to_le_bytes();
-
-            copy_from_previous_mode_store(&mut value_to_store, start_addr);
+            success = unsafe { Arch::store_bytes_from_mode(&mut value_to_store, start_addr, mode) };
         }
         2 => {
             let val = ctx.regs[rs2 as usize] as u16;
             let mut value_to_store: [u8; 2] = val.to_le_bytes();
-
-            copy_from_previous_mode_store(&mut value_to_store, start_addr);
+            success = unsafe { Arch::store_bytes_from_mode(&mut value_to_store, start_addr, mode) };
         }
         _ => {
             unreachable!("Misaligned write with a unexpected byte length")
         }
     };
 
-    ctx.pc += if is_compressed { 2 } else { 4 };
-
-    PolicyHookResult::Overwrite
-}
-
-fn copy_from_previous_mode(src: *const u8, dest: &mut [u8]) {
-    // Copy the arguments from the S-mode virtual memory to the M-mode physical memory
-    let mode = parse_mpp_return_mode(Arch::read_csr(Csr::Mstatus));
-    unsafe { Arch::read_bytes_from_mode(src, dest, mode).unwrap() }
-}
-
-fn copy_from_previous_mode_store(src: &mut [u8], dest: *mut u8) {
-    // Copy the arguments from the S-mode virtual memory to the M-mode physical memory
-    let mode = parse_mpp_return_mode(Arch::read_csr(Csr::Mstatus));
-    unsafe { Arch::store_bytes_from_mode(src, dest, mode).unwrap() }
+    match success {
+        Ok(_) => {
+            ctx.pc += if is_compressed { 2 } else { 4 };
+            Ok(())
+        }
+        Err(_) => Err(()),
+    }
 }


### PR DESCRIPTION
…on failure

This commit re-inject traps encountered during misaligned load/store emulation directly in the payload (OpenSBI does the same)