### PR TITLE
Move MPRV PMP entry after Miralis memory protection

### DIFF
--- a/src/policy/keystone.rs
+++ b/src/policy/keystone.rs
@@ -6,7 +6,7 @@
 use core::cmp::PartialEq;
 use core::ptr;
 
-use crate::arch::pmp::pmplayout::POLICY_OFFSET;
+use crate::arch::pmp::pmplayout::MODULE_OFFSET;
 use crate::arch::pmp::{pmpcfg, Segment};
 use crate::arch::{
     parse_mpp_return_mode, set_mpp, write_pmp, Arch, Architecture, Csr, MCause, Mode, Register,
@@ -198,7 +198,7 @@ impl KeystonePolicy {
 
     /// Configure PMPs so that the enclave cannot be accessed
     fn lock_enclave(mctx: &mut MiralisContext, enclave: &mut Enclave) {
-        let pmp_id = POLICY_OFFSET + enclave.eid * 2;
+        let pmp_id = MODULE_OFFSET + enclave.eid * 2;
         mctx.pmp.set_inactive(pmp_id, enclave.epm.start());
         mctx.pmp.set_tor(
             pmp_id + 1,
@@ -213,7 +213,7 @@ impl KeystonePolicy {
 
     /// Configure PMPs so that only the enclave and the untrusted memory can be accessed
     fn unlock_enclave(mctx: &mut MiralisContext, enclave: &mut Enclave) {
-        let pmp_id = POLICY_OFFSET + enclave.eid * 2;
+        let pmp_id = MODULE_OFFSET + enclave.eid * 2;
 
         // Grant access to the enclave physical memory
         mctx.pmp.set_inactive(pmp_id, enclave.epm.start());
@@ -373,7 +373,7 @@ impl KeystonePolicy {
         self.enclaves[eid].state = EnclaveState::Invalid;
 
         // Clear enclave PMPs
-        let pmp_id = POLICY_OFFSET + eid * 2;
+        let pmp_id = MODULE_OFFSET + eid * 2;
         mctx.pmp.set_inactive(pmp_id, 0);
         mctx.pmp.set_inactive(pmp_id + 1, 0);
         unsafe {

--- a/src/policy/protect_payload.rs
+++ b/src/policy/protect_payload.rs
@@ -7,7 +7,7 @@ use miralis_core::sbi_codes::SBI_ERR_DENIED;
 use tiny_keccak::{Hasher, Sha3};
 
 use crate::arch::pmp::pmpcfg;
-use crate::arch::pmp::pmplayout::POLICY_OFFSET;
+use crate::arch::pmp::pmplayout::MODULE_OFFSET;
 use crate::arch::{get_raw_faulting_instr, mie, mstatus, MCause, Register};
 use crate::config::{ALL_HARTS_MASK, TARGET_PAYLOAD_ADDRESS};
 use crate::host::MiralisContext;
@@ -120,9 +120,9 @@ impl Module for ProtectPayloadPolicy {
         self.clear_supervisor_csr(ctx);
 
         // Lock memory
-        mctx.pmp.set_inactive(POLICY_OFFSET, TARGET_PAYLOAD_ADDRESS);
+        mctx.pmp.set_inactive(MODULE_OFFSET, TARGET_PAYLOAD_ADDRESS);
         mctx.pmp
-            .set_tor(POLICY_OFFSET + 1, usize::MAX, pmpcfg::NO_PERMISSIONS);
+            .set_tor(MODULE_OFFSET + 1, usize::MAX, pmpcfg::NO_PERMISSIONS);
     }
 
     fn switch_from_firmware_to_payload(
@@ -139,8 +139,8 @@ impl Module for ProtectPayloadPolicy {
         }
 
         // Unlock memory
-        mctx.pmp.set_inactive(POLICY_OFFSET, TARGET_PAYLOAD_ADDRESS);
-        mctx.pmp.set_tor(POLICY_OFFSET + 1, usize::MAX, pmpcfg::RWX);
+        mctx.pmp.set_inactive(MODULE_OFFSET, TARGET_PAYLOAD_ADDRESS);
+        mctx.pmp.set_tor(MODULE_OFFSET + 1, usize::MAX, pmpcfg::RWX);
 
         // We restore the supervisor csr registers
         self.restore_supervisor_csr(ctx);
@@ -173,9 +173,9 @@ impl Module for ProtectPayloadPolicy {
     // In this policy module, if we receive an interrupt from Miralis, it implies we need to lock the memory
     fn on_interrupt(&mut self, _ctx: &mut VirtContext, mctx: &mut MiralisContext) {
         // Lock memory
-        mctx.pmp.set_inactive(POLICY_OFFSET, TARGET_PAYLOAD_ADDRESS);
+        mctx.pmp.set_inactive(MODULE_OFFSET, TARGET_PAYLOAD_ADDRESS);
         mctx.pmp
-            .set_tor(POLICY_OFFSET + 1, usize::MAX, pmpcfg::NO_PERMISSIONS);
+            .set_tor(MODULE_OFFSET + 1, usize::MAX, pmpcfg::NO_PERMISSIONS);
     }
 }
 


### PR DESCRIPTION
The PMP entry used to emulate MPRV in software had a higher priority than the entries used to protect Miralis' own memory. This could allow the firmware to execute Miralis' code as the MPRV entry gets higher precedence and enables code execution.

The solution is simple: to move the MPRV entry to a lower priority. Note that the MPRV entry must have a higher priority than virtual PMP entries still.

Fixes #447