### PR TITLE
Bump softcore-asm-rv64 to v0.3.0 to speed-up model checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "softcore-asm-macro"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9f5f41af73d4d6dcefaee6cc1db17da7aae8347152b0c1bde685669774ed69"
+checksum = "c08a9ef38e03d82d985625e9199f332bdbedf4282bf77a8e68691a7363f0617a"
 dependencies = [
  "anyhow",
  "pest",
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "softcore-asm-rv64"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1e060ee237ce04ad074fcab39eacba5264851f570abc78cade6b235769d624"
+checksum = "7105563f4d33ebaad72d1da6c4e4db50072c0f4958aaaa920de3eaa7ae180337"
 dependencies = [
  "softcore-asm-macro",
  "softcore-rv64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ default-members = ["runner"]
 [workspace.dependencies]
 log = "0.4.17"
 softcore-rv64 = "0.6.0"
-softcore-asm-rv64 = "0.2.0"
+softcore-asm-rv64 = "0.3.0"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn",  check-cfg = ["cfg(kani)"] }

--- a/src/arch/metal.rs
+++ b/src/arch/metal.rs
@@ -11,6 +11,8 @@
 use core::marker::PhantomData;
 
 #[cfg(any(test, feature = "userspace"))]
+use softcore_asm_rv64::softcore_init;
+#[cfg(any(test, feature = "userspace"))]
 use softcore_rv64::{Core, config, new_core};
 
 use super::{Csr, ExtensionsCapability, Mode, RegistersCapability, menvcfg};
@@ -30,40 +32,13 @@ use crate::{RegisterContextGetter, RegisterContextSetter, utils};
 // rather than real hardware.                                                 //
 // —————————————————————————————————————————————————————————————————————————— //
 
-// Each thread gets its own copy of the core, this prevent tests using different threads inside a
-// same process to share the same core.
+// We initialize the thread-local SOFT_CORE variable here using the provided helper.
+// The variable is primarily used by the `soft_asm!` macro defined below, but can also be accessed
+// directly for the purpose of testing or model checking.
+//
+// The U74 is the CPU core used in the VisionFive 2, which is one of our test boards.
 #[cfg(any(test, feature = "userspace"))]
-std::thread_local! {
-    /// A software RISC-V core that emulates a real CPU.
-    ///
-    /// When running Miralis in user-space (on any architecture) we use an in-process software
-    /// implementation of a RISC-V core. We perform all privileged operations that would normally
-    /// require assembly against that software core. For instance, all CSR operations are executed
-    /// against the software core.
-    ///
-    /// The software core can be queried, for instance to check which addresses are currently
-    /// protected by the PMP, or if there are any pending interrupts. This enables testing how
-    /// Miralis interacts with the hardware directly from unit tests, rather than within QEMU.
-    ///
-    /// We use one core per thread to prevent interference among threads, such as when running
-    /// `cargo test`. Therefore, the core lives in threat local storage and must be access using
-    /// the `thread_loca!` API.
-    ///
-    /// Usage:
-    ///
-    /// ```
-    /// SOFT_CORE.with_borrow_mut(|core| {
-    ///     // The `core` can be accessed within the closure
-    ///     core.set(reg::X1, 0x42);
-    ///     core.csrrw(reg::X0, csr::MSCRATCH, reg::X1).unwrap();
-    /// });
-    /// ```
-    pub static SOFT_CORE: core::cell::RefCell<Core> = {
-        let mut core = new_core(config::U74);
-        core.reset();
-        core::cell::RefCell::new(core)
-    };
-}
+softcore_init!(config::U74);
 
 /// Unsafe placeholder function to make softcore-asm unsafe.
 unsafe fn _unsafe_marker() {}
@@ -82,7 +57,7 @@ macro_rules! soft_asm {
         #[cfg(any(test, feature = "userspace"))]
         softcore_asm_rv64::asm!(
             $($asm)*,
-            softcore(SOFT_CORE.with_borrow_mut),
+            softcore(self),
             softcore_trap_handlers(_tracing_trap_handler, _mprv_trap_handler, _raw_trap_handler)
         );
 
@@ -112,7 +87,7 @@ macro_rules! naked_soft_asm {
                 _unsafe_marker();
                 softcore_asm_rv64::asm!(
                     $($asm)*,
-                    softcore(SOFT_CORE.with_borrow_mut)
+                    softcore(self)
                 );
             }
         }


### PR DESCRIPTION
The new softcore-asm-rv64 drastically reduces the size of generated code with the `userspace` feature used for unit tests and model-cheking. The reason is that until v0.2.0 softcore-asm uses the thread-local accessors, which consists in passing a closure to `with_borrow_mut`. Each closure leads to a different monomorphization, and as we have north of 400 `asm!` snippets in Miralis that ends-up generating too much code for Kani to deal with. The new version uses raw pointer for accessing the thread-local core, and therefore sidestep those issues.

With v0.2.0 the GOTO C produced by Kani comprises 7,780 items and 137,859 statements. With the new version we stand at 1,703 items and 80,777 statements. The .symtab.out file produced went from ~40MB to 14MB.