### PR TITLE
Improve logging on illegal instruction assertion violation

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -132,7 +132,8 @@ impl MiralisContext {
         assert_eq!(
             raw_instr & 0b1111111,
             ILLEGAL_OPCODE_MASK,
-            "Precondition violated, this is not an illegal instruction"
+            "Precondition violated, this is not an illegal instruction: 0x{:x}",
+            raw_instr
         );
 
         match raw_instr {


### PR DESCRIPTION
The assertion got triggered on the CI, although I could not reproduce it locally. Therefore this commit logs the faulting instruction to diagnostic the issue the next time the assertion triggers.