### PR TITLE
Bugfix: Apply sfence.vma(none, none) when the range to flush is big

### DIFF
--- a/src/policy/offload.rs
+++ b/src/policy/offload.rs
@@ -129,8 +129,7 @@ impl PolicyModule for OffloadPolicy {
         {
             let start = FENCE_VMA_START[mctx.hw.hart].load(Ordering::SeqCst);
             let size = FENCE_VMA_SIZE[mctx.hw.hart].load(Ordering::SeqCst);
-
-            if start == 0 && size == usize::MAX {
+            if (start == 0 && size == 0) || size >= 0xf0000 {
                 unsafe { Arch::sfencevma(None, None) };
             } else {
                 for address in (start..start + size).step_by(PAGE_SIZE) {


### PR DESCRIPTION
Sometimes we receive request for remote TLB with a big range. This destroys the performance as we need to iterate over a big for loop. This commit directly runs a global TLB flush when the range is big.