### PR TITLE
Add exit counters to protect payload policy 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ config.toml
 artifacts
 /.vscode
 /.idea
+.DS_Store

--- a/config/visionfive2-release-protect-payload.toml
+++ b/config/visionfive2-release-protect-payload.toml
@@ -24,4 +24,4 @@ start_address = 0x40000000
 profile = "release"
 
 [modules]
-modules = ["protect_payload", "exit_counter"]
+modules = ["exit_counter", "offload", "protect_payload"]

--- a/src/benchmark/boot.rs
+++ b/src/benchmark/boot.rs
@@ -94,6 +94,7 @@ impl BootBenchmark {
             && ctx.get(Register::X16) == abi::MIRALIS_READ_COUNTERS_FID
         {
             self.display_benchmark(ctx.hart_id);
+            ctx.pc += 4;
             ModuleAction::Overwrite
         } else {
             ModuleAction::Ignore

--- a/src/benchmark/counter_per_mcause.rs
+++ b/src/benchmark/counter_per_mcause.rs
@@ -128,6 +128,7 @@ impl CounterPerMcauseBenchmark {
             && ctx.get(Register::X16) == abi::MIRALIS_READ_COUNTERS_FID
         {
             self.read_counters(ctx);
+            ctx.pc += 4;
             ModuleAction::Overwrite
         } else {
             ModuleAction::Ignore

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -18,6 +18,8 @@ use crate::virt::traits::RegisterContextGetter;
 use crate::virt::{ExecutionMode, VirtContext};
 
 const NUMBER_CATEGORIES: usize = 8;
+
+#[derive(Clone, Copy, Debug)]
 pub enum ExceptionCategory {
     NotOffloaded = 0,
     ReadTime = 1,


### PR DESCRIPTION
It turns out that the module refactoring removed the PC + 4 and thus
creates an infinite loop. The fix is simple, just re-introduce the PC +
4 in the benchmark policies.
This is the configuration we used for the benchmarks of the SOSP paper.