### PR TITLE
Bugfix: missing clobber register on mprv trap

### DIFF
--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -57,6 +57,7 @@ macro_rules! asm_mprv_mem_op {
             "csrw mtvec, {1}",
             out(reg) _,
             out(reg) _,
+            out("t5") _, // t5 can be modified by the trap handler
             mtvec = in(reg) (_mprv_trap_handler as usize),
             addr = in(reg) $addr,
             rd = inout(reg) $value,


### PR DESCRIPTION
When trapping during MPRV read or write emulation, the trap handler might modify the t5 register (for the same reason as the previous commit). To fix the issue, we mark the t5 register as being used by the assembly snippet.