### PR TITLE
Only display boot info on the boot hart

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,18 +39,19 @@ pub(crate) extern "C" fn main(_hart_id: usize, device_tree_blob_addr: usize) -> 
     let hart_id = Arch::read_csr(Csr::Mhartid);
 
     init();
-    log::info!("Hello, world!");
-    log::info!("Platform name: {}", Plat::name());
-    log::info!("Hart ID: {}", hart_id);
-    log::debug!("misa:    0x{:x}", Arch::read_csr(Csr::Misa));
-    log::debug!(
-        "vmisa:   0x{:x}",
-        Arch::read_csr(Csr::Misa) & !misa::DISABLED
-    );
-    log::debug!("mstatus: 0x{:x}", Arch::read_csr(Csr::Mstatus));
-    log::debug!("DTS address: 0x{:x}", device_tree_blob_addr);
 
-    log::info!("Preparing jump into firmware");
+    if hart_id == PLATFORM_BOOT_HART_ID {
+        log::info!("Hello, world!");
+        log::info!("Platform name: {}", Plat::name());
+        log::debug!("misa:    0x{:x}", Arch::read_csr(Csr::Misa));
+        log::debug!(
+            "vmisa:   0x{:x}",
+            Arch::read_csr(Csr::Misa) & !misa::DISABLED
+        );
+        log::debug!("mstatus: 0x{:x}", Arch::read_csr(Csr::Mstatus));
+        log::debug!("DTS address: 0x{:x}", device_tree_blob_addr);
+    }
+    log::info!("Hart {} is up", hart_id);
 
     let firmware_addr = Plat::load_firmware();
     log::debug!("Firmware loaded at: {:x}", firmware_addr);

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -5,6 +5,8 @@
 
 use module_macro::{build_modules, for_each_module};
 
+use crate::arch::{Arch, Architecture, Csr};
+use crate::config::PLATFORM_BOOT_HART_ID;
 use crate::host::MiralisContext;
 use crate::virt::{ExecutionMode, VirtContext};
 
@@ -197,7 +199,13 @@ impl Module for MainModule {
                 $($module: Module::init()),*
             }
         );
-        module.log_all_modules();
+
+        // We log the lists of modules on the boot hart only to avoid cluttering the screen too
+        // much. Models are the same on all cores.
+        if Arch::read_csr(Csr::Mhartid) == PLATFORM_BOOT_HART_ID {
+            module.log_all_modules();
+        }
+
         module
     }
 


### PR DESCRIPTION
Previously we were displaying the boot info on all harts, which was just generating lots of redundant logs on our hardware platforms (with 4 and 5 harts). This commit reduces the clutter by not logging redundant information.

We don't synchronize harts yet (except for .bss initialization). We should probably add a barrier to let the boot hart perform potential one-time initialization first. That would require testing on the VisionFive 2, however, as we had some interesting bugs with hart ID numbering there.

Commit n°500, yeay! 🎉 