### PR TITLE
Update Keystone drive and add rv8 support on QEMU

### DIFF
--- a/config/qemu-keystone.toml
+++ b/config/qemu-keystone.toml
@@ -6,6 +6,7 @@ color = true
 
 [vcpu]
 max_pmp = 0
+delegate_perf_counters = true
 
 [qemu]
 memory = "8G"
@@ -26,4 +27,4 @@ start_address = 0x80200000
 stack_size = 0x8000
 
 [modules]
-modules = ["keystone"]
+modules = ["keystone", "exit_counter"]

--- a/misc/artifacts.toml
+++ b/misc/artifacts.toml
@@ -57,8 +57,8 @@ repo = "https://github.com/FredKhayat/miralis-artifact-keystone"
 
 [disk.keystone]
 description = "A .ext2 filesystem image that contains the Keystone driver and some example keystone enclaves"
-url = "https://github.com/FredKhayat/miralis-artifact-keystone/releases/download/v1.4.0/keystone.ext2"
-repo = "https://github.com/FredKhayat/miralis-artifact-keystone"
+url = "https://github.com/epfl-dcsl/miralis-artifact-keystone/releases/download/v1.4.11/keystone.ext2"
+repo = "https://github.com/epfl-dcsl/miralis-artifact-keystone"
 
 [disk.ubuntu]
 description = "A RISC-V Ubuntu image that can be used with Miralis"

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ pub(crate) extern "C" fn main(_hart_id: usize, device_tree_blob_addr: usize) -> 
         ctx.pc = firmware_addr;
 
         if DELEGATE_PERF_COUNTER {
+            log::info!("Delegating performance counters");
             Arch::write_csr(Csr::Mcounteren, DELGATE_PERF_COUNTERS_MASK);
             Arch::write_csr(Csr::Scounteren, DELGATE_PERF_COUNTERS_MASK);
         }

--- a/src/policy/keystone.rs
+++ b/src/policy/keystone.rs
@@ -6,6 +6,9 @@
 use core::cmp::PartialEq;
 use core::ptr;
 
+use miralis_config::DELEGATE_PERF_COUNTER;
+
+use crate::arch::perf_counters::DELGATE_PERF_COUNTERS_MASK;
 use crate::arch::pmp::pmplayout::MODULE_OFFSET;
 use crate::arch::pmp::{pmpcfg, Segment};
 use crate::arch::{
@@ -340,6 +343,9 @@ impl KeystonePolicy {
         enclave.ctx.satp = 0; // Enclave uses physical addresses in the first run
         enclave.ctx.mideleg = 0; // No interrupts are delegated in the first run
         enclave.ctx.mpp = Mode::S; // Enclave starts in S-mode
+        if DELEGATE_PERF_COUNTER {
+            enclave.ctx.scounteren = DELGATE_PERF_COUNTERS_MASK;
+        }
 
         Self::lock_enclave(mctx, enclave);
 


### PR DESCRIPTION
This commit switches to a more recent Keystone image, which includes the rv8 benchmark. Some of the benchmarks rely on the performance counters, therefore the commit additionally enables performance counters when initializing the enclave if the option is selected in the configuration.