### PR TITLE
Refactor: Use TARGET_PAYLOAD_ADDRESS from miralis_config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ name = "test_protect_payload_firmware"
 version = "0.1.0"
 dependencies = [
  "miralis_abi",
+ "miralis_config",
 ]
 
 [[package]]

--- a/firmware/test_protect_payload_firmware/Cargo.toml
+++ b/firmware/test_protect_payload_firmware/Cargo.toml
@@ -11,3 +11,4 @@ path = "main.rs"
 
 [dependencies]
 miralis_abi = { path = "../../crates/abi" }
+miralis_config = { path = "../../crates/config" }

--- a/firmware/test_protect_payload_firmware/main.rs
+++ b/firmware/test_protect_payload_firmware/main.rs
@@ -9,13 +9,14 @@
 use core::arch::{asm, global_asm};
 
 use miralis_abi::{failure, setup_binary};
+use miralis_config::TARGET_PAYLOAD_ADDRESS;
 
 setup_binary!(main);
 
 fn main() -> ! {
     install_trap_handler();
 
-    let os: usize = 0x80400000;
+    let os: usize = TARGET_PAYLOAD_ADDRESS;
     let mpp = 0b1 << 11; // MPP = S-mode
 
     unsafe {


### PR DESCRIPTION
Replaced the hardcoded payload start address (0x80400000) in `firmware/test_protect_payload_firmware/main.rs` with the `TARGET_PAYLOAD_ADDRESS` constant from the `miralis_config` crate.

This change makes the codebase more maintainable and less prone to errors if the payload address changes in the future.

Note: this is the first AI contribution to Miralis 🎉 