### PR TITLE
Test the protect payload policy on spike with misaligned loads and st…

### DIFF
--- a/miralis.toml
+++ b/miralis.toml
@@ -205,6 +205,11 @@ firmware = "misaligned_op"
 config = "spike-protect-payload"
 description = "Test the protect payload policy emulation of misaligned loads (on Spike)."
 
+[test.protect-payload-misaligned-linux]
+firmware = "linux"
+config = "spike-protect-payload"
+description = "Test the protect payload policy emulation of misaligned loads (on Spike)."
+
 [test.keystone]
 firmware = "opensbi-jump"
 payload = "test_keystone_payload"


### PR DESCRIPTION
…ores

We don't have any tests that checks the behavior of the protect payload policy with misaligned loads and stores and this is an important one. This commit introduces it.