### PR TITLE
Bugfix: correct NB_VIRT_DEVICES on VisionFive 2

### DIFF
--- a/src/platform/miralis.rs
+++ b/src/platform/miralis.rs
@@ -52,7 +52,7 @@ pub struct MiralisPlatform {}
 
 impl Platform for MiralisPlatform {
     const NB_HARTS: usize = usize::MAX;
-    const NB_VIRT_DEVICES: usize = 2;
+    const NB_VIRT_DEVICES: usize = VIRT_DEVICES.len();
 
     fn name() -> &'static str {
         "Miralis"

--- a/src/platform/virt.rs
+++ b/src/platform/virt.rs
@@ -86,7 +86,7 @@ pub struct VirtPlatform {}
 
 impl Platform for VirtPlatform {
     const NB_HARTS: usize = usize::MAX;
-    const NB_VIRT_DEVICES: usize = 2;
+    const NB_VIRT_DEVICES: usize = VIRT_DEVICES.len();
 
     fn name() -> &'static str {
         match PLATFORM_NAME {

--- a/src/platform/visionfive2.rs
+++ b/src/platform/visionfive2.rs
@@ -49,7 +49,7 @@ pub struct VisionFive2Platform {}
 
 impl Platform for VisionFive2Platform {
     const NB_HARTS: usize = 5;
-    const NB_VIRT_DEVICES: usize = 2;
+    const NB_VIRT_DEVICES: usize = VIRT_DEVICES.len();
 
     fn name() -> &'static str {
         "VisionFive 2 board"


### PR DESCRIPTION
We removed the test device for the VisionFive 2 platform, but did not update properly the NB_VIRT_DEVICES constant on the Platform trait. Furtunately the issue was caught by an assertion.
This commit fixes the issue by setting NB_VIRT_DEVICES to be the len of the VIRT_DEVICES constant, which is possible since slice::len is a const fn.