### PR TITLE
Build Miralis in release mode on the Premier P550

### DIFF
--- a/config/premierp550.toml
+++ b/config/premierp550.toml
@@ -18,6 +18,7 @@ boot_hart_id = 1
 [target.miralis]
 start_address = 0x80080000
 stack_size = 0x8000
+profile = "release"
 
 [target.firmware]
 start_address = 0x80000000


### PR DESCRIPTION
At the difference of the VisionFive 2, we only have one config file for the Premier P550, so it makes sense to change it for building a release image.

Another option would be to create a separate release configuration, but I would like to avoid config file proliferation. We already have a bit too many configuration files for my taste, so let's not create more for now and let's see if we can clean that up in the future.