### PR TITLE
Bugfix: Test device covers memory used by payload

### DIFF
--- a/firmware/device/main.rs
+++ b/firmware/device/main.rs
@@ -5,8 +5,9 @@ use miralis_abi::{setup_binary, success};
 
 setup_binary!(main);
 
-const TEST_DEVICE_MAGIC_REGISTER: usize = 0x3000000;
-const TEST_DEVICE_REMOTE_REGISTER: usize = 0x3000004;
+const TEST_DEVICE_BASE: usize = 0x2020000;
+const TEST_DEVICE_MAGIC_REGISTER: usize = TEST_DEVICE_BASE;
+const TEST_DEVICE_REMOTE_REGISTER: usize = TEST_DEVICE_BASE + 0x4;
 
 fn main() -> ! {
     log::info!("Hello from driver tester firmware!");

--- a/src/platform/virt.rs
+++ b/src/platform/virt.rs
@@ -20,7 +20,7 @@ const SERIAL_PORT_BASE_ADDRESS: usize = 0x10000000;
 const TEST_MMIO_ADDRESS: usize = 0x100000;
 const CLINT_BASE: usize = 0x2000000;
 const PLIC_BASE: usize = 0xC000000;
-const TEST_DEVICE_BASE: usize = 0x3000000;
+const TEST_DEVICE_BASE: usize = 0x2020000;
 
 // —————————————————————————— Spike Parameters ——————————————————————————— //
 


### PR DESCRIPTION
In 550ace64 we increased the size of the test device to account for the PMP granularity, from 0x8 to 0x10000. However with this change the test device now covers memory that happens to be used by some payload, notably U-Boot.

This commit re-locates the test device next to the CLINT, where it should not be accessed by firmware or payload.