### PR TITLE
Bugfix: tracing trap handler loses 1 bit in register

### DIFF
--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -1345,12 +1345,13 @@ global_asm!(
 .align 4
 .global _tracing_trap_handler
 _tracing_trap_handler:
+    // Save x5
+    csrw mscratch, x5
     // Skip illegal instruction (pc += 4)
-    csrrw x5, mepc, x5
+    csrr x5, mepc
     addi x5, x5, 4
-    csrrw x5, mepc, x5
+    csrw mepc, x5
     // Set mscratch to 1
-    csrrw x5, mscratch, x5
     addi x5, x0, 1
     csrrw x5, mscratch, x5
     // Return back to miralis


### PR DESCRIPTION
The `tracing_trap_handler` used to temporary store a register (x5) into mepc, while incrementing mepc to skip the trapping instruction. It turns out mepc has its bit 0 (and bit 1 if the C extension is not supported) hardwired to 0, so we were losing bit 0 of x5.
The new implementation stores x5 directly in mscratch to prevent losing any bits.

This bug was found using a new tool to convert assembly to Rust code, building on softcore-rs, so I think this is a good indication that this new tool is useful, and I hope to integrate it more deeply into Miralis in the future :)