### PR TITLE
Runner: do not panic when file removal fails

### DIFF
--- a/runner/src/artifacts.rs
+++ b/runner/src/artifacts.rs
@@ -556,7 +556,7 @@ pub fn download_disk_image(name: &str, url_path: &str) {
             format!("artifacts/{}-miralis.img", name),
         )
         .unwrap();
-        fs::remove_file(file_name).unwrap();
+        fs::remove_file(file_name).ok();
 
         log::info!("Disk image ready to use");
     } else {


### PR DESCRIPTION
When downloading a non-compressed disk artifact the runner panic when trying to remove the compressed version (because there is no compressed filed!).
This commit let the file removal fail silently, which makes running Keystone succeed on the first time.