### PR TITLE
Upgrade to Rust edition 2024

### DIFF
--- a/crates/abi/Cargo.toml
+++ b/crates/abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miralis_abi"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/crates/abi/src/lib.rs
+++ b/crates/abi/src/lib.rs
@@ -148,7 +148,7 @@ macro_rules! setup_binary {
         }
 
         // Defined in the linker script
-        extern "C" {
+        unsafe extern "C" {
             pub(crate) static _stack_start: u8;
             pub(crate) static _bss_start: u8;
             pub(crate) static _bss_stop: u8;
@@ -201,23 +201,21 @@ pub unsafe fn ecall3(
     let error: usize;
     let value: usize;
 
-    core::arch::asm!(
-    "ecall",
-    inout("a0") a0 => error,
-    inout("a1") a1 => value,
-    in("a2") a2,
-    in("a6") fid,
-    in("a7") eid,
-    );
-
-    if error != 0 {
-        Err(error)
-    } else {
-        Ok(value)
+    unsafe {
+        core::arch::asm!(
+            "ecall",
+            inout("a0") a0 => error,
+            inout("a1") a1 => value,
+            in("a2") a2,
+            in("a6") fid,
+            in("a7") eid,
+        );
     }
+
+    if error != 0 { Err(error) } else { Ok(value) }
 }
 
 #[inline]
 unsafe fn miralis_ecall(fid: usize) -> Result<usize, usize> {
-    ecall3(abi::MIRALIS_EID, fid, 0, 0, 0)
+    unsafe { ecall3(abi::MIRALIS_EID, fid, 0, 0, 0) }
 }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miralis_config"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [lints]

--- a/crates/config_select/Cargo.toml
+++ b/crates/config_select/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "config_select"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [lib]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miralis_core"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/crates/module_macro/Cargo.toml
+++ b/crates/module_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "module_macro"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [lib]

--- a/crates/module_macro/src/lib.rs
+++ b/crates/module_macro/src/lib.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Group, Span, TokenStream, TokenTree};
-use quote::{quote, ToTokens};
+use quote::{ToTokens, quote};
 use syn::parse::{Parse, ParseStream, Result};
 use syn::{Ident, LitStr, Path, Token};
 

--- a/crates/test_helpers/Cargo.toml
+++ b/crates/test_helpers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_helpers"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/firmware/breakpoint/Cargo.toml
+++ b/firmware/breakpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "breakpoint"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/breakpoint/main.rs
+++ b/firmware/breakpoint/main.rs
@@ -22,7 +22,7 @@ fn main() -> ! {
 }
 
 /// This function should be called from the raw trap handler
-extern "C" fn trap_handler() {
+unsafe extern "C" fn trap_handler() {
     // Test here
 
     // mcause = breakpoint
@@ -63,7 +63,7 @@ _raw_breakpoint_trap_handler:
     trap_handler = sym trap_handler,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _raw_breakpoint_trap_handler();
 }
 

--- a/firmware/clint_interrupt/Cargo.toml
+++ b/firmware/clint_interrupt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clint_interrupt"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "clint_interrupt"

--- a/firmware/clint_interrupt/main.rs
+++ b/firmware/clint_interrupt/main.rs
@@ -37,10 +37,12 @@ fn main() -> ! {
 
 /// Enables interrupts by setting `mstatus.MIE` to 1.
 unsafe fn enable_interrupts() {
-    asm!(
-        "csrs mstatus, {mstatus_mie}",  // Enable global interrupts (MIE), expect to trap immediately
-        mstatus_mie = in(reg) 0x8,
-    )
+    unsafe {
+        asm!(
+            "csrs mstatus, {mstatus_mie}",  // Enable global interrupts (MIE), expect to trap immediately
+            mstatus_mie = in(reg) 0x8,
+        )
+    }
 }
 
 // ———————————————————————————— Timer Interrupt ————————————————————————————— //
@@ -121,6 +123,6 @@ _raw_interrupt_trap_handler:
     trap_handler = sym trap_handler,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _raw_interrupt_trap_handler();
 }

--- a/firmware/clint_interrupt_multihart/Cargo.toml
+++ b/firmware/clint_interrupt_multihart/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clint_interrupt_multihart"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "clint_interrupt_multihart"

--- a/firmware/clint_interrupt_multihart/main.rs
+++ b/firmware/clint_interrupt_multihart/main.rs
@@ -86,6 +86,6 @@ _raw_interrupt_trap_handler:
     trap_handler = sym trap_handler,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _raw_interrupt_trap_handler();
 }

--- a/firmware/clint_interrupt_priority/Cargo.toml
+++ b/firmware/clint_interrupt_priority/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clint_interrupt_priority"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "clint_interrupt_priority"

--- a/firmware/clint_interrupt_priority/main.rs
+++ b/firmware/clint_interrupt_priority/main.rs
@@ -116,6 +116,6 @@ _raw_interrupt_trap_handler:
     trap_handler = sym trap_handler,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _raw_interrupt_trap_handler();
 }

--- a/firmware/csr_ops/Cargo.toml
+++ b/firmware/csr_ops/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "csr_ops"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/csr_ops/main.rs
+++ b/firmware/csr_ops/main.rs
@@ -131,14 +131,16 @@ fn check_csrrw(in_rs1: usize, in_csr: usize, out_csr: usize, out_rd: usize) {
 unsafe fn csrrw(csr: usize, rd: usize, rs1: usize) -> (usize, usize) {
     let mut rd = rd;
     let mut csr = csr;
-    asm!(
-        "csrw mscratch, {2}",       // Initialize mscratch
-        "csrrw {0}, mscratch, {1}", // Perform the CSR operation
-        "csrr {2}, mscratch",       // Retrieve new mscratch value
-        inout(reg) rd,
-        in(reg) rs1,
-        inout(reg) csr,
-    );
+    unsafe {
+        asm!(
+            "csrw mscratch, {2}",       // Initialize mscratch
+            "csrrw {0}, mscratch, {1}", // Perform the CSR operation
+            "csrr {2}, mscratch",       // Retrieve new mscratch value
+            inout(reg) rd,
+            in(reg) rs1,
+            inout(reg) csr,
+        );
+    }
 
     (csr, rd)
 }
@@ -151,14 +153,16 @@ fn check_csrrs(in_rs1: usize, in_csr: usize, out_csr: usize, out_rd: usize) {
 unsafe fn csrrs(csr: usize, rd: usize, rs1: usize) -> (usize, usize) {
     let mut rd = rd;
     let mut csr = csr;
-    asm!(
-        "csrw mscratch, {2}",       // Initialize mscratch
-        "csrrs {0}, mscratch, {1}", // Perform the CSR operation
-        "csrr {2}, mscratch",       // Retrieve new mscratch value
-        inout(reg) rd,
-        in(reg) rs1,
-        inout(reg) csr,
-    );
+    unsafe {
+        asm!(
+            "csrw mscratch, {2}",       // Initialize mscratch
+            "csrrs {0}, mscratch, {1}", // Perform the CSR operation
+            "csrr {2}, mscratch",       // Retrieve new mscratch value
+            inout(reg) rd,
+            in(reg) rs1,
+            inout(reg) csr,
+        );
+    }
 
     (csr, rd)
 }
@@ -171,13 +175,15 @@ fn check_csrrwi(in_csr: usize, out_csr: usize, out_rd: usize) {
 unsafe fn csrrwi(csr: usize, rd: usize) -> (usize, usize) {
     let mut rd = rd;
     let mut csr = csr;
-    asm!(
-        "csrw mscratch, {1}",       // Initialize mscratch
-        "csrrwi {0}, mscratch, 27", // Perform the CSR operation
-        "csrr {1}, mscratch",       // Retrieve new mscratch value
-        inout(reg) rd,
-        inout(reg) csr,
-    );
+    unsafe {
+        asm!(
+            "csrw mscratch, {1}",       // Initialize mscratch
+            "csrrwi {0}, mscratch, 27", // Perform the CSR operation
+            "csrr {1}, mscratch",       // Retrieve new mscratch value
+            inout(reg) rd,
+            inout(reg) csr,
+        );
+    }
 
     (csr, rd)
 }
@@ -190,13 +196,15 @@ fn check_csrrsi(in_csr: usize, out_csr: usize, out_rd: usize) {
 unsafe fn csrrsi(csr: usize, rd: usize) -> (usize, usize) {
     let mut rd = rd;
     let mut csr = csr;
-    asm!(
-        "csrw mscratch, {1}",       // Initialize mscratch
-        "csrrsi {0}, mscratch, 27", // Perform the CSR operation
-        "csrr {1}, mscratch",       // Retrieve new mscratch value
-        inout(reg) rd,
-        inout(reg) csr,
-    );
+    unsafe {
+        asm!(
+            "csrw mscratch, {1}",       // Initialize mscratch
+            "csrrsi {0}, mscratch, 27", // Perform the CSR operation
+            "csrr {1}, mscratch",       // Retrieve new mscratch value
+            inout(reg) rd,
+            inout(reg) csr,
+        );
+    }
 
     (csr, rd)
 }
@@ -209,14 +217,16 @@ fn check_csrrc(in_rs1: usize, in_csr: usize, out_csr: usize, out_rd: usize) {
 unsafe fn csrrc(csr: usize, rd: usize, rs1: usize) -> (usize, usize) {
     let mut rd = rd;
     let mut csr = csr;
-    asm!(
-        "csrw mscratch, {2}",       // Initialize mscratch
-        "csrrc {0}, mscratch, {1}", // Perform the CSR operation
-        "csrr {2}, mscratch",       // Retrieve new mscratch value
-        inout(reg) rd,
-        in(reg) rs1,
-        inout(reg) csr,
-    );
+    unsafe {
+        asm!(
+            "csrw mscratch, {2}",       // Initialize mscratch
+            "csrrc {0}, mscratch, {1}", // Perform the CSR operation
+            "csrr {2}, mscratch",       // Retrieve new mscratch value
+            inout(reg) rd,
+            in(reg) rs1,
+            inout(reg) csr,
+        );
+    }
 
     (csr, rd)
 }
@@ -229,13 +239,15 @@ fn check_csrrci(in_csr: usize, out_csr: usize, out_rd: usize) {
 unsafe fn csrrci(csr: usize, rd: usize) -> (usize, usize) {
     let mut rd = rd;
     let mut csr = csr;
-    asm!(
-        "csrw mscratch, {1}",       // Initialize mscratch
-        "csrrci {0}, mscratch, 27", // Perform the CSR operation
-        "csrr {1}, mscratch",       // Retrieve new mscratch value
-        inout(reg) rd,
-        inout(reg) csr,
-    );
+    unsafe {
+        asm!(
+            "csrw mscratch, {1}",       // Initialize mscratch
+            "csrrci {0}, mscratch, 27", // Perform the CSR operation
+            "csrr {1}, mscratch",       // Retrieve new mscratch value
+            inout(reg) rd,
+            inout(reg) csr,
+        );
+    }
 
     (csr, rd)
 }

--- a/firmware/default/Cargo.toml
+++ b/firmware/default/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "default"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/device/Cargo.toml
+++ b/firmware/device/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "device"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/ecall/Cargo.toml
+++ b/firmware/ecall/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ecall"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/hypervisor/Cargo.toml
+++ b/firmware/hypervisor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hypervisor"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/interrupt/Cargo.toml
+++ b/firmware/interrupt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "interrupt"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/interrupt/main.rs
+++ b/firmware/interrupt/main.rs
@@ -152,6 +152,6 @@ _raw_interrupt_trap_handler:
     trap_handler = sym trap_handler,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _raw_interrupt_trap_handler();
 }

--- a/firmware/misaligned_op/Cargo.toml
+++ b/firmware/misaligned_op/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "misaligned_op"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/mret/Cargo.toml
+++ b/firmware/mret/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mret"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/mret/main.rs
+++ b/firmware/mret/main.rs
@@ -54,6 +54,6 @@ _raw_breakpoint_trap_handler:
 "#,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _raw_breakpoint_trap_handler();
 }

--- a/firmware/os_ctx_switch/Cargo.toml
+++ b/firmware/os_ctx_switch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "os_ctx_switch"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/os_ctx_switch/main.rs
+++ b/firmware/os_ctx_switch/main.rs
@@ -96,7 +96,7 @@ _raw_os:
 "#,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _raw_trap_handler();
     fn _raw_os();
 }

--- a/firmware/os_ecall/Cargo.toml
+++ b/firmware/os_ecall/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "os_ecall"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/os_ecall/main.rs
+++ b/firmware/os_ecall/main.rs
@@ -64,7 +64,7 @@ _raw_os:
 "#,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _raw_trap_handler();
     fn _raw_os();
 }

--- a/firmware/pmp/Cargo.toml
+++ b/firmware/pmp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pmp"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/sandbox/Cargo.toml
+++ b/firmware/sandbox/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sandbox"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/sandbox/main.rs
+++ b/firmware/sandbox/main.rs
@@ -75,6 +75,6 @@ _raw_trap_handler:
 "#,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _raw_trap_handler();
 }

--- a/firmware/test_protect_payload_firmware/Cargo.toml
+++ b/firmware/test_protect_payload_firmware/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_protect_payload_firmware"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/test_protect_payload_firmware/main.rs
+++ b/firmware/test_protect_payload_firmware/main.rs
@@ -87,6 +87,6 @@ done:
 "
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _raw_trap_handler();
 }

--- a/firmware/tracing_firmware/Cargo.toml
+++ b/firmware/tracing_firmware/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tracing_firmware"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/tracing_firmware/main.rs
+++ b/firmware/tracing_firmware/main.rs
@@ -103,7 +103,7 @@ _empty_handler:
 "#,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _empty_handler();
 }
 

--- a/firmware/vectored_mtvec/Cargo.toml
+++ b/firmware/vectored_mtvec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vectored_mtvec"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/firmware/vectored_mtvec/main.rs
+++ b/firmware/vectored_mtvec/main.rs
@@ -84,6 +84,6 @@ _raw_interrupt_trap_handler:
     success_trap_handler = sym success_trap_handler,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _raw_interrupt_trap_handler();
 }

--- a/model_checking/Cargo.toml
+++ b/model_checking/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "model_checking"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 rand = ["dep:rand"]

--- a/model_checking/src/adapters.rs
+++ b/model_checking/src/adapters.rs
@@ -10,8 +10,8 @@ use miralis::decoder::{IllegalInst, LoadInstr, StoreInstr};
 use miralis::host::MiralisContext;
 use miralis::virt::VirtContext;
 use softcore_rv64::config::U74;
-use softcore_rv64::prelude::{bv, BitVector};
-use softcore_rv64::raw::{ast, csrop, word_width, Core, Pmpcfg_ent, Privilege};
+use softcore_rv64::prelude::{BitVector, bv};
+use softcore_rv64::raw::{Core, Pmpcfg_ent, Privilege, ast, csrop, word_width};
 use softcore_rv64::{new_core, raw, registers as reg};
 
 pub fn miralis_to_rv_core(ctx: &VirtContext) -> Core {

--- a/model_checking/src/lib.rs
+++ b/model_checking/src/lib.rs
@@ -1,14 +1,14 @@
 use miralis::arch::pmp::pmplayout;
 use miralis::arch::userspace::SOFT_CORE;
-use miralis::arch::{csr, mie, mstatus, write_pmp, MCause, Register};
+use miralis::arch::{MCause, Register, csr, mie, mstatus, write_pmp};
 use miralis::decoder::IllegalInst;
 use miralis::host::MiralisContext;
 use miralis::platform::{Plat, Platform};
-use miralis::virt::traits::{HwRegisterContextSetter, RegisterContextGetter};
 use miralis::virt::VirtContext;
-use softcore_rv64::prelude::{bv, BitVector};
+use miralis::virt::traits::{HwRegisterContextSetter, RegisterContextGetter};
+use softcore_rv64::prelude::{BitVector, bv};
 use softcore_rv64::raw;
-use softcore_rv64::raw::{regidx, AccessType, Minterrupts, Pmpcfg_ent, Privilege};
+use softcore_rv64::raw::{AccessType, Minterrupts, Pmpcfg_ent, Privilege, regidx};
 
 use crate::adapters::{
     ast_to_miralis_instr, ast_to_miralis_load, ast_to_miralis_store, miralis_to_rv_core,

--- a/model_checking/src/symbolic.rs
+++ b/model_checking/src/symbolic.rs
@@ -4,7 +4,7 @@
 //! context. We make sure that this module can compile and be tested even without Kani installed,
 //! in which case concrete values are used in place of symbolic ones.
 
-use miralis::arch::{menvcfg, mie, misa, mstatus, Arch, Architecture, ExtensionsCapability, Mode};
+use miralis::arch::{Arch, Architecture, ExtensionsCapability, Mode, menvcfg, mie, misa, mstatus};
 use miralis::host::MiralisContext;
 use miralis::platform::{Plat, Platform};
 use miralis::virt::VirtContext;

--- a/payload/hello_world/Cargo.toml
+++ b/payload/hello_world/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hello_world"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/payload/test_keystone_payload/Cargo.toml
+++ b/payload/test_keystone_payload/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_keystone_payload"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/payload/test_keystone_payload/main.rs
+++ b/payload/test_keystone_payload/main.rs
@@ -105,11 +105,13 @@ unsafe fn trap_handler() {
     log::info!("The enclave memory is protected.");
 
     // Destroy the enclave
-    ecall3(MIRALIS_KEYSTONE_EID, DESTROY_ENCLAVE_FID, EID, 0, 0)
-        .expect("Failed to destroy enclave");
+    unsafe {
+        ecall3(MIRALIS_KEYSTONE_EID, DESTROY_ENCLAVE_FID, EID, 0, 0)
+            .expect("Failed to destroy enclave")
+    };
     log::info!("Enclave destroyed successfully");
 
-    let y = *(_enclave as *const usize);
+    let y = unsafe { *(_enclave as *const usize) };
     log::info!("The enclave is no longer protected: {:x}.", y);
     success()
 }
@@ -146,6 +148,6 @@ _enclave:
 "#,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _enclave();
 }

--- a/payload/test_protect_payload_payload/Cargo.toml
+++ b/payload/test_protect_payload_payload/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_protect_payload_payload"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "runner"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 

--- a/runner/src/artifacts.rs
+++ b/runner/src/artifacts.rs
@@ -11,14 +11,14 @@ use std::{env, fs};
 
 use serde::Deserialize;
 
+use crate::ArtifactArgs;
 use crate::config::{Config, Profiles};
 use crate::path::{
+    EXT2_EXTENSION, GZ_COMPRESSION, IMG_EXTENSION, XZ_COMPRESSION, ZST_COMPRESSION,
     extract_file_extension, extract_file_name, get_artifact_manifest_path, get_artifacts_path,
     get_target_config_path, get_target_dir_path, get_workspace_path, is_file_present, is_older,
-    remove_file_extention, EXT2_EXTENSION, GZ_COMPRESSION, IMG_EXTENSION, XZ_COMPRESSION,
-    ZST_COMPRESSION,
+    remove_file_extention,
 };
-use crate::ArtifactArgs;
 
 // —————————————————————————— Target & Build Info ——————————————————————————— //
 
@@ -322,7 +322,9 @@ pub fn build_target(target: Target, cfg: &Config) -> PathBuf {
         Target::Miralis => {
             // Linker arguments
             let start_address = cfg.target.miralis.start_address.unwrap_or(0x80000000);
-            let linker_args = format!("-C link-arg=-Tmisc/linker-script.x -C link-arg=--defsym=_start_address={start_address}");
+            let linker_args = format!(
+                "-C link-arg=-Tmisc/linker-script.x -C link-arg=--defsym=_start_address={start_address}"
+            );
             build_cmd.arg("--package").arg("miralis");
             build_cmd.env("RUSTFLAGS", linker_args);
 
@@ -332,7 +334,9 @@ pub fn build_target(target: Target, cfg: &Config) -> PathBuf {
 
         Target::Firmware(ref firmware) => {
             let firmware_address = cfg.target.firmware.start_address.unwrap_or(0x80200000);
-            let linker_args = format!("-C link-arg=-Tmisc/linker-script.x -C link-arg=--defsym=_start_address={firmware_address}");
+            let linker_args = format!(
+                "-C link-arg=-Tmisc/linker-script.x -C link-arg=--defsym=_start_address={firmware_address}"
+            );
             build_cmd.env("RUSTFLAGS", linker_args);
             build_cmd.env("IS_TARGET_FIRMWARE", "true");
             build_cmd.envs(cfg.build_envs());
@@ -350,7 +354,9 @@ pub fn build_target(target: Target, cfg: &Config) -> PathBuf {
                 .as_ref()
                 .and_then(|payload| payload.start_address)
                 .unwrap_or(0x80400000);
-            let linker_args = format!("-C link-arg=-Tmisc/linker-script.x -C link-arg=--defsym=_start_address={payload_address}");
+            let linker_args = format!(
+                "-C link-arg=-Tmisc/linker-script.x -C link-arg=--defsym=_start_address={payload_address}"
+            );
             build_cmd.env("RUSTFLAGS", linker_args);
             build_cmd.env("IS_TARGET_FIRMWARE", "false");
             build_cmd.envs(cfg.build_envs());

--- a/runner/src/build.rs
+++ b/runner/src/build.rs
@@ -2,9 +2,9 @@
 
 use std::process::ExitCode;
 
-use crate::artifacts::{build_target, prepare_firmware_artifact, Target};
-use crate::config::read_config;
 use crate::BuildArgs;
+use crate::artifacts::{Target, build_target, prepare_firmware_artifact};
+use crate::config::read_config;
 
 pub fn build(args: &BuildArgs) -> ExitCode {
     let cfg = read_config(&args.config);

--- a/runner/src/config.rs
+++ b/runner/src/config.rs
@@ -12,8 +12,8 @@ use miralis_config as config;
 use serde::Deserialize;
 use walkdir::WalkDir;
 
-use crate::path::get_workspace_path;
 use crate::CheckConfigArgs;
+use crate::path::get_workspace_path;
 
 // ——————————————————————————— Config Definition ———————————————————————————— //
 

--- a/runner/src/gdb.rs
+++ b/runner/src/gdb.rs
@@ -4,12 +4,12 @@
 
 use core::panic;
 use std::io;
-use std::process::{exit, Command, Stdio};
+use std::process::{Command, Stdio, exit};
 
-use crate::artifacts::Target;
-use crate::config::{read_config, Profiles};
-use crate::path::get_target_dir_path;
 use crate::GdbArgs;
+use crate::artifacts::Target;
+use crate::config::{Profiles, read_config};
+use crate::path::get_target_dir_path;
 
 // ——————————————————————————————— Constants ———————————————————————————————— //
 

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,7 +1,7 @@
 use core::panic;
 use std::env;
 use std::path::PathBuf;
-use std::process::{exit, Command, ExitCode};
+use std::process::{Command, ExitCode, exit};
 
 use clap::{Args, Parser, Subcommand};
 use log::LevelFilter;

--- a/runner/src/path.rs
+++ b/runner/src/path.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use crate::artifacts::{Target, FIRMWARE_TARGET, MIRALIS_TARGET, PAYLOAD_TARGET};
+use crate::artifacts::{FIRMWARE_TARGET, MIRALIS_TARGET, PAYLOAD_TARGET, Target};
 use crate::config::Profiles;
 
 pub const PROJECT_CONFIG_FILE: &str = "miralis.toml";
@@ -25,10 +25,10 @@ pub fn find_project_root() -> Option<PathBuf> {
         // Check if the config file is in this directory
         let mut root_config_file = dir.clone();
         root_config_file.push(PROJECT_CONFIG_FILE);
-        if let Ok(metadata) = root_config_file.metadata() {
-            if metadata.is_file() {
-                return Some(dir);
-            }
+        if let Ok(metadata) = root_config_file.metadata()
+            && metadata.is_file()
+        {
+            return Some(dir);
         }
 
         match dir.parent() {
@@ -156,10 +156,10 @@ pub fn extract_file_name(image_path: &str) -> &str {
 }
 
 pub fn remove_file_extention(path: &str) -> String {
-    if let Some(stem) = Path::new(path).file_stem() {
-        if let Some(parent) = Path::new(path).parent() {
-            return parent.join(stem).to_string_lossy().into_owned();
-        }
+    if let Some(stem) = Path::new(path).file_stem()
+        && let Some(parent) = Path::new(path).parent()
+    {
+        return parent.join(stem).to_string_lossy().into_owned();
     }
     path.to_string()
 }

--- a/runner/src/run.rs
+++ b/runner/src/run.rs
@@ -9,12 +9,12 @@ use std::path::PathBuf;
 use std::process::{Command, ExitCode};
 use std::str::FromStr;
 
-use crate::artifacts::{
-    build_target, download_disk_image, get_external_artifacts, prepare_firmware_artifact,
-    prepare_payload_artifact, DiskArtifact, Target,
-};
-use crate::config::{read_config, Config, Platforms};
 use crate::RunArgs;
+use crate::artifacts::{
+    DiskArtifact, Target, build_target, download_disk_image, get_external_artifacts,
+    prepare_firmware_artifact, prepare_payload_artifact,
+};
+use crate::config::{Config, Platforms, read_config};
 
 // ————————————————————————————— QEMU Arguments ————————————————————————————— //
 
@@ -181,25 +181,24 @@ pub fn get_qemu_cmd(
     }
 
     // If a disk is present add the appropriate device
-    if let Some(disk) = &cfg.qemu.disk {
-        if let Some(DiskArtifact::Downloaded { name, url }) =
+    if let Some(disk) = &cfg.qemu.disk
+        && let Some(DiskArtifact::Downloaded { name, url }) =
             get_external_artifacts().disk.get(disk)
-        {
-            download_disk_image(name, url);
+    {
+        download_disk_image(name, url);
 
-            qemu_cmd
-                .arg("-device")
-                .arg("virtio-net-device,netdev=eth0")
-                .arg("-netdev")
-                .arg("user,id=eth0")
-                .arg("-device")
-                .arg("virtio-rng-pci")
-                .arg("-drive")
-                .arg(format!(
-                    "file=artifacts/{}-miralis.img,format=raw,if=virtio",
-                    name
-                ));
-        }
+        qemu_cmd
+            .arg("-device")
+            .arg("virtio-net-device,netdev=eth0")
+            .arg("-netdev")
+            .arg("user,id=eth0")
+            .arg("-device")
+            .arg("virtio-rng-pci")
+            .arg("-drive")
+            .arg(format!(
+                "file=artifacts/{}-miralis.img,format=raw,if=virtio",
+                name
+            ));
     }
 
     if let Some(nb_harts) = cfg.platform.nb_harts {

--- a/runner/src/test.rs
+++ b/runner/src/test.rs
@@ -6,12 +6,12 @@ use std::path::PathBuf;
 use std::process::{ExitCode, Stdio};
 use std::{env, fs};
 
-use crate::artifacts::{build_target, prepare_firmware_artifact, Target};
-use crate::config::{read_config, Config, Platforms};
+use crate::artifacts::{Target, build_target, prepare_firmware_artifact};
+use crate::config::{Config, Platforms, read_config};
 use crate::path::{get_project_config_path, make_path_relative_to_root};
 use crate::project::{ProjectConfig, Test};
-use crate::run::{get_qemu_cmd, get_spike_cmd, qemu_is_available, spike_is_available, QEMU, SPIKE};
-use crate::{TestArgs, RUNNER_STRICT_MODE};
+use crate::run::{QEMU, SPIKE, get_qemu_cmd, get_spike_cmd, qemu_is_available, spike_is_available};
+use crate::{RUNNER_STRICT_MODE, TestArgs};
 
 #[derive(Debug, PartialEq, Eq)]
 struct TestGroup {
@@ -97,10 +97,10 @@ pub fn run_tests(args: &mut TestArgs) -> ExitCode {
         let cfg = read_config(&Some(&test_group.config_path));
         for (test_name, test) in &test_group.tests {
             // Filter tests if a pattern is provided
-            if let Some(pattern) = &args.pattern {
-                if !test_name.starts_with(pattern) {
-                    continue;
-                }
+            if let Some(pattern) = &args.pattern
+                && !test_name.starts_with(pattern)
+            {
+                continue;
             }
 
             // Skip tests if emulator not available

--- a/runner/src/verify.rs
+++ b/runner/src/verify.rs
@@ -3,7 +3,7 @@
 use std::env;
 use std::process::{Command, ExitCode};
 
-use crate::{VerifyArgs, RUNNER_STRICT_MODE};
+use crate::{RUNNER_STRICT_MODE, VerifyArgs};
 
 pub fn verify(args: &mut VerifyArgs) -> ExitCode {
     if env::var(RUNNER_STRICT_MODE).is_ok() && !args.strict {

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miralis"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 description = "An experimental RISC-V virtual firmawre monitor"
 homepage = "https://miralis-firmware.github.io/"

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -3,14 +3,14 @@ use core::arch::{asm, global_asm};
 use core::marker::PhantomData;
 use core::usize;
 
-use super::{menvcfg, Arch, Architecture, Csr, ExtensionsCapability, Mode, RegistersCapability};
-use crate::arch::hstatus::GVA_FILTER;
+use super::{Arch, Architecture, Csr, ExtensionsCapability, Mode, RegistersCapability, menvcfg};
 use crate::arch::Csr::{Mtinst, Mtval2};
-use crate::arch::{mie, misa, mstatus, parse_mpp_return_mode, set_mpp, HardwareCapability, Width};
+use crate::arch::hstatus::GVA_FILTER;
+use crate::arch::{HardwareCapability, Width, mie, misa, mstatus, parse_mpp_return_mode, set_mpp};
 use crate::decoder::{LoadInstr, StoreInstr};
 use crate::platform::{Plat, Platform};
 use crate::virt::VirtContext;
-use crate::{utils, RegisterContextGetter, RegisterContextSetter};
+use crate::{RegisterContextGetter, RegisterContextSetter, utils};
 
 /// Bare metal RISC-V runtime.
 pub struct MetalArch {}
@@ -89,81 +89,83 @@ impl Architecture for MetalArch {
 
     unsafe fn write_pmpaddr(index: usize, pmpaddr: usize) {
         macro_rules! asm_write_pmpaddr {
-        ($idx:literal, $addr:expr) => {
-            asm!(
-                concat!("csrw pmpaddr", $idx, ", {addr}"),
-                addr = in(reg) pmpaddr,
-                options(nomem)
-            )
-        };
-    }
+            ($idx:literal, $addr:expr) => {
+                asm!(
+                    concat!("csrw pmpaddr", $idx, ", {addr}"),
+                    addr = in(reg) pmpaddr,
+                    options(nomem)
+                )
+            };
+        }
 
-        match index {
-            0 => asm_write_pmpaddr!(0, pmpaddr),
-            1 => asm_write_pmpaddr!(1, pmpaddr),
-            2 => asm_write_pmpaddr!(2, pmpaddr),
-            3 => asm_write_pmpaddr!(3, pmpaddr),
-            4 => asm_write_pmpaddr!(4, pmpaddr),
-            5 => asm_write_pmpaddr!(5, pmpaddr),
-            6 => asm_write_pmpaddr!(6, pmpaddr),
-            7 => asm_write_pmpaddr!(7, pmpaddr),
-            8 => asm_write_pmpaddr!(8, pmpaddr),
-            9 => asm_write_pmpaddr!(9, pmpaddr),
-            10 => asm_write_pmpaddr!(10, pmpaddr),
-            11 => asm_write_pmpaddr!(11, pmpaddr),
-            12 => asm_write_pmpaddr!(12, pmpaddr),
-            13 => asm_write_pmpaddr!(13, pmpaddr),
-            14 => asm_write_pmpaddr!(14, pmpaddr),
-            15 => asm_write_pmpaddr!(15, pmpaddr),
-            16 => asm_write_pmpaddr!(16, pmpaddr),
-            17 => asm_write_pmpaddr!(17, pmpaddr),
-            18 => asm_write_pmpaddr!(18, pmpaddr),
-            19 => asm_write_pmpaddr!(19, pmpaddr),
-            20 => asm_write_pmpaddr!(20, pmpaddr),
-            21 => asm_write_pmpaddr!(21, pmpaddr),
-            22 => asm_write_pmpaddr!(22, pmpaddr),
-            23 => asm_write_pmpaddr!(23, pmpaddr),
-            24 => asm_write_pmpaddr!(24, pmpaddr),
-            25 => asm_write_pmpaddr!(25, pmpaddr),
-            26 => asm_write_pmpaddr!(26, pmpaddr),
-            27 => asm_write_pmpaddr!(27, pmpaddr),
-            28 => asm_write_pmpaddr!(28, pmpaddr),
-            29 => asm_write_pmpaddr!(29, pmpaddr),
-            30 => asm_write_pmpaddr!(30, pmpaddr),
-            31 => asm_write_pmpaddr!(31, pmpaddr),
-            32 => asm_write_pmpaddr!(32, pmpaddr),
-            33 => asm_write_pmpaddr!(33, pmpaddr),
-            34 => asm_write_pmpaddr!(34, pmpaddr),
-            35 => asm_write_pmpaddr!(35, pmpaddr),
-            36 => asm_write_pmpaddr!(36, pmpaddr),
-            37 => asm_write_pmpaddr!(37, pmpaddr),
-            38 => asm_write_pmpaddr!(38, pmpaddr),
-            39 => asm_write_pmpaddr!(39, pmpaddr),
-            40 => asm_write_pmpaddr!(40, pmpaddr),
-            41 => asm_write_pmpaddr!(41, pmpaddr),
-            42 => asm_write_pmpaddr!(42, pmpaddr),
-            43 => asm_write_pmpaddr!(43, pmpaddr),
-            44 => asm_write_pmpaddr!(44, pmpaddr),
-            45 => asm_write_pmpaddr!(45, pmpaddr),
-            46 => asm_write_pmpaddr!(46, pmpaddr),
-            47 => asm_write_pmpaddr!(47, pmpaddr),
-            48 => asm_write_pmpaddr!(48, pmpaddr),
-            49 => asm_write_pmpaddr!(49, pmpaddr),
-            50 => asm_write_pmpaddr!(50, pmpaddr),
-            51 => asm_write_pmpaddr!(51, pmpaddr),
-            52 => asm_write_pmpaddr!(52, pmpaddr),
-            53 => asm_write_pmpaddr!(53, pmpaddr),
-            54 => asm_write_pmpaddr!(54, pmpaddr),
-            55 => asm_write_pmpaddr!(55, pmpaddr),
-            56 => asm_write_pmpaddr!(56, pmpaddr),
-            57 => asm_write_pmpaddr!(57, pmpaddr),
-            58 => asm_write_pmpaddr!(58, pmpaddr),
-            59 => asm_write_pmpaddr!(59, pmpaddr),
-            60 => asm_write_pmpaddr!(60, pmpaddr),
-            61 => asm_write_pmpaddr!(61, pmpaddr),
-            62 => asm_write_pmpaddr!(62, pmpaddr),
-            63 => asm_write_pmpaddr!(63, pmpaddr),
-            _ => panic!("Invalid pmpaddr register"),
+        unsafe {
+            match index {
+                0 => asm_write_pmpaddr!(0, pmpaddr),
+                1 => asm_write_pmpaddr!(1, pmpaddr),
+                2 => asm_write_pmpaddr!(2, pmpaddr),
+                3 => asm_write_pmpaddr!(3, pmpaddr),
+                4 => asm_write_pmpaddr!(4, pmpaddr),
+                5 => asm_write_pmpaddr!(5, pmpaddr),
+                6 => asm_write_pmpaddr!(6, pmpaddr),
+                7 => asm_write_pmpaddr!(7, pmpaddr),
+                8 => asm_write_pmpaddr!(8, pmpaddr),
+                9 => asm_write_pmpaddr!(9, pmpaddr),
+                10 => asm_write_pmpaddr!(10, pmpaddr),
+                11 => asm_write_pmpaddr!(11, pmpaddr),
+                12 => asm_write_pmpaddr!(12, pmpaddr),
+                13 => asm_write_pmpaddr!(13, pmpaddr),
+                14 => asm_write_pmpaddr!(14, pmpaddr),
+                15 => asm_write_pmpaddr!(15, pmpaddr),
+                16 => asm_write_pmpaddr!(16, pmpaddr),
+                17 => asm_write_pmpaddr!(17, pmpaddr),
+                18 => asm_write_pmpaddr!(18, pmpaddr),
+                19 => asm_write_pmpaddr!(19, pmpaddr),
+                20 => asm_write_pmpaddr!(20, pmpaddr),
+                21 => asm_write_pmpaddr!(21, pmpaddr),
+                22 => asm_write_pmpaddr!(22, pmpaddr),
+                23 => asm_write_pmpaddr!(23, pmpaddr),
+                24 => asm_write_pmpaddr!(24, pmpaddr),
+                25 => asm_write_pmpaddr!(25, pmpaddr),
+                26 => asm_write_pmpaddr!(26, pmpaddr),
+                27 => asm_write_pmpaddr!(27, pmpaddr),
+                28 => asm_write_pmpaddr!(28, pmpaddr),
+                29 => asm_write_pmpaddr!(29, pmpaddr),
+                30 => asm_write_pmpaddr!(30, pmpaddr),
+                31 => asm_write_pmpaddr!(31, pmpaddr),
+                32 => asm_write_pmpaddr!(32, pmpaddr),
+                33 => asm_write_pmpaddr!(33, pmpaddr),
+                34 => asm_write_pmpaddr!(34, pmpaddr),
+                35 => asm_write_pmpaddr!(35, pmpaddr),
+                36 => asm_write_pmpaddr!(36, pmpaddr),
+                37 => asm_write_pmpaddr!(37, pmpaddr),
+                38 => asm_write_pmpaddr!(38, pmpaddr),
+                39 => asm_write_pmpaddr!(39, pmpaddr),
+                40 => asm_write_pmpaddr!(40, pmpaddr),
+                41 => asm_write_pmpaddr!(41, pmpaddr),
+                42 => asm_write_pmpaddr!(42, pmpaddr),
+                43 => asm_write_pmpaddr!(43, pmpaddr),
+                44 => asm_write_pmpaddr!(44, pmpaddr),
+                45 => asm_write_pmpaddr!(45, pmpaddr),
+                46 => asm_write_pmpaddr!(46, pmpaddr),
+                47 => asm_write_pmpaddr!(47, pmpaddr),
+                48 => asm_write_pmpaddr!(48, pmpaddr),
+                49 => asm_write_pmpaddr!(49, pmpaddr),
+                50 => asm_write_pmpaddr!(50, pmpaddr),
+                51 => asm_write_pmpaddr!(51, pmpaddr),
+                52 => asm_write_pmpaddr!(52, pmpaddr),
+                53 => asm_write_pmpaddr!(53, pmpaddr),
+                54 => asm_write_pmpaddr!(54, pmpaddr),
+                55 => asm_write_pmpaddr!(55, pmpaddr),
+                56 => asm_write_pmpaddr!(56, pmpaddr),
+                57 => asm_write_pmpaddr!(57, pmpaddr),
+                58 => asm_write_pmpaddr!(58, pmpaddr),
+                59 => asm_write_pmpaddr!(59, pmpaddr),
+                60 => asm_write_pmpaddr!(60, pmpaddr),
+                61 => asm_write_pmpaddr!(61, pmpaddr),
+                62 => asm_write_pmpaddr!(62, pmpaddr),
+                63 => asm_write_pmpaddr!(63, pmpaddr),
+                _ => panic!("Invalid pmpaddr register"),
+            }
         }
     }
 
@@ -178,16 +180,18 @@ impl Architecture for MetalArch {
             };
         }
 
-        match index {
-            0 => asm_write_pmpcfg!(0, pmpcfg),
-            2 => asm_write_pmpcfg!(2, pmpcfg),
-            4 => asm_write_pmpcfg!(4, pmpcfg),
-            6 => asm_write_pmpcfg!(6, pmpcfg),
-            8 => asm_write_pmpcfg!(8, pmpcfg),
-            10 => asm_write_pmpcfg!(10, pmpcfg),
-            12 => asm_write_pmpcfg!(12, pmpcfg),
-            14 => asm_write_pmpcfg!(14, pmpcfg),
-            _ => panic!("Invalid pmpcfg register"),
+        unsafe {
+            match index {
+                0 => asm_write_pmpcfg!(0, pmpcfg),
+                2 => asm_write_pmpcfg!(2, pmpcfg),
+                4 => asm_write_pmpcfg!(4, pmpcfg),
+                6 => asm_write_pmpcfg!(6, pmpcfg),
+                8 => asm_write_pmpcfg!(8, pmpcfg),
+                10 => asm_write_pmpcfg!(10, pmpcfg),
+                12 => asm_write_pmpcfg!(12, pmpcfg),
+                14 => asm_write_pmpcfg!(14, pmpcfg),
+                _ => panic!("Invalid pmpcfg register"),
+            }
         }
     }
 
@@ -205,94 +209,96 @@ impl Architecture for MetalArch {
             };
         }
 
-        match csr {
-            Csr::Mhartid => asm_write_csr!("mhartid"),
-            Csr::Mstatus => asm_write_csr!("mstatus"),
-            Csr::Misa => asm_write_csr!("misa"),
-            Csr::Mie => asm_write_csr!("mie"),
-            Csr::Mtvec => asm_write_csr!("mtvec"),
-            Csr::Mscratch => asm_write_csr!("mscratch"),
-            Csr::Mip => asm_write_csr!("mip"),
-            Csr::Mvendorid => asm_write_csr!("mvendorid"),
-            Csr::Marchid => asm_write_csr!("marchid"),
-            Csr::Mimpid => asm_write_csr!("mimpid"),
-            Csr::Pmpcfg(_) => todo!(),
-            Csr::Pmpaddr(index) => Arch::write_pmpaddr(index, value),
-            Csr::Mcycle => asm_write_csr!("mcycle"),
-            Csr::Minstret => asm_write_csr!("minstret"),
-            Csr::Cycle => todo!(),
-            Csr::Time => todo!(),
-            Csr::Instret => todo!(),
-            Csr::Mhpmcounter(_) => todo!(),
-            Csr::Mcountinhibit => asm_write_csr!("mcountinhibit"),
-            Csr::Mhpmevent(_) => todo!(),
-            Csr::Mcounteren => asm_write_csr!("mcounteren"),
-            Csr::Menvcfg => asm_write_csr!("menvcfg"),
-            Csr::Mseccfg => asm_write_csr!("mseccfg"),
-            Csr::Mconfigptr => asm_write_csr!("mconfigptr"),
-            Csr::Medeleg => asm_write_csr!("medeleg"),
-            Csr::Mideleg => asm_write_csr!("mideleg"),
-            Csr::Mtinst => asm_write_csr!("mtinst"),
-            Csr::Mtval2 => asm_write_csr!("mtval2"),
-            Csr::Tselect => asm_write_csr!("tselect"),
-            Csr::Tdata1 => asm_write_csr!("tdata1"),
-            Csr::Tdata2 => asm_write_csr!("tdata2"),
-            Csr::Tdata3 => asm_write_csr!("tdata3"),
-            Csr::Mcontext => asm_write_csr!("mcontext"),
-            Csr::Dcsr => asm_write_csr!("dcsr"),
-            Csr::Dpc => asm_write_csr!("dpc"),
-            Csr::Dscratch0 => asm_write_csr!("dscratch0"),
-            Csr::Dscratch1 => asm_write_csr!("dscratch1"),
-            Csr::Mepc => asm_write_csr!("mepc"),
-            Csr::Mcause => asm_write_csr!("mcause"),
-            Csr::Mtval => asm_write_csr!("mtval"),
-            Csr::Sstatus => asm_write_csr!("sstatus"),
-            Csr::Sie => asm_write_csr!("sie"),
-            Csr::Stvec => asm_write_csr!("stvec"),
-            Csr::Scounteren => asm_write_csr!("scounteren"),
-            Csr::Senvcfg => asm_write_csr!("senvcfg"),
-            Csr::Sscratch => asm_write_csr!("sscratch"),
-            Csr::Sepc => asm_write_csr!("sepc"),
-            Csr::Scause => asm_write_csr!("scause"),
-            Csr::Stval => asm_write_csr!("stval"),
-            Csr::Sip => asm_write_csr!("sip"),
-            Csr::Satp => asm_write_csr!("satp"),
-            Csr::Scontext => asm_write_csr!("scontext"),
-            Csr::Stimecmp => asm_write_csr!("stimecmp"),
-            Csr::Hstatus => asm_write_csr!("hstatus"),
-            Csr::Hedeleg => asm_write_csr!("hedeleg"),
-            Csr::Hideleg => asm_write_csr!("hideleg"),
-            Csr::Hvip => asm_write_csr!("hvip"),
-            Csr::Hip => asm_write_csr!("hip"),
-            Csr::Hie => asm_write_csr!("hie"),
-            Csr::Hgeip => {} // Read-only register
-            Csr::Hgeie => asm_write_csr!("hgeie"),
-            Csr::Henvcfg => asm_write_csr!("henvcfg"),
-            Csr::Hcounteren => asm_write_csr!("hcounteren"),
-            Csr::Htimedelta => asm_write_csr!("htimedelta"),
-            Csr::Htval => asm_write_csr!("htval"),
-            Csr::Htinst => asm_write_csr!("htinst"),
-            Csr::Hgatp => asm_write_csr!("hgatp"),
-            Csr::Vsstatus => asm_write_csr!("vsstatus"),
-            Csr::Vsie => asm_write_csr!("vsie"),
-            Csr::Vstvec => asm_write_csr!("vstvec"),
-            Csr::Vsscratch => asm_write_csr!("vsscratch"),
-            Csr::Vsepc => asm_write_csr!("vsepc"),
-            Csr::Vscause => asm_write_csr!("vscause"),
-            Csr::Vstval => asm_write_csr!("vstval"),
-            Csr::Vsip => asm_write_csr!("vsip"),
-            Csr::Vsatp => asm_write_csr!("vsatp"),
-            Csr::Vstart => todo!(),
-            Csr::Vxsat => todo!(),
-            Csr::Vxrm => todo!(),
-            Csr::Vcsr => todo!(),
-            Csr::Vl => todo!(),
-            Csr::Vtype => todo!(),
-            Csr::Vlenb => todo!(),
-            Csr::Seed => todo!(),
-            Csr::Custom(_) => panic!("Custom CSR must be handled by the platform"),
-            Csr::Unknown => (),
-        };
+        unsafe {
+            match csr {
+                Csr::Mhartid => asm_write_csr!("mhartid"),
+                Csr::Mstatus => asm_write_csr!("mstatus"),
+                Csr::Misa => asm_write_csr!("misa"),
+                Csr::Mie => asm_write_csr!("mie"),
+                Csr::Mtvec => asm_write_csr!("mtvec"),
+                Csr::Mscratch => asm_write_csr!("mscratch"),
+                Csr::Mip => asm_write_csr!("mip"),
+                Csr::Mvendorid => asm_write_csr!("mvendorid"),
+                Csr::Marchid => asm_write_csr!("marchid"),
+                Csr::Mimpid => asm_write_csr!("mimpid"),
+                Csr::Pmpcfg(_) => todo!(),
+                Csr::Pmpaddr(index) => Arch::write_pmpaddr(index, value),
+                Csr::Mcycle => asm_write_csr!("mcycle"),
+                Csr::Minstret => asm_write_csr!("minstret"),
+                Csr::Cycle => todo!(),
+                Csr::Time => todo!(),
+                Csr::Instret => todo!(),
+                Csr::Mhpmcounter(_) => todo!(),
+                Csr::Mcountinhibit => asm_write_csr!("mcountinhibit"),
+                Csr::Mhpmevent(_) => todo!(),
+                Csr::Mcounteren => asm_write_csr!("mcounteren"),
+                Csr::Menvcfg => asm_write_csr!("menvcfg"),
+                Csr::Mseccfg => asm_write_csr!("mseccfg"),
+                Csr::Mconfigptr => asm_write_csr!("mconfigptr"),
+                Csr::Medeleg => asm_write_csr!("medeleg"),
+                Csr::Mideleg => asm_write_csr!("mideleg"),
+                Csr::Mtinst => asm_write_csr!("mtinst"),
+                Csr::Mtval2 => asm_write_csr!("mtval2"),
+                Csr::Tselect => asm_write_csr!("tselect"),
+                Csr::Tdata1 => asm_write_csr!("tdata1"),
+                Csr::Tdata2 => asm_write_csr!("tdata2"),
+                Csr::Tdata3 => asm_write_csr!("tdata3"),
+                Csr::Mcontext => asm_write_csr!("mcontext"),
+                Csr::Dcsr => asm_write_csr!("dcsr"),
+                Csr::Dpc => asm_write_csr!("dpc"),
+                Csr::Dscratch0 => asm_write_csr!("dscratch0"),
+                Csr::Dscratch1 => asm_write_csr!("dscratch1"),
+                Csr::Mepc => asm_write_csr!("mepc"),
+                Csr::Mcause => asm_write_csr!("mcause"),
+                Csr::Mtval => asm_write_csr!("mtval"),
+                Csr::Sstatus => asm_write_csr!("sstatus"),
+                Csr::Sie => asm_write_csr!("sie"),
+                Csr::Stvec => asm_write_csr!("stvec"),
+                Csr::Scounteren => asm_write_csr!("scounteren"),
+                Csr::Senvcfg => asm_write_csr!("senvcfg"),
+                Csr::Sscratch => asm_write_csr!("sscratch"),
+                Csr::Sepc => asm_write_csr!("sepc"),
+                Csr::Scause => asm_write_csr!("scause"),
+                Csr::Stval => asm_write_csr!("stval"),
+                Csr::Sip => asm_write_csr!("sip"),
+                Csr::Satp => asm_write_csr!("satp"),
+                Csr::Scontext => asm_write_csr!("scontext"),
+                Csr::Stimecmp => asm_write_csr!("stimecmp"),
+                Csr::Hstatus => asm_write_csr!("hstatus"),
+                Csr::Hedeleg => asm_write_csr!("hedeleg"),
+                Csr::Hideleg => asm_write_csr!("hideleg"),
+                Csr::Hvip => asm_write_csr!("hvip"),
+                Csr::Hip => asm_write_csr!("hip"),
+                Csr::Hie => asm_write_csr!("hie"),
+                Csr::Hgeip => {} // Read-only register
+                Csr::Hgeie => asm_write_csr!("hgeie"),
+                Csr::Henvcfg => asm_write_csr!("henvcfg"),
+                Csr::Hcounteren => asm_write_csr!("hcounteren"),
+                Csr::Htimedelta => asm_write_csr!("htimedelta"),
+                Csr::Htval => asm_write_csr!("htval"),
+                Csr::Htinst => asm_write_csr!("htinst"),
+                Csr::Hgatp => asm_write_csr!("hgatp"),
+                Csr::Vsstatus => asm_write_csr!("vsstatus"),
+                Csr::Vsie => asm_write_csr!("vsie"),
+                Csr::Vstvec => asm_write_csr!("vstvec"),
+                Csr::Vsscratch => asm_write_csr!("vsscratch"),
+                Csr::Vsepc => asm_write_csr!("vsepc"),
+                Csr::Vscause => asm_write_csr!("vscause"),
+                Csr::Vstval => asm_write_csr!("vstval"),
+                Csr::Vsip => asm_write_csr!("vsip"),
+                Csr::Vsatp => asm_write_csr!("vsatp"),
+                Csr::Vstart => todo!(),
+                Csr::Vxsat => todo!(),
+                Csr::Vxrm => todo!(),
+                Csr::Vcsr => todo!(),
+                Csr::Vl => todo!(),
+                Csr::Vtype => todo!(),
+                Csr::Vlenb => todo!(),
+                Csr::Seed => todo!(),
+                Csr::Custom(_) => panic!("Custom CSR must be handled by the platform"),
+                Csr::Unknown => (),
+            };
+        }
 
         prev_value
     }
@@ -452,9 +458,9 @@ impl Architecture for MetalArch {
         let mut has_zicboz_extension = false;
         if is_menvcfg_present {
             // Write bits for all known extensions to check if they are hardwired to 0
-            let prev_menvcfg = Self::set_csr_bits(Csr::Menvcfg, menvcfg::ALL);
+            let prev_menvcfg = unsafe { Self::set_csr_bits(Csr::Menvcfg, menvcfg::ALL) };
             let menvcfg_all = Self::read_csr(Csr::Menvcfg);
-            Self::write_csr(Csr::Menvcfg, prev_menvcfg);
+            unsafe { Self::write_csr(Csr::Menvcfg, prev_menvcfg) };
 
             // If a bit is not hardwired to 0 the corresponding extension is available
             if (menvcfg_all & menvcfg::STCE_FILTER) != 0 {
@@ -484,7 +490,7 @@ impl Architecture for MetalArch {
         } else {
             0
         };
-        let nb_pmp = find_nb_of_non_zero_pmp(nb_implemented_pmp);
+        let nb_pmp = unsafe { find_nb_of_non_zero_pmp(nb_implemented_pmp) };
         log::debug!("Number of PMP: {}", nb_pmp);
 
         // Detect performance counter extensions
@@ -499,21 +505,23 @@ impl Architecture for MetalArch {
 
         // Detect available interrupt IDs
         let available_int: usize;
-        asm!(
-            "csrc mstatus, {clear_mie}",   // Disable interrupts by clearing MIE in mstatus
-            "csrrw {tmp}, mie, {all_int}", // Set all bits in the mie register
-            "csrr {available_int}, mie",   // Read back wich bits are set to 1
-            "csrw mie, {tmp}",             // Clear all bits in mie
-            clear_mie = in(reg) mstatus::MIE_FILTER,
-            all_int = in(reg) usize::MAX,
-            available_int = out(reg) available_int,
-            tmp = out(reg) _,
-            options(nomem)
-        );
+        unsafe {
+            asm!(
+                "csrc mstatus, {clear_mie}",   // Disable interrupts by clearing MIE in mstatus
+                "csrrw {tmp}, mie, {all_int}", // Set all bits in the mie register
+                "csrr {available_int}, mie",   // Read back wich bits are set to 1
+                "csrw mie, {tmp}",             // Clear all bits in mie
+                clear_mie = in(reg) mstatus::MIE_FILTER,
+                all_int = in(reg) usize::MAX,
+                available_int = out(reg) available_int,
+                tmp = out(reg) _,
+                options(nomem)
+            );
 
-        // Restore CSRs
-        Self::write_csr(Csr::Mstatus, mstatus);
-        Self::write_csr(Csr::Mtvec, mtvec);
+            // Restore CSRs
+            Self::write_csr(Csr::Mstatus, mstatus);
+            Self::write_csr(Csr::Mtvec, mtvec);
+        }
 
         let misa = Self::read_csr(Csr::Misa);
 
@@ -547,50 +555,52 @@ impl Architecture for MetalArch {
     }
 
     unsafe fn run_vcpu(ctx: &mut VirtContext) {
-        asm!(
-            // We need to save some registers manually, the compiler can't handle those
-            "add sp, sp, -32",
-            "sd x3, (8*0)(sp)",
-            "sd x4, (8*1)(sp)",
-            "sd x8, (8*2)(sp)",
-            "sd x9, (8*3)(sp)",
-            // Jump into context switch code
-            "jal x30, _run_vcpu",
-            // Restore registers
-            "ld x3, (8*0)(sp)",
-            "ld x4, (8*1)(sp)",
-            "ld x8, (8*2)(sp)",
-            "ld x9, (8*3)(sp)",
-            "add sp, sp, 32",
-            // Clobber all other registers, so that the compiler automatically
-            // saves and restores the ones it needs
-            inout("x31") ctx => _,
-            out("x1") _,
-            out("x5") _,
-            out("x6") _,
-            out("x7") _,
-            out("x10") _,
-            out("x11") _,
-            out("x12") _,
-            out("x13") _,
-            out("x14") _,
-            out("x15") _,
-            out("x16") _,
-            out("x17") _,
-            out("x18") _,
-            out("x19") _,
-            out("x20") _,
-            out("x21") _,
-            out("x22") _,
-            out("x23") _,
-            out("x24") _,
-            out("x25") _,
-            out("x26") _,
-            out("x27") _,
-            out("x28") _,
-            out("x29") _,
-            out("x30") _,
-        );
+        unsafe {
+            asm!(
+                // We need to save some registers manually, the compiler can't handle those
+                "add sp, sp, -32",
+                "sd x3, (8*0)(sp)",
+                "sd x4, (8*1)(sp)",
+                "sd x8, (8*2)(sp)",
+                "sd x9, (8*3)(sp)",
+                // Jump into context switch code
+                "jal x30, _run_vcpu",
+                // Restore registers
+                "ld x3, (8*0)(sp)",
+                "ld x4, (8*1)(sp)",
+                "ld x8, (8*2)(sp)",
+                "ld x9, (8*3)(sp)",
+                "add sp, sp, 32",
+                // Clobber all other registers, so that the compiler automatically
+                // saves and restores the ones it needs
+                inout("x31") ctx => _,
+                out("x1") _,
+                out("x5") _,
+                out("x6") _,
+                out("x7") _,
+                out("x10") _,
+                out("x11") _,
+                out("x12") _,
+                out("x13") _,
+                out("x14") _,
+                out("x15") _,
+                out("x16") _,
+                out("x17") _,
+                out("x18") _,
+                out("x19") _,
+                out("x20") _,
+                out("x21") _,
+                out("x22") _,
+                out("x23") _,
+                out("x24") _,
+                out("x25") _,
+                out("x26") _,
+                out("x27") _,
+                out("x28") _,
+                out("x29") _,
+                out("x30") _,
+            );
+        }
 
         // Fill the trap_info data structure
         ctx.trap_info.mepc = Arch::read_csr(Csr::Mepc);
@@ -606,83 +616,71 @@ impl Architecture for MetalArch {
         }
     }
 
-    unsafe fn sfencevma(vaddr: Option<usize>, asid: Option<usize>) {
-        match (vaddr, asid) {
-            (None, None) => asm!("sfence.vma"),
-            (None, Some(asid)) => {
-                asm!(
+    fn sfencevma(vaddr: Option<usize>, asid: Option<usize>) {
+        unsafe {
+            match (vaddr, asid) {
+                (None, None) => asm!("sfence.vma"),
+                (None, Some(asid)) => asm!(
                     "sfence.vma x0, {asid}",
                     asid = in(reg) asid,
-                )
-            }
-            (Some(vaddr), None) => {
-                asm!(
+                ),
+                (Some(vaddr), None) => asm!(
                     "sfence.vma {vaddr}, x0",
                     vaddr = in(reg) vaddr
-                )
-            }
-            (Some(vaddr), Some(asid)) => {
-                asm!(
+                ),
+                (Some(vaddr), Some(asid)) => asm!(
                     "sfence.vma {vaddr}, {asid}",
                     vaddr = in(reg) vaddr,
                     asid = in(reg) asid
-                )
+                ),
             }
         }
     }
 
-    unsafe fn hfencegvma(vaddr: Option<usize>, asid: Option<usize>) {
-        match (vaddr, asid) {
-            (None, None) => asm!("hfence.gvma"),
-            (None, Some(asid)) => {
-                asm!(
-                "hfence.gvma x0, {asid}",
-                asid = in(reg) asid,
-                )
-            }
-            (Some(vaddr), None) => {
-                asm!(
-                "hfence.gvma {vaddr}, x0",
-                vaddr = in(reg) vaddr
-                )
-            }
-            (Some(vaddr), Some(asid)) => {
-                asm!(
-                "hfence.gvma {vaddr}, {asid}",
-                vaddr = in(reg) vaddr,
-                asid = in(reg) asid
-                )
+    fn hfencegvma(vaddr: Option<usize>, asid: Option<usize>) {
+        unsafe {
+            match (vaddr, asid) {
+                (None, None) => asm!("hfence.gvma"),
+                (None, Some(asid)) => asm!(
+                    "hfence.gvma x0, {asid}",
+                    asid = in(reg) asid,
+                ),
+                (Some(vaddr), None) => asm!(
+                    "hfence.gvma {vaddr}, x0",
+                    vaddr = in(reg) vaddr
+                ),
+                (Some(vaddr), Some(asid)) => asm!(
+                    "hfence.gvma {vaddr}, {asid}",
+                    vaddr = in(reg) vaddr,
+                    asid = in(reg) asid
+                ),
             }
         }
     }
 
-    unsafe fn hfencevvma(vaddr: Option<usize>, asid: Option<usize>) {
-        match (vaddr, asid) {
-            (None, None) => asm!("hfence.vvma"),
-            (None, Some(asid)) => {
-                asm!(
-                "hfence.vvma x0, {asid}",
-                asid = in(reg) asid,
-                )
-            }
-            (Some(vaddr), None) => {
-                asm!(
-                "hfence.vvma {vaddr}, x0",
-                vaddr = in(reg) vaddr
-                )
-            }
-            (Some(vaddr), Some(asid)) => {
-                asm!(
-                "hfence.vvma {vaddr}, {asid}",
-                vaddr = in(reg) vaddr,
-                asid = in(reg) asid
-                )
+    fn hfencevvma(vaddr: Option<usize>, asid: Option<usize>) {
+        unsafe {
+            match (vaddr, asid) {
+                (None, None) => asm!("hfence.vvma"),
+                (None, Some(asid)) => asm!(
+                    "hfence.vvma x0, {asid}",
+                    asid = in(reg) asid,
+                ),
+                (Some(vaddr), None) => asm!(
+                    "hfence.vvma {vaddr}, x0",
+                    vaddr = in(reg) vaddr
+                ),
+                (Some(vaddr), Some(asid)) => asm!(
+                    "hfence.vvma {vaddr}, {asid}",
+                    vaddr = in(reg) vaddr,
+                    asid = in(reg) asid
+                ),
             }
         }
     }
 
-    unsafe fn ifence() {
-        asm!("fence.i");
+    fn ifence() {
+        unsafe { asm!("fence.i") };
     }
 
     unsafe fn clear_csr_bits(csr: Csr, bits_mask: usize) -> usize {
@@ -698,94 +696,96 @@ impl Architecture for MetalArch {
             };
         }
 
-        match csr {
-            Csr::Mhartid => asm_clear_csr_bits!("mhartid"),
-            Csr::Mstatus => asm_clear_csr_bits!("mstatus"),
-            Csr::Misa => asm_clear_csr_bits!("misa"),
-            Csr::Mie => asm_clear_csr_bits!("mie"),
-            Csr::Mtvec => asm_clear_csr_bits!("mtvec"),
-            Csr::Mscratch => asm_clear_csr_bits!("mscratch"),
-            Csr::Mip => asm_clear_csr_bits!("mip"),
-            Csr::Mvendorid => asm_clear_csr_bits!("mvendorid"),
-            Csr::Marchid => asm_clear_csr_bits!("marchid"),
-            Csr::Mimpid => asm_clear_csr_bits!("mimpid"),
-            Csr::Pmpcfg(_) => todo!(),
-            Csr::Pmpaddr(_) => todo!(),
-            Csr::Mcycle => asm_clear_csr_bits!("mcycle"),
-            Csr::Minstret => asm_clear_csr_bits!("minstret"),
-            Csr::Cycle => todo!(),
-            Csr::Time => todo!(),
-            Csr::Instret => todo!(),
-            Csr::Mhpmcounter(_) => todo!(),
-            Csr::Mcountinhibit => asm_clear_csr_bits!("mcountinhibit"),
-            Csr::Mhpmevent(_) => todo!(),
-            Csr::Mcounteren => asm_clear_csr_bits!("mcounteren"),
-            Csr::Menvcfg => asm_clear_csr_bits!("menvcfg"),
-            Csr::Mseccfg => asm_clear_csr_bits!("mseccfg"),
-            Csr::Mconfigptr => asm_clear_csr_bits!("mconfigptr"),
-            Csr::Medeleg => asm_clear_csr_bits!("medeleg"),
-            Csr::Mideleg => asm_clear_csr_bits!("mideleg"),
-            Csr::Mtinst => asm_clear_csr_bits!("mtinst"),
-            Csr::Mtval2 => asm_clear_csr_bits!("mtval2"),
-            Csr::Tselect => asm_clear_csr_bits!("tselect"),
-            Csr::Tdata1 => asm_clear_csr_bits!("tdata1"),
-            Csr::Tdata2 => asm_clear_csr_bits!("tdata2"),
-            Csr::Tdata3 => asm_clear_csr_bits!("tdata3"),
-            Csr::Mcontext => asm_clear_csr_bits!("mcontext"),
-            Csr::Dcsr => asm_clear_csr_bits!("dcsr"),
-            Csr::Dpc => asm_clear_csr_bits!("dpc"),
-            Csr::Dscratch0 => asm_clear_csr_bits!("dscratch0"),
-            Csr::Dscratch1 => asm_clear_csr_bits!("dscratch1"),
-            Csr::Mepc => asm_clear_csr_bits!("mepc"),
-            Csr::Mcause => asm_clear_csr_bits!("mcause"),
-            Csr::Mtval => asm_clear_csr_bits!("mtval"),
-            Csr::Sstatus => asm_clear_csr_bits!("sstatus"),
-            Csr::Sie => asm_clear_csr_bits!("sie"),
-            Csr::Stvec => asm_clear_csr_bits!("stvec"),
-            Csr::Scounteren => asm_clear_csr_bits!("scounteren"),
-            Csr::Senvcfg => asm_clear_csr_bits!("senvcfg"),
-            Csr::Sscratch => asm_clear_csr_bits!("sscratch"),
-            Csr::Sepc => asm_clear_csr_bits!("sepc"),
-            Csr::Scause => asm_clear_csr_bits!("scause"),
-            Csr::Stval => asm_clear_csr_bits!("stval"),
-            Csr::Sip => asm_clear_csr_bits!("sip"),
-            Csr::Satp => asm_clear_csr_bits!("satp"),
-            Csr::Scontext => asm_clear_csr_bits!("scontext"),
-            Csr::Stimecmp => asm_clear_csr_bits!("stimecmp"),
-            Csr::Hstatus => asm_clear_csr_bits!("hstatus"),
-            Csr::Hedeleg => asm_clear_csr_bits!("hedeleg"),
-            Csr::Hideleg => asm_clear_csr_bits!("hideleg"),
-            Csr::Hvip => asm_clear_csr_bits!("hvip"),
-            Csr::Hip => asm_clear_csr_bits!("hip"),
-            Csr::Hie => asm_clear_csr_bits!("hie"),
-            Csr::Hgeip => {} // Read only register
-            Csr::Hgeie => asm_clear_csr_bits!("hgeie"),
-            Csr::Henvcfg => asm_clear_csr_bits!("henvcfg"),
-            Csr::Hcounteren => asm_clear_csr_bits!("hcounteren"),
-            Csr::Htimedelta => asm_clear_csr_bits!("htimedelta"),
-            Csr::Htval => asm_clear_csr_bits!("htval"),
-            Csr::Htinst => asm_clear_csr_bits!("htinst"),
-            Csr::Hgatp => asm_clear_csr_bits!("hgatp"),
-            Csr::Vsstatus => asm_clear_csr_bits!("vsstatus"),
-            Csr::Vsie => asm_clear_csr_bits!("vsie"),
-            Csr::Vstvec => asm_clear_csr_bits!("vstvec"),
-            Csr::Vsscratch => asm_clear_csr_bits!("vsscratch"),
-            Csr::Vsepc => asm_clear_csr_bits!("vsepc"),
-            Csr::Vscause => asm_clear_csr_bits!("vscause"),
-            Csr::Vstval => asm_clear_csr_bits!("vstval"),
-            Csr::Vsip => asm_clear_csr_bits!("vsip"),
-            Csr::Vsatp => asm_clear_csr_bits!("vsatp"),
-            Csr::Vstart => todo!(),
-            Csr::Vxsat => todo!(),
-            Csr::Vxrm => todo!(),
-            Csr::Vcsr => todo!(),
-            Csr::Vl => todo!(),
-            Csr::Vtype => todo!(),
-            Csr::Vlenb => todo!(),
-            Csr::Seed => todo!(),
-            Csr::Custom(_) => panic!("Custom CSR must be handled by the platform"),
-            Csr::Unknown => (),
-        };
+        unsafe {
+            match csr {
+                Csr::Mhartid => asm_clear_csr_bits!("mhartid"),
+                Csr::Mstatus => asm_clear_csr_bits!("mstatus"),
+                Csr::Misa => asm_clear_csr_bits!("misa"),
+                Csr::Mie => asm_clear_csr_bits!("mie"),
+                Csr::Mtvec => asm_clear_csr_bits!("mtvec"),
+                Csr::Mscratch => asm_clear_csr_bits!("mscratch"),
+                Csr::Mip => asm_clear_csr_bits!("mip"),
+                Csr::Mvendorid => asm_clear_csr_bits!("mvendorid"),
+                Csr::Marchid => asm_clear_csr_bits!("marchid"),
+                Csr::Mimpid => asm_clear_csr_bits!("mimpid"),
+                Csr::Pmpcfg(_) => todo!(),
+                Csr::Pmpaddr(_) => todo!(),
+                Csr::Mcycle => asm_clear_csr_bits!("mcycle"),
+                Csr::Minstret => asm_clear_csr_bits!("minstret"),
+                Csr::Cycle => todo!(),
+                Csr::Time => todo!(),
+                Csr::Instret => todo!(),
+                Csr::Mhpmcounter(_) => todo!(),
+                Csr::Mcountinhibit => asm_clear_csr_bits!("mcountinhibit"),
+                Csr::Mhpmevent(_) => todo!(),
+                Csr::Mcounteren => asm_clear_csr_bits!("mcounteren"),
+                Csr::Menvcfg => asm_clear_csr_bits!("menvcfg"),
+                Csr::Mseccfg => asm_clear_csr_bits!("mseccfg"),
+                Csr::Mconfigptr => asm_clear_csr_bits!("mconfigptr"),
+                Csr::Medeleg => asm_clear_csr_bits!("medeleg"),
+                Csr::Mideleg => asm_clear_csr_bits!("mideleg"),
+                Csr::Mtinst => asm_clear_csr_bits!("mtinst"),
+                Csr::Mtval2 => asm_clear_csr_bits!("mtval2"),
+                Csr::Tselect => asm_clear_csr_bits!("tselect"),
+                Csr::Tdata1 => asm_clear_csr_bits!("tdata1"),
+                Csr::Tdata2 => asm_clear_csr_bits!("tdata2"),
+                Csr::Tdata3 => asm_clear_csr_bits!("tdata3"),
+                Csr::Mcontext => asm_clear_csr_bits!("mcontext"),
+                Csr::Dcsr => asm_clear_csr_bits!("dcsr"),
+                Csr::Dpc => asm_clear_csr_bits!("dpc"),
+                Csr::Dscratch0 => asm_clear_csr_bits!("dscratch0"),
+                Csr::Dscratch1 => asm_clear_csr_bits!("dscratch1"),
+                Csr::Mepc => asm_clear_csr_bits!("mepc"),
+                Csr::Mcause => asm_clear_csr_bits!("mcause"),
+                Csr::Mtval => asm_clear_csr_bits!("mtval"),
+                Csr::Sstatus => asm_clear_csr_bits!("sstatus"),
+                Csr::Sie => asm_clear_csr_bits!("sie"),
+                Csr::Stvec => asm_clear_csr_bits!("stvec"),
+                Csr::Scounteren => asm_clear_csr_bits!("scounteren"),
+                Csr::Senvcfg => asm_clear_csr_bits!("senvcfg"),
+                Csr::Sscratch => asm_clear_csr_bits!("sscratch"),
+                Csr::Sepc => asm_clear_csr_bits!("sepc"),
+                Csr::Scause => asm_clear_csr_bits!("scause"),
+                Csr::Stval => asm_clear_csr_bits!("stval"),
+                Csr::Sip => asm_clear_csr_bits!("sip"),
+                Csr::Satp => asm_clear_csr_bits!("satp"),
+                Csr::Scontext => asm_clear_csr_bits!("scontext"),
+                Csr::Stimecmp => asm_clear_csr_bits!("stimecmp"),
+                Csr::Hstatus => asm_clear_csr_bits!("hstatus"),
+                Csr::Hedeleg => asm_clear_csr_bits!("hedeleg"),
+                Csr::Hideleg => asm_clear_csr_bits!("hideleg"),
+                Csr::Hvip => asm_clear_csr_bits!("hvip"),
+                Csr::Hip => asm_clear_csr_bits!("hip"),
+                Csr::Hie => asm_clear_csr_bits!("hie"),
+                Csr::Hgeip => {} // Read only register
+                Csr::Hgeie => asm_clear_csr_bits!("hgeie"),
+                Csr::Henvcfg => asm_clear_csr_bits!("henvcfg"),
+                Csr::Hcounteren => asm_clear_csr_bits!("hcounteren"),
+                Csr::Htimedelta => asm_clear_csr_bits!("htimedelta"),
+                Csr::Htval => asm_clear_csr_bits!("htval"),
+                Csr::Htinst => asm_clear_csr_bits!("htinst"),
+                Csr::Hgatp => asm_clear_csr_bits!("hgatp"),
+                Csr::Vsstatus => asm_clear_csr_bits!("vsstatus"),
+                Csr::Vsie => asm_clear_csr_bits!("vsie"),
+                Csr::Vstvec => asm_clear_csr_bits!("vstvec"),
+                Csr::Vsscratch => asm_clear_csr_bits!("vsscratch"),
+                Csr::Vsepc => asm_clear_csr_bits!("vsepc"),
+                Csr::Vscause => asm_clear_csr_bits!("vscause"),
+                Csr::Vstval => asm_clear_csr_bits!("vstval"),
+                Csr::Vsip => asm_clear_csr_bits!("vsip"),
+                Csr::Vsatp => asm_clear_csr_bits!("vsatp"),
+                Csr::Vstart => todo!(),
+                Csr::Vxsat => todo!(),
+                Csr::Vxrm => todo!(),
+                Csr::Vcsr => todo!(),
+                Csr::Vl => todo!(),
+                Csr::Vtype => todo!(),
+                Csr::Vlenb => todo!(),
+                Csr::Seed => todo!(),
+                Csr::Custom(_) => panic!("Custom CSR must be handled by the platform"),
+                Csr::Unknown => (),
+            };
+        }
 
         prev_value
     }
@@ -795,105 +795,105 @@ impl Architecture for MetalArch {
 
         macro_rules! asm_set_csr_bits {
             ($reg:literal) => {
-                unsafe {
-                    asm!(
-                        concat!("csrrs {prev}, ", $reg, ", {x}"),
-                        x = in(reg) bits_mask,
-                        prev = out(reg) prev_value,
-                        options(nomem)
-                    )
-                }
+                asm!(
+                    concat!("csrrs {prev}, ", $reg, ", {x}"),
+                    x = in(reg) bits_mask,
+                    prev = out(reg) prev_value,
+                    options(nomem)
+                )
             };
         }
 
-        match csr {
-            Csr::Mhartid => asm_set_csr_bits!("mhartid"),
-            Csr::Mstatus => asm_set_csr_bits!("mstatus"),
-            Csr::Misa => asm_set_csr_bits!("misa"),
-            Csr::Mie => asm_set_csr_bits!("mie"),
-            Csr::Mtvec => asm_set_csr_bits!("mtvec"),
-            Csr::Mscratch => asm_set_csr_bits!("mscratch"),
-            Csr::Mip => asm_set_csr_bits!("mip"),
-            Csr::Mvendorid => asm_set_csr_bits!("mvendorid"),
-            Csr::Marchid => asm_set_csr_bits!("marchid"),
-            Csr::Mimpid => asm_set_csr_bits!("mimpid"),
-            Csr::Pmpcfg(_) => todo!(),
-            Csr::Pmpaddr(_) => todo!(),
-            Csr::Mcycle => asm_set_csr_bits!("mcycle"),
-            Csr::Minstret => asm_set_csr_bits!("minstret"),
-            Csr::Cycle => todo!(),
-            Csr::Time => todo!(),
-            Csr::Instret => todo!(),
-            Csr::Mhpmcounter(_) => todo!(),
-            Csr::Mcountinhibit => asm_set_csr_bits!("mcountinhibit"),
-            Csr::Mhpmevent(_) => todo!(),
-            Csr::Mcounteren => asm_set_csr_bits!("mcounteren"),
-            Csr::Menvcfg => asm_set_csr_bits!("menvcfg"),
-            Csr::Mseccfg => asm_set_csr_bits!("mseccfg"),
-            Csr::Mconfigptr => asm_set_csr_bits!("mconfigptr"),
-            Csr::Medeleg => asm_set_csr_bits!("medeleg"),
-            Csr::Mideleg => asm_set_csr_bits!("mideleg"),
-            Csr::Mtinst => asm_set_csr_bits!("mtinst"),
-            Csr::Mtval2 => asm_set_csr_bits!("mtval2"),
-            Csr::Tselect => asm_set_csr_bits!("tselect"),
-            Csr::Tdata1 => asm_set_csr_bits!("tdata1"),
-            Csr::Tdata2 => asm_set_csr_bits!("tdata2"),
-            Csr::Tdata3 => asm_set_csr_bits!("tdata3"),
-            Csr::Mcontext => asm_set_csr_bits!("mcontext"),
-            Csr::Dcsr => asm_set_csr_bits!("dcsr"),
-            Csr::Dpc => asm_set_csr_bits!("dpc"),
-            Csr::Dscratch0 => asm_set_csr_bits!("dscratch0"),
-            Csr::Dscratch1 => asm_set_csr_bits!("dscratch1"),
-            Csr::Mepc => asm_set_csr_bits!("mepc"),
-            Csr::Mcause => asm_set_csr_bits!("mcause"),
-            Csr::Mtval => asm_set_csr_bits!("mtval"),
-            Csr::Sstatus => asm_set_csr_bits!("sstatus"),
-            Csr::Sie => asm_set_csr_bits!("sie"),
-            Csr::Stvec => asm_set_csr_bits!("stvec"),
-            Csr::Scounteren => asm_set_csr_bits!("scounteren"),
-            Csr::Senvcfg => asm_set_csr_bits!("senvcfg"),
-            Csr::Sscratch => asm_set_csr_bits!("sscratch"),
-            Csr::Sepc => asm_set_csr_bits!("sepc"),
-            Csr::Scause => asm_set_csr_bits!("scause"),
-            Csr::Stval => asm_set_csr_bits!("stval"),
-            Csr::Sip => asm_set_csr_bits!("sip"),
-            Csr::Satp => asm_set_csr_bits!("satp"),
-            Csr::Scontext => asm_set_csr_bits!("scontext"),
-            Csr::Stimecmp => asm_set_csr_bits!("stimecmp"),
-            Csr::Hstatus => asm_set_csr_bits!("hstatus"),
-            Csr::Hedeleg => asm_set_csr_bits!("hedeleg"),
-            Csr::Hideleg => asm_set_csr_bits!("hideleg"),
-            Csr::Hvip => asm_set_csr_bits!("hvip"),
-            Csr::Hip => asm_set_csr_bits!("hip"),
-            Csr::Hie => asm_set_csr_bits!("hie"),
-            Csr::Hgeip => asm_set_csr_bits!("hgeip"),
-            Csr::Hgeie => asm_set_csr_bits!("hgeie"),
-            Csr::Henvcfg => asm_set_csr_bits!("henvcfg"),
-            Csr::Hcounteren => asm_set_csr_bits!("hcounteren"),
-            Csr::Htimedelta => asm_set_csr_bits!("htimedelta"),
-            Csr::Htval => asm_set_csr_bits!("htval"),
-            Csr::Htinst => asm_set_csr_bits!("htinst"),
-            Csr::Hgatp => asm_set_csr_bits!("hgatp"),
-            Csr::Vsstatus => asm_set_csr_bits!("vsstatus"),
-            Csr::Vsie => asm_set_csr_bits!("vsie"),
-            Csr::Vstvec => asm_set_csr_bits!("vstvec"),
-            Csr::Vsscratch => asm_set_csr_bits!("vsscratch"),
-            Csr::Vsepc => asm_set_csr_bits!("vsepc"),
-            Csr::Vscause => asm_set_csr_bits!("vscause"),
-            Csr::Vstval => asm_set_csr_bits!("vstval"),
-            Csr::Vsip => asm_set_csr_bits!("vsip"),
-            Csr::Vsatp => asm_set_csr_bits!("vsatp"),
-            Csr::Vstart => todo!(),
-            Csr::Vxsat => todo!(),
-            Csr::Vxrm => todo!(),
-            Csr::Vcsr => todo!(),
-            Csr::Vl => todo!(),
-            Csr::Vtype => todo!(),
-            Csr::Vlenb => todo!(),
-            Csr::Seed => todo!(),
-            Csr::Custom(_) => panic!("Custom CSR must be handled by the platform"),
-            Csr::Unknown => (),
-        };
+        unsafe {
+            match csr {
+                Csr::Mhartid => asm_set_csr_bits!("mhartid"),
+                Csr::Mstatus => asm_set_csr_bits!("mstatus"),
+                Csr::Misa => asm_set_csr_bits!("misa"),
+                Csr::Mie => asm_set_csr_bits!("mie"),
+                Csr::Mtvec => asm_set_csr_bits!("mtvec"),
+                Csr::Mscratch => asm_set_csr_bits!("mscratch"),
+                Csr::Mip => asm_set_csr_bits!("mip"),
+                Csr::Mvendorid => asm_set_csr_bits!("mvendorid"),
+                Csr::Marchid => asm_set_csr_bits!("marchid"),
+                Csr::Mimpid => asm_set_csr_bits!("mimpid"),
+                Csr::Pmpcfg(_) => todo!(),
+                Csr::Pmpaddr(_) => todo!(),
+                Csr::Mcycle => asm_set_csr_bits!("mcycle"),
+                Csr::Minstret => asm_set_csr_bits!("minstret"),
+                Csr::Cycle => todo!(),
+                Csr::Time => todo!(),
+                Csr::Instret => todo!(),
+                Csr::Mhpmcounter(_) => todo!(),
+                Csr::Mcountinhibit => asm_set_csr_bits!("mcountinhibit"),
+                Csr::Mhpmevent(_) => todo!(),
+                Csr::Mcounteren => asm_set_csr_bits!("mcounteren"),
+                Csr::Menvcfg => asm_set_csr_bits!("menvcfg"),
+                Csr::Mseccfg => asm_set_csr_bits!("mseccfg"),
+                Csr::Mconfigptr => asm_set_csr_bits!("mconfigptr"),
+                Csr::Medeleg => asm_set_csr_bits!("medeleg"),
+                Csr::Mideleg => asm_set_csr_bits!("mideleg"),
+                Csr::Mtinst => asm_set_csr_bits!("mtinst"),
+                Csr::Mtval2 => asm_set_csr_bits!("mtval2"),
+                Csr::Tselect => asm_set_csr_bits!("tselect"),
+                Csr::Tdata1 => asm_set_csr_bits!("tdata1"),
+                Csr::Tdata2 => asm_set_csr_bits!("tdata2"),
+                Csr::Tdata3 => asm_set_csr_bits!("tdata3"),
+                Csr::Mcontext => asm_set_csr_bits!("mcontext"),
+                Csr::Dcsr => asm_set_csr_bits!("dcsr"),
+                Csr::Dpc => asm_set_csr_bits!("dpc"),
+                Csr::Dscratch0 => asm_set_csr_bits!("dscratch0"),
+                Csr::Dscratch1 => asm_set_csr_bits!("dscratch1"),
+                Csr::Mepc => asm_set_csr_bits!("mepc"),
+                Csr::Mcause => asm_set_csr_bits!("mcause"),
+                Csr::Mtval => asm_set_csr_bits!("mtval"),
+                Csr::Sstatus => asm_set_csr_bits!("sstatus"),
+                Csr::Sie => asm_set_csr_bits!("sie"),
+                Csr::Stvec => asm_set_csr_bits!("stvec"),
+                Csr::Scounteren => asm_set_csr_bits!("scounteren"),
+                Csr::Senvcfg => asm_set_csr_bits!("senvcfg"),
+                Csr::Sscratch => asm_set_csr_bits!("sscratch"),
+                Csr::Sepc => asm_set_csr_bits!("sepc"),
+                Csr::Scause => asm_set_csr_bits!("scause"),
+                Csr::Stval => asm_set_csr_bits!("stval"),
+                Csr::Sip => asm_set_csr_bits!("sip"),
+                Csr::Satp => asm_set_csr_bits!("satp"),
+                Csr::Scontext => asm_set_csr_bits!("scontext"),
+                Csr::Stimecmp => asm_set_csr_bits!("stimecmp"),
+                Csr::Hstatus => asm_set_csr_bits!("hstatus"),
+                Csr::Hedeleg => asm_set_csr_bits!("hedeleg"),
+                Csr::Hideleg => asm_set_csr_bits!("hideleg"),
+                Csr::Hvip => asm_set_csr_bits!("hvip"),
+                Csr::Hip => asm_set_csr_bits!("hip"),
+                Csr::Hie => asm_set_csr_bits!("hie"),
+                Csr::Hgeip => asm_set_csr_bits!("hgeip"),
+                Csr::Hgeie => asm_set_csr_bits!("hgeie"),
+                Csr::Henvcfg => asm_set_csr_bits!("henvcfg"),
+                Csr::Hcounteren => asm_set_csr_bits!("hcounteren"),
+                Csr::Htimedelta => asm_set_csr_bits!("htimedelta"),
+                Csr::Htval => asm_set_csr_bits!("htval"),
+                Csr::Htinst => asm_set_csr_bits!("htinst"),
+                Csr::Hgatp => asm_set_csr_bits!("hgatp"),
+                Csr::Vsstatus => asm_set_csr_bits!("vsstatus"),
+                Csr::Vsie => asm_set_csr_bits!("vsie"),
+                Csr::Vstvec => asm_set_csr_bits!("vstvec"),
+                Csr::Vsscratch => asm_set_csr_bits!("vsscratch"),
+                Csr::Vsepc => asm_set_csr_bits!("vsepc"),
+                Csr::Vscause => asm_set_csr_bits!("vscause"),
+                Csr::Vstval => asm_set_csr_bits!("vstval"),
+                Csr::Vsip => asm_set_csr_bits!("vsip"),
+                Csr::Vsatp => asm_set_csr_bits!("vsatp"),
+                Csr::Vstart => todo!(),
+                Csr::Vxsat => todo!(),
+                Csr::Vxrm => todo!(),
+                Csr::Vcsr => todo!(),
+                Csr::Vl => todo!(),
+                Csr::Vtype => todo!(),
+                Csr::Vlenb => todo!(),
+                Csr::Seed => todo!(),
+                Csr::Custom(_) => panic!("Custom CSR must be handled by the platform"),
+                Csr::Unknown => (),
+            };
+        }
 
         prev_value
     }
@@ -906,11 +906,11 @@ impl Architecture for MetalArch {
     /// ensure the proper access rights are enforced.
     unsafe fn handle_virtual_load(instr: LoadInstr, ctx: &mut VirtContext) {
         // Zero out mcause to check if a trap occured during emulation
-        Self::write_csr(Csr::Mcause, 0);
+        unsafe { Self::write_csr(Csr::Mcause, 0) };
 
         // Set the MPP mode to match the vMPP
-        let prev_mpp = set_mpp(parse_mpp_return_mode(ctx.csr.mstatus));
-        let prev_satp = Self::write_csr(Csr::Satp, ctx.csr.satp);
+        let prev_mpp = unsafe { set_mpp(parse_mpp_return_mode(ctx.csr.mstatus)) };
+        let prev_satp = unsafe { Self::write_csr(Csr::Satp, ctx.csr.satp) };
 
         // Changes to SATP require an sfence instruction to take effect
         Self::sfencevma(None, None);
@@ -918,16 +918,18 @@ impl Architecture for MetalArch {
         let mut value: usize = 0;
         let addr: usize = utils::calculate_addr(ctx.get(instr.rs1), instr.imm);
 
-        match (instr.len, instr.is_unsigned) {
-            (Width::Byte, false) => asm_mprv_mem_op!("lb", addr, value),
-            (Width::Byte2, false) => asm_mprv_mem_op!("lh", addr, value),
-            (Width::Byte4, false) => asm_mprv_mem_op!("lw", addr, value),
-            (Width::Byte8, false) => asm_mprv_mem_op!("ld", addr, value),
-            (Width::Byte, true) => asm_mprv_mem_op!("lbu", addr, value),
-            (Width::Byte2, true) => asm_mprv_mem_op!("lhu", addr, value),
-            (Width::Byte4, true) => asm_mprv_mem_op!("lwu", addr, value),
-            _ => panic!("Unknown load instruction"),
-        };
+        unsafe {
+            match (instr.len, instr.is_unsigned) {
+                (Width::Byte, false) => asm_mprv_mem_op!("lb", addr, value),
+                (Width::Byte2, false) => asm_mprv_mem_op!("lh", addr, value),
+                (Width::Byte4, false) => asm_mprv_mem_op!("lw", addr, value),
+                (Width::Byte8, false) => asm_mprv_mem_op!("ld", addr, value),
+                (Width::Byte, true) => asm_mprv_mem_op!("lbu", addr, value),
+                (Width::Byte2, true) => asm_mprv_mem_op!("lhu", addr, value),
+                (Width::Byte4, true) => asm_mprv_mem_op!("lwu", addr, value),
+                _ => panic!("Unknown load instruction"),
+            };
+        }
 
         // If `mcause` is not zero then the load caused a trap.
         // In that case we need to update the trap info and inject the trap back.
@@ -940,8 +942,10 @@ impl Architecture for MetalArch {
         }
 
         // Restore the original values
-        Self::write_csr(Csr::Satp, prev_satp);
-        set_mpp(prev_mpp);
+        unsafe {
+            Self::write_csr(Csr::Satp, prev_satp);
+            set_mpp(prev_mpp);
+        }
 
         // Ensure memory consistency
         Self::sfencevma(None, None);
@@ -955,11 +959,11 @@ impl Architecture for MetalArch {
     /// properly to ensure the proper access rights are enforced.
     unsafe fn handle_virtual_store(instr: StoreInstr, ctx: &mut VirtContext) {
         // Zero out mcause to check if a trap occured during emulation
-        Self::write_csr(Csr::Mcause, 0);
+        unsafe { Self::write_csr(Csr::Mcause, 0) };
 
         // Set the MPP mode to match the vMPP
-        let prev_mpp = set_mpp(parse_mpp_return_mode(ctx.csr.mstatus));
-        let prev_satp = Self::write_csr(Csr::Satp, ctx.csr.satp);
+        let prev_mpp = unsafe { set_mpp(parse_mpp_return_mode(ctx.csr.mstatus)) };
+        let prev_satp = unsafe { Self::write_csr(Csr::Satp, ctx.csr.satp) };
 
         // Changes to SATP require an sfence instruction to take effect
         Self::sfencevma(None, None);
@@ -967,12 +971,14 @@ impl Architecture for MetalArch {
         let mut value: usize = ctx.get(instr.rs2);
         let addr: usize = utils::calculate_addr(ctx.get(instr.rs1), instr.imm);
 
-        match instr.len {
-            Width::Byte => asm_mprv_mem_op!("sb", addr, value),
-            Width::Byte2 => asm_mprv_mem_op!("sh", addr, value),
-            Width::Byte4 => asm_mprv_mem_op!("sw", addr, value),
-            Width::Byte8 => asm_mprv_mem_op!("sd", addr, value),
-        };
+        unsafe {
+            match instr.len {
+                Width::Byte => asm_mprv_mem_op!("sb", addr, value),
+                Width::Byte2 => asm_mprv_mem_op!("sh", addr, value),
+                Width::Byte4 => asm_mprv_mem_op!("sw", addr, value),
+                Width::Byte8 => asm_mprv_mem_op!("sd", addr, value),
+            };
+        }
 
         // Silence unused warning caused by the macro
         let _ = value;
@@ -987,8 +993,10 @@ impl Architecture for MetalArch {
         }
 
         // Restore the original values
-        Self::write_csr(Csr::Satp, prev_satp);
-        set_mpp(prev_mpp);
+        unsafe {
+            Self::write_csr(Csr::Satp, prev_satp);
+            set_mpp(prev_mpp);
+        }
 
         // Ensure memory consistency
         Self::sfencevma(None, None);
@@ -1003,57 +1011,58 @@ impl Architecture for MetalArch {
         let prev_mcause = Self::read_csr(Csr::Mcause);
         let prev_mstatus = Self::read_csr(Csr::Mstatus);
 
-        // Set mstatus.MPP to mode
-        let prev_mode = set_mpp(mode);
-        for i in 0..dest.len() {
-            let mut byte_read: u8 = 0;
-            unsafe {
+        unsafe {
+            // Set mstatus.MPP to mode
+            let prev_mode = set_mpp(mode);
+            for i in 0..dest.len() {
+                let mut byte_read: u8 = 0;
                 asm!(
-                // Try
-                "la {r_mtvec}, 0f",
-                "csrrw {r_mtvec}, mtvec, {r_mtvec}",  // Trap to catch-block if an exception occurs
+                    // Try
+                    "la {r_mtvec}, 0f",
+                    "csrrw {r_mtvec}, mtvec, {r_mtvec}",  // Trap to catch-block if an exception occurs
 
-                // Set the mstatus.MPRV bit to 1
-                "csrs mstatus, {mprv_filter}",
-                // Read byte at src
-                "lb {byte}, 0x00({src})",
-                // Set the mstatus.MPRV bit to 0
-                "csrc mstatus, {mprv_filter}",
-                "j 1f", // Jump to finally if the read was successful
+                    // Set the mstatus.MPRV bit to 1
+                    "csrs mstatus, {mprv_filter}",
+                    // Read byte at src
+                    "lb {byte}, 0x00({src})",
+                    // Set the mstatus.MPRV bit to 0
+                    "csrc mstatus, {mprv_filter}",
+                    "j 1f", // Jump to finally if the read was successful
 
-                // Catch
-                ".align 4",
-                "0:",
-                "li {success}, 0",
-                "la {byte}, 1f",
-                "csrw mepc, {byte}",
-                "mret",  // Jump to finally and set mstatus.MPRV to 0
+                    // Catch
+                    ".align 4",
+                    "0:",
+                    "li {success}, 0",
+                    "la {byte}, 1f",
+                    "csrw mepc, {byte}",
+                    "mret",  // Jump to finally and set mstatus.MPRV to 0
 
-                // Finally
-                ".align 4",
-                "1:",
-                "csrw mtvec, {r_mtvec}", // Restore mtvec
-                src = in(reg) src,
-                mprv_filter = in(reg) mstatus::MPRV_FILTER,
-                byte = inout(reg) byte_read,
-                success = inout(reg) success,
-                r_mtvec = out(reg) _,
-                )
+                    // Finally
+                    ".align 4",
+                    "1:",
+                    "csrw mtvec, {r_mtvec}", // Restore mtvec
+                    src = in(reg) src,
+                    mprv_filter = in(reg) mstatus::MPRV_FILTER,
+                    byte = inout(reg) byte_read,
+                    success = inout(reg) success,
+                    r_mtvec = out(reg) _,
+                );
+
+                if success == 0 {
+                    // Restore previous registers
+                    Self::write_csr(Csr::Mepc, prev_mepc);
+                    Self::write_csr(Csr::Mcause, prev_mcause);
+                    Self::write_csr(Csr::Mstatus, prev_mstatus);
+                    return Err(());
+                }
+
+                dest[i] = byte_read;
+                src += 1;
             }
 
-            if success == 0 {
-                Self::write_csr(Csr::Mepc, prev_mepc);
-                Self::write_csr(Csr::Mcause, prev_mcause);
-                Self::write_csr(Csr::Mstatus, prev_mstatus);
-                return Err(());
-            }
-
-            dest[i] = byte_read;
-            src += 1;
+            set_mpp(prev_mode);
+            Ok(())
         }
-
-        set_mpp(prev_mode);
-        Ok(())
     }
 
     unsafe fn store_bytes_from_mode(src: &mut [u8], dest: *const u8, mode: Mode) -> Result<(), ()> {
@@ -1065,54 +1074,57 @@ impl Architecture for MetalArch {
         let prev_mcause = Self::read_csr(Csr::Mcause);
         let prev_mstatus = Self::read_csr(Csr::Mstatus);
 
-        // Set mstatus.MPP to mode
-        let prev_mode = set_mpp(mode);
-        for i in 0..src.len() {
-            let byte_value: u8 = src[i];
-            unsafe {
+        unsafe {
+            // Set mstatus.MPP to mode
+            let prev_mode = set_mpp(mode);
+            for i in 0..src.len() {
+                let byte_value: u8 = src[i];
                 asm!(
-                // Try
-                "la {r_mtvec}, 0f",
-                "csrrw {r_mtvec}, mtvec, {r_mtvec}",  // Trap to catch-block if an exception occurs
+                    // Try
+                    "la {r_mtvec}, 0f",
+                    "csrrw {r_mtvec}, mtvec, {r_mtvec}",  // Trap to catch-block if an exception occurs
 
-                // Set the mstatus.MPRV bit to 1
-                "csrs mstatus, {mprv_filter}",
-                // Store byte at src
-                "sb {byte}, 0x00({dest})",
-                // Set the mstatus.MPRV bit to 0
-                "csrc mstatus, {mprv_filter}",
-                "j 1f", // Jump to finally if the read was successful
+                    // Set the mstatus.MPRV bit to 1
+                    "csrs mstatus, {mprv_filter}",
+                    // Store byte at src
+                    "sb {byte}, 0x00({dest})",
+                    // Set the mstatus.MPRV bit to 0
+                    "csrc mstatus, {mprv_filter}",
+                    "j 1f", // Jump to finally if the read was successful
 
-                // Catch
-                ".align 4",
-                "0:",
-                "li {success}, 0",
-                "la {byte}, 1f",
-                "csrw mepc, {byte}",
-                "mret",  // Jump to finally and set mstatus.MPRV to 0
+                    // Catch
+                    ".align 4",
+                    "0:",
+                    "li {success}, 0",
+                    "la {byte}, 1f",
+                    "csrw mepc, {byte}",
+                    "mret",  // Jump to finally and set mstatus.MPRV to 0
 
-                // Finally
-                ".align 4",
-                "1:",
-                "csrw mtvec, {r_mtvec}", // Restore mtvec
-                dest = in(reg) dest,
-                mprv_filter = in(reg) mstatus::MPRV_FILTER,
-                byte = in(reg) byte_value,
-                success = inout(reg) success,
-                r_mtvec = out(reg) _,
-                )
+                    // Finally
+                    ".align 4",
+                    "1:",
+                    "csrw mtvec, {r_mtvec}", // Restore mtvec
+                    dest = in(reg) dest,
+                    mprv_filter = in(reg) mstatus::MPRV_FILTER,
+                    byte = in(reg) byte_value,
+                    success = inout(reg) success,
+                    r_mtvec = out(reg) _,
+                );
+
+                if success == 0 {
+                    // Restore previous registers
+                    Self::write_csr(Csr::Mepc, prev_mepc);
+                    Self::write_csr(Csr::Mcause, prev_mcause);
+                    Self::write_csr(Csr::Mstatus, prev_mstatus);
+                    return Err(());
+                }
+
+                dest += 1;
             }
-            if success == 0 {
-                Self::write_csr(Csr::Mepc, prev_mepc);
-                Self::write_csr(Csr::Mcause, prev_mcause);
-                Self::write_csr(Csr::Mstatus, prev_mstatus);
-                return Err(());
-            }
-            dest += 1;
+
+            set_mpp(prev_mode);
+            Ok(())
         }
-
-        set_mpp(prev_mode);
-        Ok(())
     }
 }
 
@@ -1162,75 +1174,79 @@ unsafe fn find_nb_of_non_zero_pmp(nb_implemented: usize) -> usize {
         return 0;
     }
 
-    test_pmp!(0);
-    test_pmp!(1);
-    test_pmp!(2);
-    test_pmp!(3);
-    test_pmp!(4);
-    test_pmp!(5);
-    test_pmp!(6);
-    test_pmp!(7);
-    test_pmp!(8);
-    test_pmp!(9);
-    test_pmp!(10);
-    test_pmp!(11);
-    test_pmp!(12);
-    test_pmp!(13);
-    test_pmp!(14);
-    test_pmp!(15);
+    unsafe {
+        test_pmp!(0);
+        test_pmp!(1);
+        test_pmp!(2);
+        test_pmp!(3);
+        test_pmp!(4);
+        test_pmp!(5);
+        test_pmp!(6);
+        test_pmp!(7);
+        test_pmp!(8);
+        test_pmp!(9);
+        test_pmp!(10);
+        test_pmp!(11);
+        test_pmp!(12);
+        test_pmp!(13);
+        test_pmp!(14);
+        test_pmp!(15);
+    }
 
     if nb_implemented == 16 {
         return 16;
     }
 
-    test_pmp!(16);
-    test_pmp!(17);
-    test_pmp!(18);
-    test_pmp!(19);
-    test_pmp!(20);
-    test_pmp!(21);
-    test_pmp!(22);
-    test_pmp!(23);
-    test_pmp!(24);
-    test_pmp!(25);
-    test_pmp!(26);
-    test_pmp!(27);
-    test_pmp!(28);
-    test_pmp!(29);
-    test_pmp!(30);
-    test_pmp!(31);
-    test_pmp!(32);
-    test_pmp!(33);
-    test_pmp!(34);
-    test_pmp!(35);
-    test_pmp!(36);
-    test_pmp!(37);
-    test_pmp!(38);
-    test_pmp!(39);
-    test_pmp!(40);
-    test_pmp!(41);
-    test_pmp!(42);
-    test_pmp!(43);
-    test_pmp!(44);
-    test_pmp!(45);
-    test_pmp!(46);
-    test_pmp!(47);
-    test_pmp!(48);
-    test_pmp!(49);
-    test_pmp!(50);
-    test_pmp!(51);
-    test_pmp!(52);
-    test_pmp!(53);
-    test_pmp!(54);
-    test_pmp!(55);
-    test_pmp!(56);
-    test_pmp!(57);
-    test_pmp!(58);
-    test_pmp!(59);
-    test_pmp!(60);
-    test_pmp!(61);
-    test_pmp!(62);
-    test_pmp!(63);
+    unsafe {
+        test_pmp!(16);
+        test_pmp!(17);
+        test_pmp!(18);
+        test_pmp!(19);
+        test_pmp!(20);
+        test_pmp!(21);
+        test_pmp!(22);
+        test_pmp!(23);
+        test_pmp!(24);
+        test_pmp!(25);
+        test_pmp!(26);
+        test_pmp!(27);
+        test_pmp!(28);
+        test_pmp!(29);
+        test_pmp!(30);
+        test_pmp!(31);
+        test_pmp!(32);
+        test_pmp!(33);
+        test_pmp!(34);
+        test_pmp!(35);
+        test_pmp!(36);
+        test_pmp!(37);
+        test_pmp!(38);
+        test_pmp!(39);
+        test_pmp!(40);
+        test_pmp!(41);
+        test_pmp!(42);
+        test_pmp!(43);
+        test_pmp!(44);
+        test_pmp!(45);
+        test_pmp!(46);
+        test_pmp!(47);
+        test_pmp!(48);
+        test_pmp!(49);
+        test_pmp!(50);
+        test_pmp!(51);
+        test_pmp!(52);
+        test_pmp!(53);
+        test_pmp!(54);
+        test_pmp!(55);
+        test_pmp!(56);
+        test_pmp!(57);
+        test_pmp!(58);
+        test_pmp!(59);
+        test_pmp!(60);
+        test_pmp!(61);
+        test_pmp!(62);
+        test_pmp!(63);
+    }
 
     return 64;
 }
@@ -1382,7 +1398,7 @@ _mprv_trap_handler:
 "#,
 );
 
-extern "C" {
+unsafe extern "C" {
     fn _raw_trap_handler();
     fn _tracing_trap_handler();
     fn _mprv_trap_handler();

--- a/src/arch/pmp.rs
+++ b/src/arch/pmp.rs
@@ -7,12 +7,12 @@ use core::fmt;
 use core::fmt::Formatter;
 
 use super::Architecture;
+use crate::arch::Arch;
 use crate::arch::pmp::pmpcfg::{INACTIVE, NAPOT, TOR};
 use crate::arch::pmp::pmplayout::{
     DEVICES_OFFSET, INACTIVE_ENTRY_OFFSET, MIRALIS_OFFSET, MIRALIS_TOTAL_PMP, MODULE_OFFSET,
     MODULE_SIZE, MPRV_EMULATION_OFFSET, VIRTUAL_PMP_OFFSET,
 };
-use crate::arch::Arch;
 use crate::platform::{Plat, Platform};
 use crate::{config, logger};
 
@@ -431,7 +431,7 @@ impl PmpGroup {
 impl PmpFlush {
     /// Flush the caches, which is required for PMP changes to take effect.
     pub fn flush(self) {
-        unsafe { Arch::sfencevma(None, None) }
+        Arch::sfencevma(None, None)
     }
 
     /// Do not flush the caches, PMP changes will not take effect predictably which can lead to

--- a/src/arch/userspace.rs
+++ b/src/arch/userspace.rs
@@ -7,9 +7,9 @@ use core::cell::RefCell;
 use core::marker::PhantomData;
 use std::thread_local;
 
-use softcore_rv64::{config, new_core, registers as reg, Core};
+use softcore_rv64::{Core, config, new_core, registers as reg};
 
-use super::{mie, Architecture, Csr, ExtensionsCapability, Mode};
+use super::{Architecture, Csr, ExtensionsCapability, Mode, mie};
 use crate::arch::HardwareCapability;
 use crate::decoder::{LoadInstr, StoreInstr};
 use crate::logger;
@@ -85,19 +85,19 @@ impl Architecture for HostArch {
         todo!()
     }
 
-    unsafe fn sfencevma(_vaddr: Option<usize>, _asid: Option<usize>) {
+    fn sfencevma(_vaddr: Option<usize>, _asid: Option<usize>) {
         logger::debug!("Userspace sfencevma");
     }
 
-    unsafe fn hfencegvma(_: Option<usize>, _: Option<usize>) {
+    fn hfencegvma(_: Option<usize>, _: Option<usize>) {
         logger::debug!("Userspace hfencegvma")
     }
 
-    unsafe fn hfencevvma(_: Option<usize>, _: Option<usize>) {
+    fn hfencevvma(_: Option<usize>, _: Option<usize>) {
         logger::debug!("Userspace hfencevvma")
     }
 
-    unsafe fn ifence() {
+    fn ifence() {
         logger::debug!("Userspace ifence");
     }
 
@@ -146,11 +146,11 @@ impl Architecture for HostArch {
     }
 
     unsafe fn clear_csr_bits(csr: Csr, bits_mask: usize) -> usize {
-        Self::write_csr(csr, Self::read_csr(csr) & !bits_mask)
+        unsafe { Self::write_csr(csr, Self::read_csr(csr) & !bits_mask) }
     }
 
     unsafe fn set_csr_bits(csr: Csr, bits_mask: usize) -> usize {
-        Self::write_csr(csr, Self::read_csr(csr) | bits_mask)
+        unsafe { Self::write_csr(csr, Self::read_csr(csr) | bits_mask) }
     }
 
     unsafe fn handle_virtual_load(_instr: LoadInstr, _ctx: &mut VirtContext) {

--- a/src/benchmark/boot.rs
+++ b/src/benchmark/boot.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use miralis_core::abi;
 
 use crate::arch::{Arch, Architecture, Csr, Register};
-use crate::benchmark::{get_exception_category, NUMBER_CATEGORIES};
+use crate::benchmark::{NUMBER_CATEGORIES, get_exception_category};
 use crate::config::MODULES;
 use crate::host::MiralisContext;
 use crate::modules::{Module, ModuleAction};

--- a/src/benchmark/counter.rs
+++ b/src/benchmark/counter.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::{AtomicU64, Ordering};
 use miralis_core::abi;
 
 use crate::arch::Register;
-use crate::benchmark::{get_exception_category, ExceptionCategory};
+use crate::benchmark::{ExceptionCategory, get_exception_category};
 use crate::config::PLATFORM_NB_HARTS;
 use crate::host::MiralisContext;
 use crate::modules::{Module, ModuleAction};

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -12,7 +12,7 @@ use miralis_core::sbi_codes::{
 
 use crate::arch::{MCause, Register};
 use crate::benchmark::ExceptionCategory::{
-    FirmwareTrap, MisalignedOp, NotOffloaded, PageFault, ReadTime, RemoteFence, SetTimer, IPI,
+    FirmwareTrap, IPI, MisalignedOp, NotOffloaded, PageFault, ReadTime, RemoteFence, SetTimer,
 };
 use crate::virt::traits::RegisterContextGetter;
 use crate::virt::{ExecutionMode, VirtContext};

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,5 +1,5 @@
 //! RISC-V instruction decoder
-use crate::arch::{csr, Csr, Register, Width};
+use crate::arch::{Csr, Register, Width, csr};
 use crate::host::MiralisContext;
 use crate::logger;
 use crate::platform::{Plat, Platform};
@@ -471,9 +471,9 @@ impl MiralisContext {
             csr::MTINST => {
                 if !self.hw.extensions.has_h_extension {
                     log::warn!(
-                    "Unknown CSR: 0x{:x}, Mtisnt should not exist in a system without without hypervisor extension",
-                    csr
-                );
+                        "Unknown CSR: 0x{:x}, Mtisnt should not exist in a system without without hypervisor extension",
+                        csr
+                    );
                     Csr::Unknown
                 } else {
                     Csr::Mtinst
@@ -482,9 +482,9 @@ impl MiralisContext {
             csr::MTVAL2 => {
                 if !self.hw.extensions.has_h_extension {
                     log::warn!(
-                    "Unknown CSR: 0x{:x}, Mtval2 should not exist in a system without hypervisor extension",
-                    csr
-                );
+                        "Unknown CSR: 0x{:x}, Mtval2 should not exist in a system without hypervisor extension",
+                        csr
+                    );
                     Csr::Unknown
                 } else {
                     Csr::Mtval2

--- a/src/device/clint.rs
+++ b/src/device/clint.rs
@@ -2,11 +2,11 @@ use core::cmp::min;
 use core::mem::size_of;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use crate::arch::{mie, Arch, Architecture, Csr, Mode};
+use crate::arch::{Arch, Architecture, Csr, Mode, mie};
 use crate::config::PLATFORM_NB_HARTS;
 use crate::device::{DeviceAccess, Width};
 use crate::driver::clint::{
-    ClintDriver, MSIP_OFFSET, MSIP_WIDTH, MTIMECMP_OFFSET, MTIMECMP_WIDTH, MTIME_OFFSET,
+    ClintDriver, MSIP_OFFSET, MSIP_WIDTH, MTIME_OFFSET, MTIMECMP_OFFSET, MTIMECMP_WIDTH,
 };
 use crate::host::MiralisContext;
 use crate::platform::{Plat, Platform};
@@ -356,7 +356,7 @@ impl VirtClint {
     /// handling timer interrupt from the payload and returning to the payload without a world
     /// switch.
     unsafe fn set_physical_stip(&self) {
-        Arch::set_csr_bits(Csr::Mip, mie::STIE_FILTER);
+        unsafe { Arch::set_csr_bits(Csr::Mip, mie::STIE_FILTER) };
     }
 
     /// Clear the `mip.STIP` bit within the physical registers.
@@ -366,6 +366,6 @@ impl VirtClint {
     /// handling timer interrupt from the payload and returning to the payload without a world
     /// switch.
     unsafe fn clear_physical_stip(&self) {
-        Arch::clear_csr_bits(Csr::Mip, mie::STIE_FILTER);
+        unsafe { Arch::clear_csr_bits(Csr::Mip, mie::STIE_FILTER) };
     }
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -2,8 +2,8 @@
 //!
 //! This module exposes the host context as [MiralisCtx], which holds Miralis's own configuration registers.
 
-use crate::arch::pmp::PmpGroup;
 use crate::arch::HardwareCapability;
+use crate::arch::pmp::PmpGroup;
 use crate::device;
 use crate::platform::{Plat, Platform};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,19 +13,19 @@
 use core::arch::global_asm;
 
 use miralis::arch::perf_counters::DELGATE_PERF_COUNTERS_MASK;
-use miralis::arch::{misa, set_mpp, write_pmp, Arch, Architecture, Csr, Mode, Register};
+use miralis::arch::{Arch, Architecture, Csr, Mode, Register, misa, set_mpp, write_pmp};
 use miralis::host::MiralisContext;
 use miralis::modules::{MainModule, Module};
-use miralis::platform::{init, Plat, Platform};
-use miralis::virt::traits::*;
+use miralis::platform::{Plat, Platform, init};
 use miralis::virt::VirtContext;
+use miralis::virt::traits::*;
 use miralis_config::{
     DELEGATE_PERF_COUNTER, PLATFORM_BOOT_HART_ID, PLATFORM_NAME, PLATFORM_NB_HARTS,
     TARGET_STACK_SIZE,
 };
 
 // Memory layout, defined in the linker script.
-extern "C" {
+unsafe extern "C" {
     static _stack_start: u8;
     static _bss_start: u8;
     static _bss_stop: u8;

--- a/src/platform/miralis.rs
+++ b/src/platform/miralis.rs
@@ -5,11 +5,11 @@ use core::fmt;
 use log::Level;
 use miralis_abi::{failure, miralis_log_fmt, success};
 
-use crate::device::clint::{VirtClint, CLINT_SIZE};
-use crate::device::tester::{VirtTestDevice, TEST_DEVICE_SIZE};
-use crate::device::VirtDevice;
-use crate::driver::clint::ClintDriver;
 use crate::Platform;
+use crate::device::VirtDevice;
+use crate::device::clint::{CLINT_SIZE, VirtClint};
+use crate::device::tester::{TEST_DEVICE_SIZE, VirtTestDevice};
+use crate::driver::clint::ClintDriver;
 
 // —————————————————————————— Platform Parameters ——————————————————————————— //
 

--- a/src/platform/premierp550.rs
+++ b/src/platform/premierp550.rs
@@ -6,12 +6,12 @@ use core::fmt::Write;
 use log::Level;
 use spin::Mutex;
 
+use crate::Platform;
 use crate::arch::{read_custom_csr, write_custom_csr};
-use crate::device::clint::{VirtClint, CLINT_SIZE};
 use crate::device::VirtDevice;
+use crate::device::clint::{CLINT_SIZE, VirtClint};
 use crate::driver::clint::ClintDriver;
 use crate::driver::uart::UartDriver;
-use crate::Platform;
 
 // —————————————————————————— Platform Parameters ——————————————————————————— //
 

--- a/src/platform/virt.rs
+++ b/src/platform/virt.rs
@@ -9,10 +9,10 @@ use uart_16550::MmioSerialPort;
 
 use super::Platform;
 use crate::config::PLATFORM_NAME;
-use crate::device::clint::{VirtClint, CLINT_SIZE};
-use crate::device::plic::VirtPlic;
-use crate::device::tester::{VirtTestDevice, TEST_DEVICE_SIZE};
 use crate::device::VirtDevice;
+use crate::device::clint::{CLINT_SIZE, VirtClint};
+use crate::device::plic::VirtPlic;
+use crate::device::tester::{TEST_DEVICE_SIZE, VirtTestDevice};
 use crate::driver::clint::ClintDriver;
 use crate::driver::plic::PlicDriver;
 
@@ -25,13 +25,15 @@ const TEST_DEVICE_BASE: usize = 0x2020000;
 // —————————————————————————— Spike Parameters ——————————————————————————— //
 
 /// Symbol used by the Spike simulator.
-#[no_mangle]
 #[used]
+#[allow(non_upper_case_globals)]
+#[unsafe(no_mangle)]
 static mut tohost: u64 = 0;
 
 /// Symbol used by the Spike simulator.
-#[no_mangle]
 #[used]
+#[allow(non_upper_case_globals)]
+#[unsafe(no_mangle)]
 static mut fromhost: u64 = 0;
 
 // ———————————————————————————— Platform Devices ———————————————————————————— //

--- a/src/platform/visionfive2.rs
+++ b/src/platform/visionfive2.rs
@@ -6,11 +6,11 @@ use core::{fmt, ptr};
 use log::Level;
 use spin::Mutex;
 
-use crate::device::clint::{VirtClint, CLINT_SIZE};
+use crate::Platform;
 use crate::device::VirtDevice;
+use crate::device::clint::{CLINT_SIZE, VirtClint};
 use crate::driver::clint::ClintDriver;
 use crate::driver::uart::UartDriver;
-use crate::Platform;
 
 // —————————————————————————— Platform Parameters ——————————————————————————— //
 

--- a/src/policy/keystone.rs
+++ b/src/policy/keystone.rs
@@ -10,15 +10,15 @@ use miralis_config::DELEGATE_PERF_COUNTER;
 
 use crate::arch::perf_counters::DELGATE_PERF_COUNTERS_MASK;
 use crate::arch::pmp::pmplayout::MODULE_OFFSET;
-use crate::arch::pmp::{pmpcfg, Segment};
+use crate::arch::pmp::{Segment, pmpcfg};
 use crate::arch::{
-    parse_mpp_return_mode, set_mpp, write_pmp, Arch, Architecture, Csr, MCause, Mode, Register,
+    Arch, Architecture, Csr, MCause, Mode, Register, parse_mpp_return_mode, set_mpp, write_pmp,
 };
 use crate::host::MiralisContext;
 use crate::modules::{Module, ModuleAction};
 use crate::policy::keystone::ReturnCode::IllegalArgument;
 use crate::virt::traits::*;
-use crate::{logger, RegisterContextGetter, VirtContext};
+use crate::{RegisterContextGetter, VirtContext, logger};
 
 /// Keystone parameters
 ///

--- a/src/policy/protect_payload.rs
+++ b/src/policy/protect_payload.rs
@@ -9,11 +9,11 @@ use tiny_keccak::{Hasher, Sha3};
 
 use crate::arch::pmp::pmpcfg;
 use crate::arch::pmp::pmplayout::MODULE_OFFSET;
-use crate::arch::{get_raw_faulting_instr, mie, mstatus, MCause, Register};
+use crate::arch::{MCause, Register, get_raw_faulting_instr, mie, mstatus};
 use crate::host::MiralisContext;
 use crate::logger;
 use crate::modules::{Module, ModuleAction};
-use crate::platform::{Plat, Platform, ALL_HARTS_MASK};
+use crate::platform::{ALL_HARTS_MASK, Plat, Platform};
 use crate::virt::memory::{emulate_misaligned_read, emulate_misaligned_write};
 use crate::virt::traits::*;
 use crate::virt::{VirtContext, VirtCsr};
@@ -199,7 +199,9 @@ impl ProtectPayloadPolicy {
             MCause::EcallFromSMode
                 if ctx.get(Register::X17) == sbi_codes::SBI_DEBUG_CONSOLE_EXTENSION_EID =>
             {
-                logger::debug!("Ignoring console ecall to the debug_console_extension, please implement a bounce buffer if the feature is required");
+                logger::debug!(
+                    "Ignoring console ecall to the debug_console_extension, please implement a bounce buffer if the feature is required"
+                );
                 // Explicitly tell the payload this feature is not available
                 ctx.set(Register::X10, SBI_ERR_DENIED);
                 ctx.pc += 4;

--- a/src/virt/csr.rs
+++ b/src/virt/csr.rs
@@ -6,8 +6,8 @@
 use super::{VirtContext, VirtCsr};
 use crate::arch::mie::SSIE_FILTER;
 use crate::arch::pmp::pmpcfg;
-use crate::arch::{hstatus, menvcfg, mie, misa, mstatus, Arch, Architecture, Csr, Register};
-use crate::{debug, logger, MiralisContext, Plat, Platform};
+use crate::arch::{Arch, Architecture, Csr, Register, hstatus, menvcfg, mie, misa, mstatus};
+use crate::{MiralisContext, Plat, Platform, debug, logger};
 
 /// A module exposing the traits to manipulate registers of a virtual context.
 ///
@@ -309,7 +309,7 @@ impl HwRegisterContextSetter<Csr> for VirtContext {
                     // TODO: it seems the PMP are not yet written to hardware here,
                     // that seems like a bug to me. We should investigate.
                     // unsafe { write_pmp(&mctx.pmp).flush() };
-                    unsafe { Arch::sfencevma(None, None) };
+                    Arch::sfencevma(None, None);
                 }
 
                 if !mctx.hw.extensions.has_s_extension || self.csr.misa & misa::S == 0 {

--- a/src/virt/emulator.rs
+++ b/src/virt/emulator.rs
@@ -4,7 +4,7 @@ use miralis_core::abi;
 
 use super::csr::traits::*;
 use super::{VirtContext, VirtCsr};
-use crate::arch::hstatus::{GVA_FILTER, SPVP_FILTER, SPV_FILTER};
+use crate::arch::hstatus::{GVA_FILTER, SPV_FILTER, SPVP_FILTER};
 use crate::arch::mie::{
     MEIE_OFFSET, MSIE_OFFSET, MTIE_OFFSET, SEIE_OFFSET, SIE_FILTER, SSIE_FILTER, SSIE_OFFSET,
     STIE_OFFSET,
@@ -13,8 +13,8 @@ use crate::arch::mstatus::{
     MPP_FILTER, MPP_OFFSET, MPV_FILTER, SPIE_FILTER, SPIE_OFFSET, SPP_FILTER, SPP_OFFSET,
 };
 use crate::arch::{
-    get_raw_faulting_instr, mie, misa, mstatus, mtvec, parse_mpp_return_mode,
-    parse_spp_return_mode, Arch, Architecture, Csr, MCause, Mode, Register,
+    Arch, Architecture, Csr, MCause, Mode, Register, get_raw_faulting_instr, mie, misa, mstatus,
+    mtvec, parse_mpp_return_mode, parse_spp_return_mode,
 };
 use crate::decoder::{IllegalInst, LoadInstr, StoreInstr};
 use crate::device::VirtDevice;
@@ -959,17 +959,15 @@ impl VirtContext {
         rs1: &Register,
         rs2: &Register,
     ) {
-        unsafe {
-            let vaddr = match rs1 {
-                Register::X0 => None,
-                reg => Some(self.get(reg)),
-            };
-            let asid = match rs2 {
-                Register::X0 => None,
-                reg => Some(self.get(reg)),
-            };
-            Arch::sfencevma(vaddr, asid);
-        }
+        let vaddr = match rs1 {
+            Register::X0 => None,
+            reg => Some(self.get(reg)),
+        };
+        let asid = match rs2 {
+            Register::X0 => None,
+            reg => Some(self.get(reg)),
+        };
+        Arch::sfencevma(vaddr, asid);
     }
 
     pub fn emulate_hfence_gvma(
@@ -978,17 +976,15 @@ impl VirtContext {
         rs1: &Register,
         rs2: &Register,
     ) {
-        unsafe {
-            let vaddr = match rs1 {
-                Register::X0 => None,
-                reg => Some(self.get(reg)),
-            };
-            let asid = match rs2 {
-                Register::X0 => None,
-                reg => Some(self.get(reg)),
-            };
-            Arch::hfencegvma(vaddr, asid);
-        }
+        let vaddr = match rs1 {
+            Register::X0 => None,
+            reg => Some(self.get(reg)),
+        };
+        let asid = match rs2 {
+            Register::X0 => None,
+            reg => Some(self.get(reg)),
+        };
+        Arch::hfencegvma(vaddr, asid);
     }
 
     pub fn emulate_hfence_vvma(
@@ -997,17 +993,15 @@ impl VirtContext {
         rs1: &Register,
         rs2: &Register,
     ) {
-        unsafe {
-            let vaddr = match rs1 {
-                Register::X0 => None,
-                reg => Some(self.get(reg)),
-            };
-            let asid = match rs2 {
-                Register::X0 => None,
-                reg => Some(self.get(reg)),
-            };
-            Arch::hfencevvma(vaddr, asid);
-        }
+        let vaddr = match rs1 {
+            Register::X0 => None,
+            reg => Some(self.get(reg)),
+        };
+        let asid = match rs2 {
+            Register::X0 => None,
+            reg => Some(self.get(reg)),
+        };
+        Arch::hfencevvma(vaddr, asid);
     }
 }
 
@@ -1048,10 +1042,10 @@ fn get_next_interrupt(mie: usize, mip: usize, mideleg: usize) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::get_next_interrupt;
-    use crate::arch::{mie, Arch, Architecture, Csr};
+    use crate::HwRegisterContextSetter;
+    use crate::arch::{Arch, Architecture, Csr, mie};
     use crate::host::MiralisContext;
     use crate::virt::VirtContext;
-    use crate::HwRegisterContextSetter;
 
     /// If the firmware wants to read the `mip` register after cleaning `vmip.SEIP`,
     /// and we don't sync `vmip.SEIP` with `mip.SEIP`, it can't know if there is an interrupt

--- a/src/virt/memory.rs
+++ b/src/virt/memory.rs
@@ -1,6 +1,6 @@
 //! Emulation logic for misaligned loads and stores
 
-use crate::arch::{get_raw_faulting_instr, parse_mpp_return_mode, Arch, Architecture};
+use crate::arch::{Arch, Architecture, get_raw_faulting_instr, parse_mpp_return_mode};
 use crate::decoder::{LoadInstr, StoreInstr};
 use crate::host::MiralisContext;
 use crate::virt::VirtContext;

--- a/src/virt/mod.rs
+++ b/src/virt/mod.rs
@@ -8,7 +8,7 @@ mod world_switch;
 pub use csr::traits;
 pub use emulator::ExitResult;
 
-use crate::arch::{mie, misa, ExtensionsCapability, Mode, TrapInfo};
+use crate::arch::{ExtensionsCapability, Mode, TrapInfo, mie, misa};
 
 /// The execution mode, either virtualized firmware or native payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
The main changes with the new edition are:
- The need for unsafe keyword inside unsafe function.
- Update to the sorting algorithm for imports.
- Let chains.

This causes quite a lot of style churn, but this commit does not change the semantic at all.